### PR TITLE
Add optional WebRTC transport

### DIFF
--- a/endpoints/go.mod
+++ b/endpoints/go.mod
@@ -9,11 +9,13 @@ require (
 	github.com/cilium/ebpf v0.18.0
 	github.com/emmansun/gmsm v0.24.1
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/gin-gonic/gin v1.10.0
+	github.com/gin-contrib/sessions v1.0.4
+	github.com/gin-gonic/gin v1.10.1
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.33.0
 	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/pion/webrtc/v4 v4.1.0
 	github.com/sigstore/cosign/v2 v2.5.3
 	github.com/spf13/viper v1.20.1
 	github.com/urfave/cli/v2 v2.27.6
@@ -38,12 +40,11 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/bytedance/sonic v1.11.6 // indirect
-	github.com/bytedance/sonic/loader v0.1.1 // indirect
+	github.com/bytedance/sonic v1.13.2 // indirect
+	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudwego/base64x v0.1.4 // indirect
-	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/coocood/freecache v1.2.4 // indirect
@@ -61,7 +62,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
-	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/gin-contrib/sse v1.0.0 // indirect
 	github.com/globocom/go-buffer v1.2.2 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
@@ -82,17 +83,20 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.6 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
+	github.com/gorilla/context v1.1.2 // indirect
+	github.com/gorilla/securecookie v1.1.2 // indirect
+	github.com/gorilla/sessions v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect
@@ -104,7 +108,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20240620165639-de9c06129bec // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
@@ -118,6 +122,21 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pion/datachannel v1.5.10 // indirect
+	github.com/pion/dtls/v3 v3.0.6 // indirect
+	github.com/pion/ice/v4 v4.0.10 // indirect
+	github.com/pion/interceptor v0.1.37 // indirect
+	github.com/pion/logging v0.2.3 // indirect
+	github.com/pion/mdns/v2 v2.0.7 // indirect
+	github.com/pion/randutil v0.1.0 // indirect
+	github.com/pion/rtcp v1.2.15 // indirect
+	github.com/pion/rtp v1.8.15 // indirect
+	github.com/pion/sctp v1.8.39 // indirect
+	github.com/pion/sdp/v3 v3.0.11 // indirect
+	github.com/pion/srtp/v3 v3.0.4 // indirect
+	github.com/pion/stun/v3 v3.0.0 // indirect
+	github.com/pion/transport/v3 v3.0.7 // indirect
+	github.com/pion/turn/v4 v4.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -150,13 +169,14 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
+	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.1 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.1 // indirect
 	go.etcd.io/etcd/client/v3 v3.6.1 // indirect
-	go.mongodb.org/mongo-driver v1.14.0 // indirect
+	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.36.0 // indirect
@@ -169,7 +189,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/arch v0.8.0 // indirect
+	golang.org/x/arch v0.16.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/mod v0.26.0 // indirect
@@ -188,7 +208,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.5.2 // indirect
-	gorm.io/gorm v1.25.5 // indirect
+	gorm.io/gorm v1.25.12 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 )
 

--- a/endpoints/server/main/etc/config.toml
+++ b/endpoints/server/main/etc/config.toml
@@ -16,3 +16,10 @@ Hostname = "localhost" # the hostname of NHP-Server
 LogLevel = 4
 DisableAgentValidation = false
 
+[webrtc]
+Enable = false
+OfferFile = ""
+AnswerFile = ""
+StunServers = ["stun:stun.l.google.com:19302"]
+TurnServers = []
+

--- a/endpoints/server/webrtcserver.go
+++ b/endpoints/server/webrtcserver.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+
+	"github.com/OpenNHP/opennhp/nhp/core"
+	"github.com/OpenNHP/opennhp/nhp/log"
+)
+
+// WebRTCConfig holds settings for the optional WebRTC transport.
+type WebRTCConfig struct {
+	Enable      bool
+	OfferFile   string
+	AnswerFile  string
+	StunServers []string
+	TurnServers []string
+}
+
+// WebRTCServer bridges a WebRTC DataChannel with the UDP server message pipeline.
+type WebRTCServer struct {
+	us   *UdpServer
+	conf *WebRTCConfig
+	pc   *webrtc.PeerConnection
+}
+
+func NewWebRTCServer(us *UdpServer, conf *WebRTCConfig) *WebRTCServer {
+	return &WebRTCServer{us: us, conf: conf}
+}
+
+func (w *WebRTCServer) Start() error {
+	if w.conf == nil || !w.conf.Enable {
+		return nil
+	}
+
+	cfg := webrtc.Configuration{}
+	for _, u := range w.conf.StunServers {
+		cfg.ICEServers = append(cfg.ICEServers, webrtc.ICEServer{URLs: []string{u}})
+	}
+	for _, u := range w.conf.TurnServers {
+		cfg.ICEServers = append(cfg.ICEServers, webrtc.ICEServer{URLs: []string{u}})
+	}
+
+	var err error
+	w.pc, err = webrtc.NewPeerConnection(cfg)
+	if err != nil {
+		return err
+	}
+
+	w.pc.OnDataChannel(w.setupDataChannel)
+
+	// if an offer file is provided, perform one-shot signaling using files
+	if w.conf.OfferFile != "" {
+		if offerBytes, err := os.ReadFile(w.conf.OfferFile); err == nil {
+			var offer webrtc.SessionDescription
+			if err := json.Unmarshal(offerBytes, &offer); err == nil {
+				if err := w.pc.SetRemoteDescription(offer); err == nil {
+					answer, err := w.pc.CreateAnswer(nil)
+					if err == nil {
+						if err = w.pc.SetLocalDescription(answer); err == nil {
+							if w.conf.AnswerFile != "" {
+								if data, err := json.Marshal(answer); err == nil {
+									_ = os.WriteFile(w.conf.AnswerFile, data, 0644)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (w *WebRTCServer) setupDataChannel(dc *webrtc.DataChannel) {
+	dc.OnOpen(func() {
+		log.Info("WebRTC data channel %d open", dc.ID())
+		recvTime := time.Now().UnixNano()
+		addr := &net.UDPAddr{IP: net.IPv4zero, Port: int(dc.ID())}
+		conn := &UdpConn{isWebRTC: true, dc: dc}
+		conn.ConnData = &core.ConnectionData{
+			InitTime:             recvTime,
+			LastLocalRecvTime:    recvTime,
+			Device:               w.us.device,
+			LocalAddr:            w.us.listenAddr,
+			RemoteAddr:           addr,
+			CookieStore:          &core.CookieStore{},
+			RemoteTransactionMap: make(map[uint64]*core.RemoteTransaction),
+			TimeoutMs:            DefaultAgentConnectionTimeoutMs,
+			SendQueue:            make(chan *core.Packet, PacketQueueSizePerConnection),
+			RecvQueue:            make(chan *core.Packet, PacketQueueSizePerConnection),
+			BlockSignal:          make(chan struct{}),
+			SetTimeoutSignal:     make(chan struct{}),
+			StopSignal:           make(chan struct{}),
+		}
+
+		key := addr.String()
+		w.us.remoteConnectionMapMutex.Lock()
+		w.us.remoteConnectionMap[key] = conn
+		w.us.remoteConnectionMapMutex.Unlock()
+
+		w.us.wg.Add(1)
+		go w.us.connectionRoutine(conn)
+	})
+
+	dc.OnMessage(func(m webrtc.DataChannelMessage) {
+		if m.IsString {
+			return
+		}
+		addr := &net.UDPAddr{IP: net.IPv4zero, Port: int(dc.ID())}
+		key := addr.String()
+		w.us.remoteConnectionMapMutex.Lock()
+		conn, ok := w.us.remoteConnectionMap[key]
+		w.us.remoteConnectionMapMutex.Unlock()
+		if !ok {
+			return
+		}
+		pkt := w.us.device.AllocatePoolPacket()
+		copy(pkt.Buf[:], m.Data)
+		pkt.Content = pkt.Buf[:len(m.Data)]
+		if len(pkt.Content) < pkt.MinimalLength() {
+			w.us.device.ReleasePoolPacket(pkt)
+			return
+		}
+		atomic.AddUint64(&w.us.stats.totalRecvBytes, uint64(len(m.Data)))
+		conn.ConnData.ForwardInboundPacket(pkt)
+	})
+
+	dc.OnClose(func() {
+		addr := &net.UDPAddr{IP: net.IPv4zero, Port: int(dc.ID())}
+		key := addr.String()
+		w.us.remoteConnectionMapMutex.Lock()
+		conn, ok := w.us.remoteConnectionMap[key]
+		if ok {
+			delete(w.us.remoteConnectionMap, key)
+		}
+		w.us.remoteConnectionMapMutex.Unlock()
+		if ok {
+			conn.Close()
+		}
+	})
+}
+
+func (w *WebRTCServer) Stop() {
+	if w.pc != nil {
+		_ = w.pc.Close()
+	}
+}


### PR DESCRIPTION
## Summary
- add pion/webrtc dependency and new `WebRTCServer`
- configure WebRTC via `[webrtc]` section in config.toml
- start/stop WebRTC server from `UdpServer`
- forward packets over WebRTC data channel
- revert README changes

## Testing
- `go vet ./...` *(fails: missing go.sum entries)*


------
https://chatgpt.com/codex/tasks/task_e_686a04e12948832ca69ffba9e23a2e35