### PR TITLE
resolved #144

### DIFF
--- a/widget/footer/src/footer.js
+++ b/widget/footer/src/footer.js
@@ -14,7 +14,7 @@ define(function(require, exports, module) {
       $('#am-footer-mode').modal();
     });
 
-    addToHS();
+    !window.AMUI_NO_ADD2HS && addToHS();
 
     // switch mode
     // switch to desktop


### PR DESCRIPTION
using `window.AMUI_NO_ADD2HS = true` to disable add2home plugin in Footer
