### PR TITLE
cookie expires problem

### DIFF
--- a/js/util.cookie.js
+++ b/js/util.cookie.js
@@ -27,7 +27,7 @@ var cookie = {
       encodeURIComponent(value);
 
     if (expires instanceof Date) {
-      cookieText += '; expires=' + expires.toGMTString();
+      cookieText += '; expires=' + expires.toUTCString();
     }
 
     if (path) {


### PR DESCRIPTION
将.toGMTString()更改为.toUTCString()，因为.toGMTString()已不再使用，在部分浏览器上不能正确的设置cookie的expires。
