### PR TITLE
Update amazeui.hbs.helper.js

### DIFF
--- a/vendor/amazeui.hbs.helper.js
+++ b/vendor/amazeui.hbs.helper.js
@@ -34,5 +34,5 @@
     module.exports = registerIfCondHelper;
   }
 
-  this.Handlebars && registerIfCondHelper(Handlebars);
+  this.Handlebars && registerIfCondHelper(this.Handlebars);
 }).call(this);


### PR DESCRIPTION
我认为Handlebars不一定会暴露在全局中,如果只暴露在this中的话就会出问题,还有<pre>
if (typeof module !== 'undefined' && module.exports) {
    module.exports = registerIfCondHelper;
  }
</pre>
实在不知道有什么用,请回复我的建议,谢谢
