### PR TITLE
travis-ci added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+node_js:
+  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ language: node_js
 node_js:
   - "0.10"
 
+script: gulp build
+
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 
 node_js:
   - "0.10"
+
+sudo: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Bower version](https://badge.fury.io/bo/amazeui.svg)](http://badge.fury.io/bo/amazeui)
 [![NPM version](https://badge.fury.io/js/amazeui.svg)](http://badge.fury.io/js/amazeui)
+[![Build Status](https://travis-ci.org/HuangShaoyan/amazeui.svg?branch=master)](https://travis-ci.org/HuangShaoyan/amazeui)
 
 Amaze UI 是基于社区开源项目构建的一个跨屏前端框架。 __[README in English](https://github.com/allmobilize/amazeui/blob/master/README_EN.md)__
 


### PR DESCRIPTION
https://travis-ci.com/ 是一个持续集成服务。

添加.travis.yml后，每次收到commit，travis-ci都会触发一次构建，可以用来随时验证编译、测试、静态代码检查等是否通过。

现在配置的只是简单地调用gulp build。未来可以在travis的build box里运行测试。

README里添加一个build passing的图标，用来标识travis ci的构建状态。

留意一点：现在配置的是我的fork的构建状态。如果pull request被接受，需要allmobilize的owner到 https://travis-ci.org 上做些必要的配置，并对README做相应修改。
