### PR TITLE
Modal bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.iml
 
 pids
 logs

--- a/js/core.js
+++ b/js/core.js
@@ -155,8 +155,9 @@ define(function(require, exports, module) {
             if (!called) {
                 $($el).trigger(UI.support.transition.end);
             }
+            $el.transitionHandle = undefined;
         };
-        setTimeout(callback, duration);
+        this.transitionHandle = setTimeout(callback, duration);
         return this;
     };
 

--- a/js/ui.modal.js
+++ b/js/ui.modal.js
@@ -57,9 +57,19 @@ define(function(require, exports, module) {
             options = this.options,
             isPopup = this.isPopup;
 
-        if (this.transitioning || this.active) return;
+        if (this.active) return;
 
         if (!this.$element.length)  return;
+
+        var hasAnimation = this.transitioning;
+
+        // 判断如果还在动画，就先触发之前的closed事件
+        if (hasAnimation) {
+            clearTimeout($element.transitionHandle);
+            $element.transitionHandle = null;
+            $element.trigger(supportTransition.end);
+            $element.off(supportTransition.end);
+        }
 
         isPopup && this.$element.show();
 
@@ -88,12 +98,22 @@ define(function(require, exports, module) {
     };
 
     Modal.prototype.close = function(relatedElement) {
-        if (this.transitioning || !this.active) return;
+        if (!this.active) return;
+
+        var hasAnimation = this.transitioning;
 
         var $element = this.$element,
             options = this.options,
             isPopup = this.isPopup,
             that = this;
+
+        // 判断如果还在动画，就先触发之前的opened事件
+        if (hasAnimation) {
+            clearTimeout($element.transitionHandle);
+            $element.transitionHandle = null;
+            $element.trigger(supportTransition.end);
+            $element.off(supportTransition.end);
+        }
 
         this.$element.trigger($.Event('close:modal:amui', {relatedElement: relatedElement}));
 


### PR DESCRIPTION
Hi, 你们好：
     我在使用AmazeUI的modal组件的时候:

``` javascript
$.ajax({
beforeSend: function() {
     $("#modal").modal("toggle");
},
complete: function() {
    $("#modal").modal("toggle");
});
```

如果response 速度过快，因为源码中有一句

``` js
 //ui.modal.js 第2557行和第2583行
if (this.transitioning || this.active) return;
```

会导致 complete中的modal关闭不能执行。
因此我提交了以上PR。
完成的功能是

> 如果modal transitioning，则提前trigger相关函数，并更新状态。

不知道这个PR对你们是否有用，但无论如何希望给一个反馈。

非常感谢。
