### PR TITLE
Fix IPSet default name assignment

### DIFF
--- a/nhp/utils/iptables.go
+++ b/nhp/utils/iptables.go
@@ -305,14 +305,12 @@ func (ipset *IPSet) GetDefaultName(ipType IPTYPE, t int) string {
 		} else if ipType == IPV6 {
 			name = WhitelistSetV6
 		}
-		name = WhitelistSet
 	case 3: // Blacklist
 		if ipType == IPV4 {
 			name = BlacklistSet
 		} else if ipType == IPV6 {
 			name = BlacklistSetV6
 		}
-		name = BlacklistSet
 	}
 	return name
 }


### PR DESCRIPTION
## Summary
- ensure IPv6 table names are preserved for whitelist/blacklist

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_6869feb7b014832cadda8dbd9300bba4