### PR TITLE
OpenNHP Agent SDK Introduction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ generate-version-and-build:
 	@$(MAKE) serverd
 	@$(MAKE) db
 	@$(MAKE) kgc
-	@$(MAKE) agentsdk
+	@$(MAKE) linuxagentsdk
 	@$(MAKE) androidagentsdk
 	@$(MAKE) macosagentsdk
 	@$(MAKE) iosagentsdk
@@ -127,8 +127,8 @@ kgc:
 	mkdir -p ../release/nhp-kgc/etc; \
 	cp ./kgc/main/etc/*.toml ../release/nhp-kgc/etc/
 
-agentsdk:
-	@echo "$(COLOUR_BLUE)[OpenNHP] Building agent SDK... $(END_COLOUR)"
+linuxagentsdk:
+	@echo "$(COLOUR_BLUE)[OpenNHP] Building Linux agent SDK... $(END_COLOUR)"
 ifeq ($(OS_NAME), linux)
 	cd endpoints && \
 	go build -a -trimpath -buildmode=c-shared -ldflags ${LD_FLAGS} -v -o ../release/nhp-agent/nhp-agent.so ./agent/main/main.go ./agent/main/export.go && \
@@ -185,4 +185,4 @@ archive:
 	@cd release && mkdir -p archive && tar -czvf ./archive/$(PACKAGE_FILE) nhp-agent nhp-ac nhp-db nhp-server
 	@echo "$(COLOUR_GREEN)[OpenNHP] Package ${PACKAGE_FILE} archived!$(END_COLOUR)"
 
-.PHONY: all generate-version-and-build init agentd acd serverd db agentsdk androidagentsdk macosagentsdk iosagentsdk devicesdk plugins test archive ebpf clean_ebpf
+.PHONY: all generate-version-and-build init agentd acd serverd db linuxagentsdk androidagentsdk macosagentsdk iosagentsdk devicesdk plugins test archive ebpf clean_ebpf

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ END_COLOUR=\033[0m
 # Plugins
 NHP_SERVER_PLUGINS = ./endpoints/server/plugins
 
+# Android environment settings
+ANDROID_CC='${TOOLCHAIN}/bin/aarch64-linux-android21-clang'
+ANDROID_CXX='${TOOLCHAIN}/bin/aarch64-linux-android21-clang++'
+
 # eBPF compile
 ifneq (,$(findstring ebpf,$(MAKECMDGOALS)))
     CLANG := $(shell command -v clang 2>/dev/null)
@@ -75,6 +79,9 @@ generate-version-and-build:
 	@$(MAKE) db
 	@$(MAKE) kgc
 	@$(MAKE) agentsdk
+	@$(MAKE) androidagentsdk
+	@$(MAKE) macosagentsdk
+	@$(MAKE) iosagentsdk
 	@$(MAKE) devicesdk
 	@$(MAKE) plugins
 	@$(MAKE) archive
@@ -128,6 +135,35 @@ ifeq ($(OS_NAME), linux)
 	gcc ./agent/sdkdemo/nhp-agent-demo.c -I ../release/nhp-agent -l:nhp-agent.so -L../release/nhp-agent -Wl,-rpath=. -o ../release/nhp-agent/nhp-agent-demo
 endif
 
+androidagentsdk:
+	@echo "$(COLOUR_BLUE)[OpenNHP] Building Android agent SDK... $(END_COLOUR)"
+ifeq ($(OS_NAME), linux)
+    ifeq ($(TOOLCHAIN),)
+		@echo "Android NDK is not installed. Please install Android NDK to compile Android SDK."
+    else
+		cd endpoints && \
+		GOOS=android GOARCH=arm64 CGO_ENABLED=1 \
+		CC=${ANDROID_CC} CXX=${ANDROID_CXX} \
+		go build -a -trimpath -buildmode=c-shared -ldflags ${LD_FLAGS} -v -o ../release/nhp-agent/libnhpagent.so ./agent/main/main.go ./agent/main/export.go
+    endif
+endif
+
+macosagentsdk:
+	@echo "$(COLOUR_BLUE)[OpenNHP] Building MacOS agent SDK... $(END_COLOUR)"
+ifeq ($(OS_NAME), darwin)
+	cd endpoints && \
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 \
+	go build -a -trimpath -buildmode=c-shared -ldflags ${LD_FLAGS} -v -o ../release/nhp-agent/nhp-agent.dylib ./agent/main/main.go ./agent/main/expotr.go
+endif
+
+iosagentsdk:
+	@echo "$(COLOUR_BLUE)[OpenNHP] Building IOS agent SDK... $(END_COLOUR)"
+ifeq ($(OS_NAME), darwin)
+	cd endpoints && \
+	gomobile bind -target ios -o ../release/nhp-agent/nhpagent.xcframework ./agent/iossdk
+endif
+
+
 devicesdk:
 	@echo "$(COLOUR_BLUE)[OpenNHP] Building nhp SDK... $(END_COLOUR)"
 ifeq ($(OS_NAME), linux)
@@ -149,4 +185,4 @@ archive:
 	@cd release && mkdir -p archive && tar -czvf ./archive/$(PACKAGE_FILE) nhp-agent nhp-ac nhp-db nhp-server
 	@echo "$(COLOUR_GREEN)[OpenNHP] Package ${PACKAGE_FILE} archived!$(END_COLOUR)"
 
-.PHONY: all generate-version-and-build init agentd acd serverd db agentsdk devicesdk plugins test archive ebpf clean_ebpf
+.PHONY: all generate-version-and-build init agentd acd serverd db agentsdk androidagentsdk macosagentsdk iosagentsdk devicesdk plugins test archive ebpf clean_ebpf

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: About
-nav_order: 10
+nav_order: 11
 permalink: /about/
 ---
 

--- a/docs/agent_sdk.md
+++ b/docs/agent_sdk.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: OpenNHP Client Agent SDK Introduction
-nav_order: 12
+title: Client SDKs
+nav_order: 10
 permalink: /agent_sdk/
 ---
 
-# OpenNHP Client Agent SDK Introduction
+# Client SDKs
 {: .fs-9 }
 
 [中文版](/zh-cn/agent_sdk/){: .label .fs-4 }
@@ -476,10 +476,10 @@ Set up the compilation environment for Windows by referring to the Windows secti
 - **Method 1**：Run the *BAT* file in the code root directory
   `build.bat`<br>
   <small>*（Note: If an error occurs during the compilation process under windows, try this compilation method: In the Visual Studio developer command prompt for VS command window, switch to the project directory and execute the `./build.bat `command）*</small>
-  
+
 - Method 2: Command to compile the .dll file for the SDK separately:
 
-  Navigate to the opennhp/endpoints/agent/main/ directory and execute:
+  Navigate to the `opennhp/endpoints/agent/main/` directory and execute:
 
   `go build -trimpath -buildmode=c-shared -ldflags '-s -w' -v -o nhp-agent.dll main.go export.go`
 
@@ -491,117 +491,114 @@ Set up the compilation environment for Windows by referring to the Windows secti
 
   Java programs can call SDK methods using JNA:
 
-  - OpennhpLibrary interface loads the OpenNHP agent SDK
+    - OpennhpLibrary interface loads the OpenNHP agent SDK
 
-    ```java
-    package org.example;
-        
-    import com.sun.jna.Library;
-    import com.sun.jna.Native;
-    
-    /**
-     * OpenNHP agent sdk interface
-     *
-     * @author haochangjiu
-     * @version JDK 8
-     * @className OpennhpLibrary
-     * @date 2025/10/27
-     */
-    public interface OpennhpLibrary extends Library {
-        // load OpenNHP agent sdk
-        OpennhpLibrary INSTANCE = Native.load("nhp-agent", OpennhpLibrary.class);
-    
-        /**
-         * @description Initialization of the nhp_agent instance working directory path:
-         *              The configuration files to be read are located under workingdir/etc/,
-         *              and log files will be generated under workingdir/logs/.
-         * @param workingDir: the working directory path for the agent
-         * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
-         *                    return boolean Whether agent instance has been initialized successfully.
-         * @return boolean
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link boolean}
-         */
-        boolean nhp_agent_init(String workingDir, int logLevel);
-    
-        /**
-         * @description Synchronously stop and release nhp_agent.
-         * @author haochangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_close();
-        /**
-         * @description Read the user information, resource information, server information,
-         *              and other configuration files written under workingdir/etc,
-         *              and asynchronously start the loop knocking thread.
-         * @return int
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link int}
-         */
-        int nhp_agent_knockloop_start();
-    
-        /**
-         * @description Synchronously stop the loop, knock-on sub thread
-         * @author hangchangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_knockloop_stop();
-    }
-    ```
+      ```java
+      package org.example;
+          
+      import com.sun.jna.Library;
+      import com.sun.jna.Native;
+      
+      /**
+       * OpenNHP agent sdk interface
+       *
+       * @author haochangjiu
+       * @version JDK 8
+       * @className OpennhpLibrary
+       * @date 2025/10/27
+       */
+      public interface OpennhpLibrary extends Library {
+          // load OpenNHP agent sdk
+          OpennhpLibrary INSTANCE = Native.load("nhp-agent", OpennhpLibrary.class);
+      
+          /**
+           * @description Initialization of the nhp_agent instance working directory path:
+           *              The configuration files to be read are located under workingdir/etc/,
+           *              and log files will be generated under workingdir/logs/.
+           * @param workingDir: the working directory path for the agent
+           * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
+           *                    return boolean Whether agent instance has been initialized successfully.
+           * @return boolean
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link boolean}
+           */
+          boolean nhp_agent_init(String workingDir, int logLevel);
+      
+          /**
+           * @description Synchronously stop and release nhp_agent.
+           * @author haochangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_close();
+          /**
+           * @description Read the user information, resource information, server information,
+           *              and other configuration files written under workingdir/etc,
+           *              and asynchronously start the loop knocking thread.
+           * @return int
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link int}
+           */
+          int nhp_agent_knockloop_start();
+      
+          /**
+           * @description Synchronously stop the loop, knock-on sub thread
+           * @author hangchangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_knockloop_stop();
+      }
+      ```
+    - Application main entry, calling the SDK
 
-    
-
-  - Application main entry, calling the SDK
-
-    ```java
-    package org.example;
-        
-    import java.util.Scanner;
-    
-    /**
-     * Application for calling the OpenNHP agent SDK
-     *
-     * @author haochangjiu
-     * @version JDK 8
-     * @className App
-     * @date 2025/10/27
-     */
-    public class App {
-        public static void main(String[] args) throws Exception {
-            //        Initialize and start the OpenNHP agent SDK service
-            boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init("D:\\console-workspace\\opennhp-knock", 3);
-            if (!initFlag) {
-                System.out.println("NHP Agent init failed");
-                System.exit(0);
-            }
-            //        Invoke methods in the OpenNHP agent SDK via input commands
-            Scanner scanner = new Scanner(System.in);
-    
-            while (true) {
-                System.out.print("> ");
-                if (scanner.hasNextLine()) {
-                    String input = scanner.nextLine().trim();
-                    if ("knock".equalsIgnoreCase(input)) {
-                        System.out.println("start the loop knocking thread...");
-                        OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
-                    } else if ("cancel".equalsIgnoreCase(input)) {
-                        System.out.println("stop the loop knocking thread...");
-                        OpennhpLibrary.INSTANCE.nhp_agent_knockloop_stop();
-                    } else if ("exit".equalsIgnoreCase(input)) {
-                        System.out.println("exit nhp agent service...");
-                        OpennhpLibrary.INSTANCE.nhp_agent_close();
-                        break;
-                    } else {
-                        System.out.println("invalid input");
-                    }
-                }
-            }
-            scanner.close();
-        }
-    }
-    ```
+      ```java
+      package org.example;
+          
+      import java.util.Scanner;
+      
+      /**
+       * Application for calling the OpenNHP agent SDK
+       *
+       * @author haochangjiu
+       * @version JDK 8
+       * @className App
+       * @date 2025/10/27
+       */
+      public class App {
+          public static void main(String[] args) throws Exception {
+              //        Initialize and start the OpenNHP agent SDK service
+              boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init("D:\\console-workspace\\opennhp-knock", 3);
+              if (!initFlag) {
+                  System.out.println("NHP Agent init failed");
+                  System.exit(0);
+              }
+              //        Invoke methods in the OpenNHP agent SDK via input commands
+              Scanner scanner = new Scanner(System.in);
+      
+              while (true) {
+                  System.out.print("> ");
+                  if (scanner.hasNextLine()) {
+                      String input = scanner.nextLine().trim();
+                      if ("knock".equalsIgnoreCase(input)) {
+                          System.out.println("start the loop knocking thread...");
+                          OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
+                      } else if ("cancel".equalsIgnoreCase(input)) {
+                          System.out.println("stop the loop knocking thread...");
+                          OpennhpLibrary.INSTANCE.nhp_agent_knockloop_stop();
+                      } else if ("exit".equalsIgnoreCase(input)) {
+                          System.out.println("exit nhp agent service...");
+                          OpennhpLibrary.INSTANCE.nhp_agent_close();
+                          break;
+                      } else {
+                          System.out.println("invalid input");
+                      }
+                  }
+              }
+              scanner.close();
+          }
+      }
+      ```
 
 - **c/c++**
 
@@ -639,7 +636,7 @@ Set up the compilation environment for Windows by referring to the Windows secti
   }
   ```
 
-  
+
 
 - **python**
 
@@ -699,7 +696,7 @@ Set up the compilation environment for Linux by referring to the Linux section i
 
 - Method 2: Command to compile the .so file for the SDK separately:
 
-  Navigate to the opennhp/endpoints/agent/main/ directory and execute:
+  Navigate to the `opennhp/endpoints/agent/main/` directory and execute:
 
   `go build -trimpath -buildmode=c-shared -ldflags '-s -w' -v -o nhp-agent.so main.go export.go`
 
@@ -719,13 +716,16 @@ Set up the compilation environment for MacOS by referring to the MacOS section i
 
 ##### 2.1.3.2 Compiling the SDK
 
-The SDK compiled via the make command is a .so file, but the dynamic library file format on MacOS is .dylib. Therefore, SDK compilation needs to be done separately.
+- Method 1: Run the script in the project root directory.
+  `make`
 
-Navigate to the opennhp/endpoints/agent/main/ directory and execute the build command:
+- Method 2: Command to compile the .dylib file for the SDK separately:
 
-`GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -buildmode=c-shared -o nhp-agent.dylib main.go export.go`
+  Navigate to the `opennhp/endpoints/agent/main/` directory and execute the build command:
 
-<small>*(Note: Because export.go does not contain a main method, main.go is included in the build command. For custom SDK code files that include a main method, the build command only needs the SDK code file and does not need to include main.go.)*</small>
+  `GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -buildmode=c-shared -o nhp-agent.dylib main.go export.go`
+
+  <small>*(Note: Because export.go does not contain a main method, main.go is included in the build command. For custom SDK code files that include a main method, the build command only needs the SDK code file and does not need to include main.go.)*</small>
 
 ##### 2.1.3.3 SDK Adaptation
 The SDK adaptation on MacOS is the same as on Windows. Refer to section 2.1.1.3 for the code.
@@ -742,77 +742,81 @@ The SDK adaptation on MacOS is the same as on Windows. Refer to section 2.1.1.3 
 
 - Android NDK Environment:
 
-  - Download and install Android NDK.
+    - Download and install Android NDK.
 
-    `wget https://dl.google.com/android/repository/android-ndk-r25b-linux.zip
-    unzip android-ndk-r25b-linux.zip`
+      `wget https://dl.google.com/android/repository/android-ndk-r25b-linux.zip
+      unzip android-ndk-r25b-linux.zip`
 
-  - Set environment variables.
+    - Set environment variables.
 
-    - Edit the bashrc file.
+        - Edit the bashrc file.
 
-      `vim ~/.bashrc`
+          `vim ~/.bashrc`
 
-    - Add environment variables.
+        - Add environment variables.
 
-      ```sh
-      # Set NDK path (according to your actual installation path)
-      export ANDROID_NDK_HOME=/opt/android-ndk-r25b/
-      export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64
-      # For arm64-v8a use aarch64 toolchain
-      export CC=$TOOLCHAIN/bin/aarch64-linux-android21-clang
-      export CXX=$TOOLCHAIN/bin/aarch64-linux-android21-clang++
-      ```
+          ```sh
+          # Set NDK path (according to your actual installation path)
+          export ANDROID_NDK_HOME=/opt/android-ndk-r25b/
+          export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64
+          ```
 
-    - Make the configuration effective.
+        - Make the configuration effective.
 
-      `source ~/.bashrc`
+  `source ~/.bashrc`
 
 ##### 2.2.1.2 Compiling the SDK
 
-Navigate to the opennhp/endpoints/agent/main/ directory and execute the build command:
+- Method 1: Run the script in the project root directory.
+  `make`
 
-`GOOS=android GOARCH=arm64 CGO_ENABLED=1 go build -buildmode=c-shared -o libnhpagent.so main.go export.go`
+  <small>*(Note: The Android NDK must be installed, otherwise the Android SDK will fail to compile.)*</small>
+  
+- Method 2: Command to compile the .so file for the SDK separately:
 
-<small>*(Note: When an Android project loads .so files via JNA, it adds 'lib' to the front of the input .so file name. When compiling the SDK, the name should start with 'lib', e.g., libnhpagent.so.)*</small>
+  Navigate to the `opennhp/endpoints/agent/main/` directory and execute the build command:
+
+  `GOOS=android GOARCH=arm64 CGO_ENABLED=1 CC=$TOOLCHAIN/bin/aarch64-linux-android21-clang CXX=$TOOLCHAIN/bin/aarch64-linux-android21-clang++ go build -buildmode=c-shared -o libnhpagent.so main.go export.go`
+
+  <small>*(Note: When an Android project loads .so files via JNA, it adds 'lib' to the front of the input .so file name. When compiling the SDK, the name should start with 'lib', e.g., libnhpagent.so.)*</small>
 
 ##### 2.2.1.3 SDK Adaptation
 
 - **Android Configuration (Applicable for both Kotlin and Java)**:
 
-  - 1.Add the following configuration in build.gradle (app):
+    - 1.Add the following configuration in build.gradle (app):
 
-    Add under the `android` section:
+      Add under the `android` section:
 
-    ```json
-    sourceSets {
-        main {
-            jniLibs.srcDirs = ['src/main/jniLibs', 'libs']
-        }
-    }
-    ```
+      ```json
+      sourceSets {
+          main {
+              jniLibs.srcDirs = ['src/main/jniLibs', 'libs']
+          }
+      }
+      ```
 
-    Add the following dependencies under the `dependencies` section:
+      Add the following dependencies under the `dependencies` section:
 
-    // Note: It is recommended for Android to use an adapted JNA version, e.g., 5.13.0 or higher.`implementation 'net.java.dev.jna:jna:5.13.0@aar'`
+      // Note: It is recommended for Android to use an adapted JNA version, e.g., 5.13.0 or higher.`implementation 'net.java.dev.jna:jna:5.13.0@aar'`
 
-    // Permission request framework: https://github.com/getActivity/XXPermissions
-    `implementation libs.xxpermissions`
+      // Permission request framework: https://github.com/getActivity/XXPermissions
+      `implementation libs.xxpermissions`
 
-    In the libs.versions.toml file:
-    Under `[versions]`, add:
-    `xxpermissions = "18.6"`
-    Under `[libraries]`, add:
-    `xxpermissions = { module = "com.github.getActivity:XXPermissions", version.ref = "xxpermissions" }`
+      In the libs.versions.toml file:
+      Under `[versions]`, add:
+      `xxpermissions = "18.6"`
+      Under `[libraries]`, add:
+      `xxpermissions = { module = "com.github.getActivity:XXPermissions", version.ref = "xxpermissions" }`
 
-  - 2.Add file storage read and write permissions in the AndroidManifest.xml file:
+    - 2.Add file storage read and write permissions in the AndroidManifest.xml file:
 
-    ```xml
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    ```
+      ```xml
+      <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+      <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+      <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+      <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+      ```
 
 - **Kotlin**
 
@@ -931,122 +935,112 @@ Navigate to the opennhp/endpoints/agent/main/ directory and execute the build co
   }
   ```
 
-  
+
 
 - **java**
 
-  - Create the OpennhpLibrary interface to load the OpenNHP agent SDK.
+    - Create the OpennhpLibrary interface to load the OpenNHP agent SDK.
 
-    <small>*(Note: When introducing .so files in an Android project, 'lib' is added before the dynamic library file name. That is, the SDK name loaded in the code is 'nhpagent', but the actual SDK loaded by the program is the 'libnhpagent.so' file.)*</small>
+      <small>*(Note: When introducing .so files in an Android project, 'lib' is added before the dynamic library file name. That is, the SDK name loaded in the code is 'nhpagent', but the actual SDK loaded by the program is the 'libnhpagent.so' file.)*</small>
 
-    ```java
-    package org.example;
-    
-    import com.sun.jna.Library;
-    import com.sun.jna.Native;
-    
-    /**
-     * OpenNHP agent sdk interface
-     *
-     * @author haochangjiu
-     * @version JDK 8
-     * @className OpennhpLibrary
-     * @date 2025/10/27
-     */
-    public interface OpennhpLibrary extends Library {
-        // load OpenNHP agent sdk
-        OpennhpLibrary INSTANCE = Native.load("nhpagent", OpennhpLibrary.class);
-    
-        /**
-         * @description Initialization of the nhp_agent instance working directory path:
-         *              The configuration files to be read are located under workingdir/etc/,
-         *              and log files will be generated under workingdir/logs/.
-         * @param workingDir: the working directory path for the agent
-         * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
-         *                    return boolean Whether agent instance has been initialized successfully.
-         * @return boolean
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link boolean}
-         */
-        boolean nhp_agent_init(String workingDir, int logLevel);
-    
-        /**
-         * @description Synchronously stop and release nhp_agent.
-         * @author haochangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_close();
-        /**
-         * @description Read the user information, resource information, server information,
-         *              and other configuration files written under workingdir/etc,
-         *              and asynchronously start the loop knocking thread.
-         * @return int
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link int}
-         */
-        int nhp_agent_knockloop_start();
-    
-        /**
-         * @description Synchronously stop the loop, knock-on sub thread
-         * @author hangchangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_knockloop_stop();
-    }
-    ```
-  - Calling the SDK: In the sample, the configuration file etc folder is placed in the nhp directory under the phone's download directory.
+      ```java
+      package org.example;
+      
+      import com.sun.jna.Library;
+      import com.sun.jna.Native;
+      
+      /**
+       * OpenNHP agent sdk interface
+       *
+       * @author haochangjiu
+       * @version JDK 8
+       * @className OpennhpLibrary
+       * @date 2025/10/27
+       */
+      public interface OpennhpLibrary extends Library {
+          // load OpenNHP agent sdk
+          OpennhpLibrary INSTANCE = Native.load("nhpagent", OpennhpLibrary.class);
+      
+          /**
+           * @description Initialization of the nhp_agent instance working directory path:
+           *              The configuration files to be read are located under workingdir/etc/,
+           *              and log files will be generated under workingdir/logs/.
+           * @param workingDir: the working directory path for the agent
+           * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
+           *                    return boolean Whether agent instance has been initialized successfully.
+           * @return boolean
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link boolean}
+           */
+          boolean nhp_agent_init(String workingDir, int logLevel);
+      
+          /**
+           * @description Synchronously stop and release nhp_agent.
+           * @author haochangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_close();
+          /**
+           * @description Read the user information, resource information, server information,
+           *              and other configuration files written under workingdir/etc,
+           *              and asynchronously start the loop knocking thread.
+           * @return int
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link int}
+           */
+          int nhp_agent_knockloop_start();
+      
+          /**
+           * @description Synchronously stop the loop, knock-on sub thread
+           * @author hangchangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_knockloop_stop();
+      }
+      ```
+    - Calling the SDK: In the sample, the configuration file etc folder is placed in the nhp directory under the phone's download directory.
 
-    ```java
-    package org.example;
-    
-    import android.os.Bundle;
-    import android.os.Environment;
-    import android.util.Log;
-    import androidx.appcompat.app.AppCompatActivity;
-    
-    
-    import com.OpennhpLibrary;
-    import com.fancy.zerotrust.R;
-    
-    import java.io.File;
-    
-    public class MainActivity extends AppCompatActivity {
-    
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            // Read the phone's storage download directory.
-            String appDir = Environment.getExternalStorageDirectory() + File.separator + "download";
-            // Does the nhp directory exist in the downloads
-            File file = new File(appDir);
-            if (!file.exists()) {
-                Log.d("MainActivity","download file not exist！");
-                return;
-            }
-            Log.d("MainActivity","download file exist！");
-            String appDir1 = Environment.getExternalStorageDirectory() + File.separator + "download"+ File.separator + "nhp";
-            boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init(appDir1, 3);
-            if (!initFlag) {
-                System.out.println("NHP Agent init failed");
-                System.exit(0);
-            }
-            System.out.println("start the loop knocking thread...");
-            OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
-        }
-    }
-    ```
-
-    
-
-
-
-
-
-
-
-
+      ```java
+      package org.example;
+      
+      import android.os.Bundle;
+      import android.os.Environment;
+      import android.util.Log;
+      import androidx.appcompat.app.AppCompatActivity;
+      
+      
+      import com.OpennhpLibrary;
+      import com.fancy.zerotrust.R;
+      
+      import java.io.File;
+      
+      public class MainActivity extends AppCompatActivity {
+      
+          @Override
+          protected void onCreate(Bundle savedInstanceState) {
+              super.onCreate(savedInstanceState);
+              // Read the phone's storage download directory.
+              String appDir = Environment.getExternalStorageDirectory() + File.separator + "download";
+              // Does the nhp directory exist in the downloads
+              File file = new File(appDir);
+              if (!file.exists()) {
+                  Log.d("MainActivity","download file not exist！");
+                  return;
+              }
+              Log.d("MainActivity","download file exist！");
+              String appDir1 = Environment.getExternalStorageDirectory() + File.separator + "download"+ File.separator + "nhp";
+              boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init(appDir1, 3);
+              if (!initFlag) {
+                  System.out.println("NHP Agent init failed");
+                  System.exit(0);
+              }
+              System.out.println("start the loop knocking thread...");
+              OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
+          }
+      }
+      ```
 
 
 
@@ -1060,22 +1054,22 @@ Navigate to the opennhp/endpoints/agent/main/ directory and execute the build co
 
 - Install gomobile:
 
-  - Install
+    - Install
 
-    `go install golang.org/x/mobile/cmd/gomobile@latest`
+      `go install golang.org/x/mobile/cmd/gomobile@latest`
 
-  - Initialize
+    - Initialize
 
-    `gomobile init`
+      `gomobile init`
 
 ##### 2.2.2.2 SDK Sample
 
-When compiling the .xcframework file required for IOS, the names of the exported methods must start with a capital letter, and the parameter types must be standard Go language types, not C.int and C.char. Another important point is that the code cannot be under package main. Move the program to a newly created sdk path.
+When compiling the .xcframework file required for IOS, the names of the exported methods must start with a capital letter, and the parameter types must be standard Go language types, not C.int and C.char. Another important point is that the code cannot be under package main. Move the program to a newly created iossdk directory.
 
-Modified code based on the export.go file in OpenNHP is as follows:
+Modified code based on the export.go file in OpenNHP is as follows: ***opennhp/endpoints/agent/iossdk/export.go***
 
 ```go
-package sdk
+package iossdk
 
 import "C"
 import (
@@ -1086,6 +1080,7 @@ import (
 	"github.com/OpenNHP/opennhp/endpoints/agent"
 	"github.com/OpenNHP/opennhp/nhp/common"
 	"github.com/OpenNHP/opennhp/nhp/core"
+	_ "golang.org/x/mobile/bind"
 )
 
 var gAgentInstance *agent.UdpAgent
@@ -1460,300 +1455,305 @@ func NhpPrivkeyToPubkey(cipherType int, privateBase64 string) string {
 
 ##### 2.2.2.3 Compiling the SDK
 
-Navigate to the opennhp/endpoints/agent/sdk/ directory and execute the build command.<small>*(Note: The re-edited sdk source code files are placed under opennhp/endpoints/agent/sdk/)*</small>
+- Method 1: Run the script in the project root directory.
+  `make`
 
-`gomobile bind -target ios -o nhpagent.xcframework .`
+- Method 2: Command to compile the .xcframework file for the SDK separately:
+
+  Navigate to the `opennhp/endpoints/agent/iossdk/` directory and execute the build command.<small>*(Note: The re-edited sdk source code files are placed under opennhp/endpoints/agent/iossdk/)*</small>
+
+  `gomobile bind -target ios -o nhpagent.xcframework .`
 
 ##### 2.2.2.4 SDK Adaptation
 
 - **Objective-C**
-  - FileCopyManager.h: Declares methods to copy SDK configuration files to the sandbox.
-    ```objective-c
-    //
-    //  FileCopyManager.h
-    //  TestXCFramework
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    #import <Foundation/Foundation.h>
-    
-    NS_ASSUME_NONNULL_BEGIN
-    
-    @interface FileCopyManager : NSObject
-    /// Copy the specified file(s) to the etc and certs directories in the application's home directory
-    + (void)copyFilesToSandboxEtc;
-    @end
-    
-    NS_ASSUME_NONNULL_END
-    ```
-  - FileCopyManager.m: Implementation of FileCopyManager.h.
-    ```objective-c
-    //
-    //  FileCopyManager.m
-    //  TestXCFramework
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    #import "FileCopyManager.h"
-    #import <Foundation/Foundation.h>
-    
-    @implementation FileCopyManager
-    
-    /// Copy the specified file(s) to the etc and certs directories in the application's home directory
-    + (void)copyFilesToSandboxEtc {
-        // 1. Retrieve the sandboxed Documents directory
-        NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
-        NSURL *documentsURL = [documentsURLs firstObject];
-        if (!documentsURL) {
-            NSLog(@"Failed to retrieve Documents directory");
-            return;
-        }
-        
-        // 2. Define paths for etc and certs directories within the sandbox
-        NSURL *etcURL = [documentsURL URLByAppendingPathComponent:@"etc"];
-        NSURL *certsURL = [etcURL URLByAppendingPathComponent:@"certs"];
-        
-        // 3. Create etc and certs directories (if they don't exist)
-        [self createDirectoryIfNotExists:etcURL];
-        [self createDirectoryIfNotExists:certsURL];
-        
-        // 4. Copy toml files to the etc directory
-        NSArray *tomlFiles = @[@"server.toml", @"config.toml", @"dhp.toml", @"resource.toml"];
-        for (NSString *fileName in tomlFiles) {
-            [self copyFileFromBundle:fileName toDestinationURL:etcURL];
-        }
-        
-        // 5. Copy certificate files to the etc/certs directory
-        NSArray *certFiles = @[@"server.crt", @"server.key"];
-        for (NSString *fileName in certFiles) {
-            [self copyFileFromBundle:fileName toDestinationURL:certsURL];
-        }
-    }
-    
-    /// Create directory if it does not exist
-    + (void)createDirectoryIfNotExists:(NSURL *)directoryURL {
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        if (![fileManager fileExistsAtPath:directoryURL.path]) {
-            NSError *error;
-            BOOL success = [fileManager createDirectoryAtURL:directoryURL
-                                  withIntermediateDirectories:YES
-                                                   attributes:nil
-                                                        error:&error];
-            if (success) {
-                NSLog(@"Directory created successfully: %@", directoryURL.path);
-            } else {
-                NSLog(@"Failed to create directory: %@, error: %@", directoryURL.path, error.localizedDescription);
-            }
-        } else {
-            NSLog(@"Directory already exists: %@", directoryURL.path);
-        }
-    }
-    
-    /// Copy file from Bundle to destination path
-    + (void)copyFileFromBundle:(NSString *)fileName toDestinationURL:(NSURL *)destinationURL {
-        // Get the file path in the Bundle
-        NSURL *sourceURL = [[NSBundle mainBundle] URLForResource:[fileName stringByDeletingPathExtension]
-                                                    withExtension:[fileName pathExtension]];
-        if (!sourceURL) {
-            NSLog(@"File not found in Bundle: %@", fileName);
-            return;
-        }
-        
-        // Destination file path (destination directory + file name)
-        NSURL *destFileURL = [destinationURL URLByAppendingPathComponent:fileName];
-        
-        // Copy file (if it doesn't exist)
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        if (![fileManager fileExistsAtPath:destFileURL.path]) {
-            NSError *error;
-            BOOL success = [fileManager copyItemAtURL:sourceURL toURL:destFileURL error:&error];
-            if (success) {
-                NSLog(@"File copied successfully: %@ -> %@", fileName, destFileURL.path);
-            } else {
-                NSLog(@"File copy failed: %@, error: %@", fileName, error.localizedDescription);
-            }
-        } else {
-            NSLog(@"File already exists: %@", destFileURL.path);
-        }
-    }
-    
-    @end
-    ```
-  - ViewController.m: Program main entry, calling SDK methods.
-    ```objective-c
-    //
-    //  ViewController.m
-    //  TestXCFramework
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    #import "ViewController.h"
-    #import <Nhpagent/Nhpagent.h>
-    #import "FileCopyManager.h"
-    
-    @interface ViewController ()
-    
-    @end
-    
-    @implementation ViewController
-    
-    - (void)viewDidLoad {
-        [super viewDidLoad];
-        // Do any additional setup after loading the view.
-        // Invoke method to copy files from etc folder to sandbox etc directory
-        [FileCopyManager copyFilesToSandboxEtc];
-        // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
-        NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
-        NSURL *documentsURL = [documentsURLs firstObject];
-        if (!documentsURL) {
-            NSLog(@"Error: Failed to read Documents directory");
-        }
-        // Get the parent directory path of the etc folder
-        NSString *etcPath = documentsURL.path;
-        // SdkNhpAgentInit
-        BOOL initFlag = SdkNhpAgentInit(etcPath, 3);
-        if (!initFlag) {
-            NSLog(@"NHP Agent init failed");
-            return;
-        }
-        // knockloop_start
-        long value = SdkNhpAgentKnockloopStart();
-        NSLog(@"SdkNhpAgentKnockloopStart value : %ld", value);
-    }
-    
-    @end
-    ```
+    - FileCopyManager.h: Declares methods to copy SDK configuration files to the sandbox.
+      ```objective-c
+      //
+      //  FileCopyManager.h
+      //  TestXCFramework
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      #import <Foundation/Foundation.h>
+      
+      NS_ASSUME_NONNULL_BEGIN
+      
+      @interface FileCopyManager : NSObject
+      /// Copy the specified file(s) to the etc and certs directories in the application's home directory
+      + (void)copyFilesToSandboxEtc;
+      @end
+      
+      NS_ASSUME_NONNULL_END
+      ```
+    - FileCopyManager.m: Implementation of FileCopyManager.h.
+      ```objective-c
+      //
+      //  FileCopyManager.m
+      //  TestXCFramework
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      #import "FileCopyManager.h"
+      #import <Foundation/Foundation.h>
+      
+      @implementation FileCopyManager
+      
+      /// Copy the specified file(s) to the etc and certs directories in the application's home directory
+      + (void)copyFilesToSandboxEtc {
+          // 1. Retrieve the sandboxed Documents directory
+          NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
+          NSURL *documentsURL = [documentsURLs firstObject];
+          if (!documentsURL) {
+              NSLog(@"Failed to retrieve Documents directory");
+              return;
+          }
+          
+          // 2. Define paths for etc and certs directories within the sandbox
+          NSURL *etcURL = [documentsURL URLByAppendingPathComponent:@"etc"];
+          NSURL *certsURL = [etcURL URLByAppendingPathComponent:@"certs"];
+          
+          // 3. Create etc and certs directories (if they don't exist)
+          [self createDirectoryIfNotExists:etcURL];
+          [self createDirectoryIfNotExists:certsURL];
+          
+          // 4. Copy toml files to the etc directory
+          NSArray *tomlFiles = @[@"server.toml", @"config.toml", @"dhp.toml", @"resource.toml"];
+          for (NSString *fileName in tomlFiles) {
+              [self copyFileFromBundle:fileName toDestinationURL:etcURL];
+          }
+          
+          // 5. Copy certificate files to the etc/certs directory
+          NSArray *certFiles = @[@"server.crt", @"server.key"];
+          for (NSString *fileName in certFiles) {
+              [self copyFileFromBundle:fileName toDestinationURL:certsURL];
+          }
+      }
+      
+      /// Create directory if it does not exist
+      + (void)createDirectoryIfNotExists:(NSURL *)directoryURL {
+          NSFileManager *fileManager = [NSFileManager defaultManager];
+          if (![fileManager fileExistsAtPath:directoryURL.path]) {
+              NSError *error;
+              BOOL success = [fileManager createDirectoryAtURL:directoryURL
+                                    withIntermediateDirectories:YES
+                                                     attributes:nil
+                                                          error:&error];
+              if (success) {
+                  NSLog(@"Directory created successfully: %@", directoryURL.path);
+              } else {
+                  NSLog(@"Failed to create directory: %@, error: %@", directoryURL.path, error.localizedDescription);
+              }
+          } else {
+              NSLog(@"Directory already exists: %@", directoryURL.path);
+          }
+      }
+      
+      /// Copy file from Bundle to destination path
+      + (void)copyFileFromBundle:(NSString *)fileName toDestinationURL:(NSURL *)destinationURL {
+          // Get the file path in the Bundle
+          NSURL *sourceURL = [[NSBundle mainBundle] URLForResource:[fileName stringByDeletingPathExtension]
+                                                      withExtension:[fileName pathExtension]];
+          if (!sourceURL) {
+              NSLog(@"File not found in Bundle: %@", fileName);
+              return;
+          }
+          
+          // Destination file path (destination directory + file name)
+          NSURL *destFileURL = [destinationURL URLByAppendingPathComponent:fileName];
+          
+          // Copy file (if it doesn't exist)
+          NSFileManager *fileManager = [NSFileManager defaultManager];
+          if (![fileManager fileExistsAtPath:destFileURL.path]) {
+              NSError *error;
+              BOOL success = [fileManager copyItemAtURL:sourceURL toURL:destFileURL error:&error];
+              if (success) {
+                  NSLog(@"File copied successfully: %@ -> %@", fileName, destFileURL.path);
+              } else {
+                  NSLog(@"File copy failed: %@, error: %@", fileName, error.localizedDescription);
+              }
+          } else {
+              NSLog(@"File already exists: %@", destFileURL.path);
+          }
+      }
+      
+      @end
+      ```
+    - ViewController.m: Program main entry, calling SDK methods.
+      ```objective-c
+      //
+      //  ViewController.m
+      //  TestXCFramework
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      #import "ViewController.h"
+      #import <Nhpagent/Nhpagent.h>
+      #import "FileCopyManager.h"
+      
+      @interface ViewController ()
+      
+      @end
+      
+      @implementation ViewController
+      
+      - (void)viewDidLoad {
+          [super viewDidLoad];
+          // Do any additional setup after loading the view.
+          // Invoke method to copy files from etc folder to sandbox etc directory
+          [FileCopyManager copyFilesToSandboxEtc];
+          // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
+          NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
+          NSURL *documentsURL = [documentsURLs firstObject];
+          if (!documentsURL) {
+              NSLog(@"Error: Failed to read Documents directory");
+          }
+          // Get the parent directory path of the etc folder
+          NSString *etcPath = documentsURL.path;
+          // SdkNhpAgentInit
+          BOOL initFlag = IossdkNhpAgentInit(etcPath, 3);
+          if (!initFlag) {
+              NSLog(@"NHP Agent init failed");
+              return;
+          }
+          // knockloop_start
+          long value = IossdkNhpAgentKnockloopStart();
+          NSLog(@"SdkNhpAgentKnockloopStart value : %ld", value);
+      }
+      
+      @end
+      ```
 
 - **Swift**
-  - FileCopyManager.swift: Methods to copy SDK configuration files to the sandbox.
+    - FileCopyManager.swift: Methods to copy SDK configuration files to the sandbox.
 
-    ```swift
-    //
-    //  FileCopyManager.swift
-    //  TestXCFrameworkSwift
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    import UIKit
-    import Foundation
-    
-    class FileCopyManager {
-        
-        /// Copy specified files to the etc and certs directories in the sandbox
-        static func copyFilesToSandboxEtc() {
-            // 1. Get the Documents directory in the sandbox
-            guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-                print("Failed to get Documents directory")
-                return
-            }
-            
-            // 2. Define paths for etc and certs directories in the sandbox
-            let etcURL = documentsURL.appendingPathComponent("etc")
-            let certsURL = etcURL.appendingPathComponent("certs")
-            
-            // 3. Create etc and certs directories (if they don't exist)
-            createDirectoryIfNotExists(at: etcURL)
-            createDirectoryIfNotExists(at: certsURL)
-            
-            // 4. Copy toml files to the etc directory
-            let tomlFiles = ["server.toml", "config.toml", "dhp.toml", "resource.toml"]
-            tomlFiles.forEach { fileName in
-                copyFileFromBundle(fileName: fileName, to: etcURL)
-            }
-            
-            // 5. Copy certificate files to the etc/certs directory
-            let certFiles = ["server.crt", "server.key"]
-            certFiles.forEach { fileName in
-                copyFileFromBundle(fileName: fileName, to: certsURL)
-            }
-        }
-        
-        /// Create directory if it doesn't exist
-        private static func createDirectoryIfNotExists(at url: URL) {
-            let fileManager = FileManager.default
-            guard !fileManager.fileExists(atPath: url.path) else {
-                print("Directory already exists: \(url.path)")
-                return
-            }
-            
-            do {
-                try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
-                print("Directory created successfully: \(url.path)")
-            } catch {
-                print("Failed to create directory: \(url.path), error: \(error.localizedDescription)")
-            }
-        }
-        
-        /// Copy file from Bundle to destination path
-        private static func copyFileFromBundle(fileName: String, to destinationURL: URL) {
-            // Split filename and extension (handling files with extensions)
-            let fileNameWithoutExt = (fileName as NSString).deletingPathExtension
-            let fileExt = (fileName as NSString).pathExtension
-            
-            // Get the file path in the Bundle
-            guard let sourceURL = Bundle.main.url(forResource: fileNameWithoutExt, withExtension: fileExt) else {
-                print("File not found in Bundle: \(fileName)")
-                return
-            }
-            
-            // Destination file path (destination directory + filename)
-            let destFileURL = destinationURL.appendingPathComponent(fileName)
-            let fileManager = FileManager.default
-            
-            // Copy file (if it doesn't exist)
-            guard !fileManager.fileExists(atPath: destFileURL.path) else {
-                print("File already exists: \(destFileURL.path)")
-                return
-            }
-            
-            do {
-                try fileManager.copyItem(at: sourceURL, to: destFileURL)
-                print("File copied successfully: \(fileName) -> \(destFileURL.path)")
-            } catch {
-                print("File copy failed: \(fileName), error: \(error.localizedDescription)")
-            }
-        }
-    }
-    ```
-  - ViewController.swift: Program main entry, calling SDK methods.
-    ```swift
-    //
-    //  ViewController.swift
-    //  TestXCFrameworkSwift
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    import UIKit
-    import Nhpagent
-    
-    class ViewController: UIViewController {
-        override func viewDidLoad() {
-            super.viewDidLoad()
-            // Do any additional setup after loading the view.
-            // Call method to copy files from etc folder to sandbox etc directory
-            FileCopyManager.copyFilesToSandboxEtc()
-            // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
-            guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-                print("Error: Failed to read Documents directory")
-                return
-            }
-            // Get the parent directory path of the etc folder
-            let etcPath: String = documentsURL.path
-            // Call SdkNhpAgentInit for initialization
-            let initFlag: Bool = SdkNhpAgentInit(etcPath, 3)
-            if !initFlag {
-                print("NHP Agent init failed")
-            }
-            // Call knockloop_start
-            let value = SdkNhpAgentKnockloopStart()
-            print("SdkNhpAgentKnockloopStart value: %ld", value)
+      ```swift
+      //
+      //  FileCopyManager.swift
+      //  TestXCFrameworkSwift
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      import UIKit
+      import Foundation
+      
+      class FileCopyManager {
+          
+          /// Copy specified files to the etc and certs directories in the sandbox
+          static func copyFilesToSandboxEtc() {
+              // 1. Get the Documents directory in the sandbox
+              guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                  print("Failed to get Documents directory")
+                  return
+              }
+              
+              // 2. Define paths for etc and certs directories in the sandbox
+              let etcURL = documentsURL.appendingPathComponent("etc")
+              let certsURL = etcURL.appendingPathComponent("certs")
+              
+              // 3. Create etc and certs directories (if they don't exist)
+              createDirectoryIfNotExists(at: etcURL)
+              createDirectoryIfNotExists(at: certsURL)
+              
+              // 4. Copy toml files to the etc directory
+              let tomlFiles = ["server.toml", "config.toml", "dhp.toml", "resource.toml"]
+              tomlFiles.forEach { fileName in
+                  copyFileFromBundle(fileName: fileName, to: etcURL)
+              }
+              
+              // 5. Copy certificate files to the etc/certs directory
+              let certFiles = ["server.crt", "server.key"]
+              certFiles.forEach { fileName in
+                  copyFileFromBundle(fileName: fileName, to: certsURL)
+              }
+          }
+          
+          /// Create directory if it doesn't exist
+          private static func createDirectoryIfNotExists(at url: URL) {
+              let fileManager = FileManager.default
+              guard !fileManager.fileExists(atPath: url.path) else {
+                  print("Directory already exists: \(url.path)")
+                  return
+              }
+              
+              do {
+                  try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+                  print("Directory created successfully: \(url.path)")
+              } catch {
+                  print("Failed to create directory: \(url.path), error: \(error.localizedDescription)")
+              }
+          }
+          
+          /// Copy file from Bundle to destination path
+          private static func copyFileFromBundle(fileName: String, to destinationURL: URL) {
+              // Split filename and extension (handling files with extensions)
+              let fileNameWithoutExt = (fileName as NSString).deletingPathExtension
+              let fileExt = (fileName as NSString).pathExtension
+              
+              // Get the file path in the Bundle
+              guard let sourceURL = Bundle.main.url(forResource: fileNameWithoutExt, withExtension: fileExt) else {
+                  print("File not found in Bundle: \(fileName)")
+                  return
+              }
+              
+              // Destination file path (destination directory + filename)
+              let destFileURL = destinationURL.appendingPathComponent(fileName)
+              let fileManager = FileManager.default
+              
+              // Copy file (if it doesn't exist)
+              guard !fileManager.fileExists(atPath: destFileURL.path) else {
+                  print("File already exists: \(destFileURL.path)")
+                  return
+              }
+              
+              do {
+                  try fileManager.copyItem(at: sourceURL, to: destFileURL)
+                  print("File copied successfully: \(fileName) -> \(destFileURL.path)")
+              } catch {
+                  print("File copy failed: \(fileName), error: \(error.localizedDescription)")
+              }
+          }
       }
-    }
-    ```
+      ```
+    - ViewController.swift: Program main entry, calling SDK methods.
+      ```swift
+      //
+      //  ViewController.swift
+      //  TestXCFrameworkSwift
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      import UIKit
+      import Nhpagent
+      
+      class ViewController: UIViewController {
+          override func viewDidLoad() {
+              super.viewDidLoad()
+              // Do any additional setup after loading the view.
+              // Call method to copy files from etc folder to sandbox etc directory
+              FileCopyManager.copyFilesToSandboxEtc()
+              // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
+              guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                  print("Error: Failed to read Documents directory")
+                  return
+              }
+              // Get the parent directory path of the etc folder
+              let etcPath: String = documentsURL.path
+              // Call SdkNhpAgentInit for initialization
+              let initFlag: Bool = IossdkNhpAgentInit(etcPath, 3)
+              if !initFlag {
+                  print("NHP Agent init failed")
+              }
+              // Call knockloop_start
+              let value = IossdkNhpAgentKnockloopStart()
+              print("SdkNhpAgentKnockloopStart value: %ld", value)
+        }
+      }
+      ```
 
     

--- a/docs/zh-cn/about.zh-cn.md
+++ b/docs/zh-cn/about.zh-cn.md
@@ -2,7 +2,7 @@
 layout: page
 title: 关于我们
 parent: 中文版
-nav_order: 10
+nav_order: 11
 permalink: /zh-cn/about/
 ---
 

--- a/docs/zh-cn/agent_sdk.zh-cn.md
+++ b/docs/zh-cn/agent_sdk.zh-cn.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: OpenNHP客户端代理SDK介绍
+title: 客户端SDK
 parent: 中文版
-nav_order: 12
+nav_order: 10
 permalink: /zh-cn/agent_sdk/
 ---
 
-# OpenNHP客户端代理SDK介绍
+# 客户端SDK
 {: .fs-9 }
 
 [English](/agent_sdk/){: .label .fs-4 }
@@ -489,7 +489,7 @@ Windows下的编译环境参照**编译源代码**中***系统需求***章节win
   在`opennhp/endpoints/agent/main/`目录下执行
 
   `go build -trimpath -buildmode=c-shared -ldflags '-s -w' -v -o nhp-agent.dll main.go export.go`
-  
+
   <small>*（注：因为export.go文件中没有main方法，所有编译命令中加入了main.go，自定义的SDK代码文件中在加入main方法后，在编译时编译指令只需要SDK代码文件，不需要在引入main.go文件）*</small>
 
 ##### 2.1.1.3 SDK适配
@@ -498,117 +498,117 @@ Windows下的编译环境参照**编译源代码**中***系统需求***章节win
 
   java程序可以通过jna来完成对SDK的方法调用：
 
-  - OpennhpLibrary接口加载OpenNHP agent SDK
+    - OpennhpLibrary接口加载OpenNHP agent SDK
 
-    ```java
-    package org.example;
-    
-    import com.sun.jna.Library;
-    import com.sun.jna.Native;
-    
-    /**
-     * OpenNHP agent sdk interface
-     *
-     * @author haochangjiu
-     * @version JDK 8
-     * @className OpennhpLibrary
-     * @date 2025/10/27
-     */
-    public interface OpennhpLibrary extends Library {
-        // load OpenNHP agent sdk
-        OpennhpLibrary INSTANCE = Native.load("nhp-agent", OpennhpLibrary.class);
-    
-        /**
-         * @description Initialization of the nhp_agent instance working directory path:
-         *              The configuration files to be read are located under workingdir/etc/,
-         *              and log files will be generated under workingdir/logs/.
-         * @param workingDir: the working directory path for the agent
-         * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
-         *                    return boolean Whether agent instance has been initialized successfully.
-         * @return boolean
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link boolean}
-         */
-        boolean nhp_agent_init(String workingDir, int logLevel);
-    
-        /**
-         * @description Synchronously stop and release nhp_agent.
-         * @author haochangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_close();
-        /**
-         * @description Read the user information, resource information, server information,
-         *              and other configuration files written under workingdir/etc,
-         *              and asynchronously start the loop knocking thread.
-         * @return int
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link int}
-         */
-        int nhp_agent_knockloop_start();
-    
-        /**
-         * @description Synchronously stop the loop, knock-on sub thread
-         * @author hangchangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_knockloop_stop();
-    }
-    ```
+      ```java
+      package org.example;
+      
+      import com.sun.jna.Library;
+      import com.sun.jna.Native;
+      
+      /**
+       * OpenNHP agent sdk interface
+       *
+       * @author haochangjiu
+       * @version JDK 8
+       * @className OpennhpLibrary
+       * @date 2025/10/27
+       */
+      public interface OpennhpLibrary extends Library {
+          // load OpenNHP agent sdk
+          OpennhpLibrary INSTANCE = Native.load("nhp-agent", OpennhpLibrary.class);
+      
+          /**
+           * @description Initialization of the nhp_agent instance working directory path:
+           *              The configuration files to be read are located under workingdir/etc/,
+           *              and log files will be generated under workingdir/logs/.
+           * @param workingDir: the working directory path for the agent
+           * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
+           *                    return boolean Whether agent instance has been initialized successfully.
+           * @return boolean
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link boolean}
+           */
+          boolean nhp_agent_init(String workingDir, int logLevel);
+      
+          /**
+           * @description Synchronously stop and release nhp_agent.
+           * @author haochangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_close();
+          /**
+           * @description Read the user information, resource information, server information,
+           *              and other configuration files written under workingdir/etc,
+           *              and asynchronously start the loop knocking thread.
+           * @return int
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link int}
+           */
+          int nhp_agent_knockloop_start();
+      
+          /**
+           * @description Synchronously stop the loop, knock-on sub thread
+           * @author hangchangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_knockloop_stop();
+      }
+      ```
 
-  - 程序主入口，调用SDK
+    - 程序主入口，调用SDK
 
-    ```java
-    package org.example;
-    
-    import java.util.Scanner;
-    
-    /**
-     * Application for calling the OpenNHP agent SDK
-     *
-     * @author haochangjiu
-     * @version JDK 8
-     * @className App
-     * @date 2025/10/27
-     */
-    public class App {
-        public static void main(String[] args) throws Exception {
-    //        Initialize and start the OpenNHP agent SDK service
-            boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init("D:\\console-workspace\\opennhp-knock", 3);
-            if (!initFlag) {
-                System.out.println("NHP Agent init failed");
-                System.exit(0);
-            }
-    //        Invoke methods in the OpenNHP agent SDK via input commands
-            Scanner scanner = new Scanner(System.in);
-    
-            while (true) {
-                System.out.print("> ");
-                if (scanner.hasNextLine()) {
-                    String input = scanner.nextLine().trim();
-                    if ("knock".equalsIgnoreCase(input)) {
-                        System.out.println("start the loop knocking thread...");
-                        OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
-                    } else if ("cancel".equalsIgnoreCase(input)) {
-                        System.out.println("stop the loop knocking thread...");
-                        OpennhpLibrary.INSTANCE.nhp_agent_knockloop_stop();
-                    } else if ("exit".equalsIgnoreCase(input)) {
-                        System.out.println("exit nhp agent service...");
-                        OpennhpLibrary.INSTANCE.nhp_agent_close();
-                        break;
-                    } else {
-                        System.out.println("invalid input");
-                    }
-                }
-            }
-            scanner.close();
-        }
-    }
-    ```
+      ```java
+      package org.example;
+      
+      import java.util.Scanner;
+      
+      /**
+       * Application for calling the OpenNHP agent SDK
+       *
+       * @author haochangjiu
+       * @version JDK 8
+       * @className App
+       * @date 2025/10/27
+       */
+      public class App {
+          public static void main(String[] args) throws Exception {
+      //        Initialize and start the OpenNHP agent SDK service
+              boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init("D:\\console-workspace\\opennhp-knock", 3);
+              if (!initFlag) {
+                  System.out.println("NHP Agent init failed");
+                  System.exit(0);
+              }
+      //        Invoke methods in the OpenNHP agent SDK via input commands
+              Scanner scanner = new Scanner(System.in);
+      
+              while (true) {
+                  System.out.print("> ");
+                  if (scanner.hasNextLine()) {
+                      String input = scanner.nextLine().trim();
+                      if ("knock".equalsIgnoreCase(input)) {
+                          System.out.println("start the loop knocking thread...");
+                          OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
+                      } else if ("cancel".equalsIgnoreCase(input)) {
+                          System.out.println("stop the loop knocking thread...");
+                          OpennhpLibrary.INSTANCE.nhp_agent_knockloop_stop();
+                      } else if ("exit".equalsIgnoreCase(input)) {
+                          System.out.println("exit nhp agent service...");
+                          OpennhpLibrary.INSTANCE.nhp_agent_close();
+                          break;
+                      } else {
+                          System.out.println("invalid input");
+                      }
+                  }
+              }
+              scanner.close();
+          }
+      }
+      ```
 
-    
+
 
 - **c/c++**
 
@@ -724,13 +724,16 @@ MacOS下的编译环境参照**编译源代码**中***系统需求***章节MacOS
 
 ##### 2.1.3.2 编译SDK
 
-通过`make`指令编译后的SDK是.so文件，而在MacOS上的动态库文件是.dylib格式，因此需要通过单独执行进行SDK的编译。
+- 方法一：运行代码根目录下脚本
+  `make`
 
-在`opennhp/endpoints/agent/main/`目录下执行编译指令
+- 方法二：单独编译SDK的.dylib文件指令：
 
-`GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -buildmode=c-shared -o nhp-agent.dylib main.go export.go`
+  在`opennhp/endpoints/agent/main/`目录下执行编译指令
 
-<small>*（注：因为export.go文件中没有main方法，所有编译命令中加入了main.go，自定义的SDK代码文件中在加入main方法后，在编译时编译指令只需要SDK代码文件，不需要在引入main.go文件）*</small>
+  `GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -buildmode=c-shared -o nhp-agent.dylib main.go export.go`
+
+  <small>*（注：因为export.go文件中没有main方法，所有编译命令中加入了main.go，自定义的SDK代码文件中在加入main方法后，在编译时编译指令只需要SDK代码文件，不需要在引入main.go文件）*</small>
 
 ##### 2.1.3.3 SDK适配
 
@@ -748,81 +751,85 @@ MacOS下对SDK的适配与Windows一致，代码参照章节**2.1.1.3**
 
 - Android NDK环境：
 
-  - 下载并安装Android NDK
+    - 下载并安装Android NDK
 
-    `wget https://dl.google.com/android/repository/android-ndk-r25b-linux.zip`
+      `wget https://dl.google.com/android/repository/android-ndk-r25b-linux.zip`
 
-    `unzip android-ndk-r25b-linux.zip`
+      `unzip android-ndk-r25b-linux.zip`
 
-  - 设置环境变量
-  
-    - 编辑bashrc文件
-  
-      `vim ~/.bashrc`
-  
-    - 增加环境变量
-  
-      ```sh
-      #设置 NDK 路径（根据你的实际安装路径）
-      export ANDROID_NDK_HOME=/opt/android-ndk-r25b/
-      export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64
-      #对于 arm64-v8a 使用 aarch64 工具链
-      export CC=$TOOLCHAIN/bin/aarch64-linux-android21-clang
-      export CXX=$TOOLCHAIN/bin/aarch64-linux-android21-clang++
-      ```
-  
-    - 使配置生效
-  
-      `source ~/.bashrc`
+    - 设置环境变量
+
+        - 编辑bashrc文件
+
+          `vim ~/.bashrc`
+
+        - 增加环境变量
+
+          ```sh
+          #设置 NDK 路径（根据你的实际安装路径）
+          export ANDROID_NDK_HOME=/opt/android-ndk-r25b/
+          export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64
+          ```
+
+        - 使配置生效
+
+          `source ~/.bashrc`
 
 ##### 2.2.1.2 编译SDK
 
-在`opennhp/endpoints/agent/main/`目录下执行编译指令
+- 方法一：运行代码根目录下脚本
+  `make`
 
-`GOOS=android GOARCH=arm64 CGO_ENABLED=1 go build -buildmode=c-shared -o libnhpagent.so main.go export.go`
+  <small>*（注：确保Android NDK已安装,如果没有安装,Android SDK将不会编译）*</small>
+  
+- 方法二：单独编译SDK的.so文件指令：
 
-<small>*（注：Android项目在通过jna加载.so文件时会在输入的.so文件名称前增加lib，在编译SDK时名称应以lib开头，例如：libnhpagent.so）*</small>
+  在`opennhp/endpoints/agent/main/`目录下执行编译指令
+
+  `GOOS=android GOARCH=arm64 CGO_ENABLED=1 CC=$TOOLCHAIN/bin/aarch64-linux-android21-clang CXX=$TOOLCHAIN/bin/aarch64-linux-android21-clang++ go build -buildmode=c-shared -o libnhpagent.so main.go export.go`
+
+  <small>*（注：Android项目在通过jna加载.so文件时会在输入的.so文件名称前增加lib，在编译SDK时名称应以lib开头，例如：libnhpagent.so）*</small>
 
 ##### 2.2.1.3 SDK适配
 
 - **Android配置（Kotlin和java通用）**：
 
-  - 1、在build.gradle(app)中加入如下配置：
-    在android下加入
+    - 1、在build.gradle(app)中加入如下配置：
+      在android下加入
 
-    ``` json
-    sourceSets {
-            main {
-                jniLibs.srcDirs = ['src/main/jniLibs', 'libs']
-            }
-        }
-    ```
+      ``` json
+      sourceSets {
+              main {
+                  jniLibs.srcDirs = ['src/main/jniLibs', 'libs']
+              }
+          }
+      ```
 
-    dependencies 下加入如下依赖
-    // 注意：安卓推荐使用适配的 JNA 版本，如 5.13.0 及以上
-    `implementation 'net.java.dev.jna:jna:5.13.0@aar'`
-    // 权限请求框架：https://github.com/getActivity/XXPermissions
-    `implementation libs.xxpermissions`
+      dependencies 下加入如下依赖
+      // 注意：安卓推荐使用适配的 JNA 版本，如 5.13.0 及以上
+      `implementation 'net.java.dev.jna:jna:5.13.0@aar'`
+      // 权限请求框架：https://github.com/getActivity/XXPermissions
+      `implementation libs.xxpermissions`
 
-    libs.versions.toml文件
-    [versions]下加入
-    `xxpermissions = "18.6"`
-    [libraries]下加入
-    `xxpermissions = { module = "com.github.getActivity:XXPermissions", version.ref = "xxpermissions" }`
+      libs.versions.toml文件
+      [versions]下加入
+      `xxpermissions = "18.6"`
+      [libraries]下加入
+      `xxpermissions = { module = "com.github.getActivity:XXPermissions", version.ref = "xxpermissions" }`
 
-  - 2、AndroidManifest.xml文件加入文件存储读写权限
+    - 2、AndroidManifest.xml文件加入文件存储读写权限
 
-    ```xml
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    ```
+      ```xml
+      <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+      <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+      <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+      <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+      ```
 
 - **Kotlin**
-  
+
   Kotlin开发Android应用适配SDK样例
-  
+
     ```kotlin
     package com.example.androidtestsoapp
     
@@ -935,111 +942,111 @@ MacOS下对SDK的适配与Windows一致，代码参照章节**2.1.1.3**
         }
     }
     ```
-  
+
 - **java**
 
-  - 创建OpennhpLibrary接口来加载OpenNHP agent SDK。
-    <small>*（注：Android项目在引入.so文件时，会在动态库文件前加入lib，即代码中加载的SDK名称为nhpagent，实际程序加载的SDK为libnhpagent.so文件）*</small>
+    - 创建OpennhpLibrary接口来加载OpenNHP agent SDK。
+      <small>*（注：Android项目在引入.so文件时，会在动态库文件前加入lib，即代码中加载的SDK名称为nhpagent，实际程序加载的SDK为libnhpagent.so文件）*</small>
 
-    ```java
-    package org.example;
-    
-    import com.sun.jna.Library;
-    import com.sun.jna.Native;
-    
-    /**
-     * OpenNHP agent sdk interface
-     *
-     * @author haochangjiu
-     * @version JDK 8
-     * @className OpennhpLibrary
-     * @date 2025/10/27
-     */
-    public interface OpennhpLibrary extends Library {
-        // load OpenNHP agent sdk
-        OpennhpLibrary INSTANCE = Native.load("nhpagent", OpennhpLibrary.class);
-    
-        /**
-         * @description Initialization of the nhp_agent instance working directory path:
-         *              The configuration files to be read are located under workingdir/etc/,
-         *              and log files will be generated under workingdir/logs/.
-         * @param workingDir: the working directory path for the agent
-         * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
-         *                    return boolean Whether agent instance has been initialized successfully.
-         * @return boolean
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link boolean}
-         */
-        boolean nhp_agent_init(String workingDir, int logLevel);
-    
-        /**
-         * @description Synchronously stop and release nhp_agent.
-         * @author haochangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_close();
-        /**
-         * @description Read the user information, resource information, server information,
-         *              and other configuration files written under workingdir/etc,
-         *              and asynchronously start the loop knocking thread.
-         * @return int
-         * @author haochangjiu
-         * @date 2025/10/27
-         * {@link int}
-         */
-        int nhp_agent_knockloop_start();
-    
-        /**
-         * @description Synchronously stop the loop, knock-on sub thread
-         * @author hangchangjiu
-         * @date 2025/10/27
-         */
-        void nhp_agent_knockloop_stop();
-    }
-    ```
+      ```java
+      package org.example;
+      
+      import com.sun.jna.Library;
+      import com.sun.jna.Native;
+      
+      /**
+       * OpenNHP agent sdk interface
+       *
+       * @author haochangjiu
+       * @version JDK 8
+       * @className OpennhpLibrary
+       * @date 2025/10/27
+       */
+      public interface OpennhpLibrary extends Library {
+          // load OpenNHP agent sdk
+          OpennhpLibrary INSTANCE = Native.load("nhpagent", OpennhpLibrary.class);
+      
+          /**
+           * @description Initialization of the nhp_agent instance working directory path:
+           *              The configuration files to be read are located under workingdir/etc/,
+           *              and log files will be generated under workingdir/logs/.
+           * @param workingDir: the working directory path for the agent
+           * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
+           *                    return boolean Whether agent instance has been initialized successfully.
+           * @return boolean
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link boolean}
+           */
+          boolean nhp_agent_init(String workingDir, int logLevel);
+      
+          /**
+           * @description Synchronously stop and release nhp_agent.
+           * @author haochangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_close();
+          /**
+           * @description Read the user information, resource information, server information,
+           *              and other configuration files written under workingdir/etc,
+           *              and asynchronously start the loop knocking thread.
+           * @return int
+           * @author haochangjiu
+           * @date 2025/10/27
+           * {@link int}
+           */
+          int nhp_agent_knockloop_start();
+      
+          /**
+           * @description Synchronously stop the loop, knock-on sub thread
+           * @author hangchangjiu
+           * @date 2025/10/27
+           */
+          void nhp_agent_knockloop_stop();
+      }
+      ```
 
-  - 调用SDK：样例中将配置文件的etc文件夹放在手机下载目录的nhp目录下
+    - 调用SDK：样例中将配置文件的etc文件夹放在手机下载目录的nhp目录下
 
-    ```java
-    package org.example;
-    
-    import android.os.Bundle;
-    import android.os.Environment;
-    import android.util.Log;
-    import androidx.appcompat.app.AppCompatActivity;
-    
-    
-    import com.OpennhpLibrary;
-    import com.fancy.zerotrust.R;
-    
-    import java.io.File;
-    
-    public class MainActivity extends AppCompatActivity {
-    
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            // Read the phone's storage download directory.
-            String appDir = Environment.getExternalStorageDirectory() + File.separator + "download";
-            // Does the nhp directory exist in the downloads
-            File file = new File(appDir);
-            if (!file.exists()) {
-                Log.d("MainActivity","download file not exist！");
-                return;
-            }
-            Log.d("MainActivity","download file exist！");
-            String appDir1 = Environment.getExternalStorageDirectory() + File.separator + "download"+ File.separator + "nhp";
-            boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init(appDir1, 3);
-            if (!initFlag) {
-                System.out.println("NHP Agent init failed");
-                System.exit(0);
-            }
-            System.out.println("start the loop knocking thread...");
-            OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
-        }
-    }
-    ```
+      ```java
+      package org.example;
+      
+      import android.os.Bundle;
+      import android.os.Environment;
+      import android.util.Log;
+      import androidx.appcompat.app.AppCompatActivity;
+      
+      
+      import com.OpennhpLibrary;
+      import com.fancy.zerotrust.R;
+      
+      import java.io.File;
+      
+      public class MainActivity extends AppCompatActivity {
+      
+          @Override
+          protected void onCreate(Bundle savedInstanceState) {
+              super.onCreate(savedInstanceState);
+              // Read the phone's storage download directory.
+              String appDir = Environment.getExternalStorageDirectory() + File.separator + "download";
+              // Does the nhp directory exist in the downloads
+              File file = new File(appDir);
+              if (!file.exists()) {
+                  Log.d("MainActivity","download file not exist！");
+                  return;
+              }
+              Log.d("MainActivity","download file exist！");
+              String appDir1 = Environment.getExternalStorageDirectory() + File.separator + "download"+ File.separator + "nhp";
+              boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init(appDir1, 3);
+              if (!initFlag) {
+                  System.out.println("NHP Agent init failed");
+                  System.exit(0);
+              }
+              System.out.println("start the loop knocking thread...");
+              OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
+          }
+      }
+      ```
 
 #### 2.2.2 IOS
 
@@ -1051,22 +1058,22 @@ MacOS下对SDK的适配与Windows一致，代码参照章节**2.1.1.3**
 
 - 安装gomobile：
 
-  - 安装gomobile
+    - 安装gomobile
 
-     `go install golang.org/x/mobile/cmd/gomobile@latest`
+      `go install golang.org/x/mobile/cmd/gomobile@latest`
 
-  - 初始化gomobile
+    - 初始化gomobile
 
-     `gomobile init`
+      `gomobile init`
 
 ##### 2.2.2.2 SDK样例
 
-在编译IOS所需的.xcframework文件时，需要导出的方法名称必须大写开头，同时参数类型为标准的Go语言类型，不能是C.int和C.char。另外一点需要注意的是代码不能在**package main**下，将程序移动到新建的sdk路径下。
+在编译IOS所需的.xcframework文件时，需要导出的方法名称必须大写开头，同时参数类型为标准的Go语言类型，不能是C.int和C.char。另外一点需要注意的是代码不能在**package main**下，将程序移动到新建的iossdk目录下。
 
-根据OpenNHP中的export.go文件进行修改如下：
+根据OpenNHP中的export.go文件进行修改如下：***opennhp/endpoints/agent/iossdk/export.go***
 
 ```go
-package sdk
+package iossdk
 
 import "C"
 import (
@@ -1077,6 +1084,7 @@ import (
 	"github.com/OpenNHP/opennhp/endpoints/agent"
 	"github.com/OpenNHP/opennhp/nhp/common"
 	"github.com/OpenNHP/opennhp/nhp/core"
+	_ "golang.org/x/mobile/bind"
 )
 
 var gAgentInstance *agent.UdpAgent
@@ -1452,309 +1460,314 @@ func NhpPrivkeyToPubkey(cipherType int, privateBase64 string) string {
 
 ##### 2.2.2.3 编译SDK
 
-在`opennhp/endpoints/agent/sdk/`目录下执行编译指令<small>*（注：重新编辑的sdk源码文件放在了opennhp/endpoints/agent/sdk/下）*</small>
+- 方法一：运行代码根目录下脚本
+  `make`
 
-` gomobile bind -target ios -o nhpagent.xcframework .`
+- 方法二：单独编译SDK的.xcframework文件指令：
+
+  在`opennhp/endpoints/agent/sdk/`目录下执行编译指令<small>*（注：重新编辑的sdk源码文件放在了opennhp/endpoints/agent/sdk/下）*</small>
+
+  ` gomobile bind -target ios -o nhpagent.xcframework .`
 
 ##### 2.2.2.4 SDK适配
 
 - **Objective-C**
 
-  - FileCopyManager.h：声明将SDK所需配置文件拷贝到沙盒方法
+    - FileCopyManager.h：声明将SDK所需配置文件拷贝到沙盒方法
 
-    ```objective-c
-    //
-    //  FileCopyManager.h
-    //  TestXCFramework
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    #import <Foundation/Foundation.h>
-    
-    NS_ASSUME_NONNULL_BEGIN
-    
-    @interface FileCopyManager : NSObject
-    /// Copy the specified file(s) to the etc and certs directories in the application's home directory
-    + (void)copyFilesToSandboxEtc;
-    @end
-    
-    NS_ASSUME_NONNULL_END
-    
-    ```
-  - FileCopyManager.m：FileCopyManager.h的实现
+      ```objective-c
+      //
+      //  FileCopyManager.h
+      //  TestXCFramework
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      #import <Foundation/Foundation.h>
+      
+      NS_ASSUME_NONNULL_BEGIN
+      
+      @interface FileCopyManager : NSObject
+      /// Copy the specified file(s) to the etc and certs directories in the application's home directory
+      + (void)copyFilesToSandboxEtc;
+      @end
+      
+      NS_ASSUME_NONNULL_END
+      
+      ```
+    - FileCopyManager.m：FileCopyManager.h的实现
 
-    ```objective-c
-    //
-    //  FileCopyManager.m
-    //  TestXCFramework
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    #import "FileCopyManager.h"
-    #import <Foundation/Foundation.h>
-    
-    @implementation FileCopyManager
-    
-    /// Copy the specified file(s) to the etc and certs directories in the application's home directory
-    + (void)copyFilesToSandboxEtc {
-        // 1. Retrieve the sandboxed Documents directory
-        NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
-        NSURL *documentsURL = [documentsURLs firstObject];
-        if (!documentsURL) {
-            NSLog(@"Failed to retrieve Documents directory");
-            return;
-        }
-        
-        // 2. Define paths for etc and certs directories within the sandbox
-        NSURL *etcURL = [documentsURL URLByAppendingPathComponent:@"etc"];
-        NSURL *certsURL = [etcURL URLByAppendingPathComponent:@"certs"];
-        
-        // 3. Create etc and certs directories (if they don't exist)
-        [self createDirectoryIfNotExists:etcURL];
-        [self createDirectoryIfNotExists:certsURL];
-        
-        // 4. Copy toml files to the etc directory
-        NSArray *tomlFiles = @[@"server.toml", @"config.toml", @"dhp.toml", @"resource.toml"];
-        for (NSString *fileName in tomlFiles) {
-            [self copyFileFromBundle:fileName toDestinationURL:etcURL];
-        }
-        
-        // 5. Copy certificate files to the etc/certs directory
-        NSArray *certFiles = @[@"server.crt", @"server.key"];
-        for (NSString *fileName in certFiles) {
-            [self copyFileFromBundle:fileName toDestinationURL:certsURL];
-        }
-    }
-    
-    /// Create directory if it does not exist
-    + (void)createDirectoryIfNotExists:(NSURL *)directoryURL {
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        if (![fileManager fileExistsAtPath:directoryURL.path]) {
-            NSError *error;
-            BOOL success = [fileManager createDirectoryAtURL:directoryURL
-                                  withIntermediateDirectories:YES
-                                                   attributes:nil
-                                                        error:&error];
-            if (success) {
-                NSLog(@"Directory created successfully: %@", directoryURL.path);
-            } else {
-                NSLog(@"Failed to create directory: %@, error: %@", directoryURL.path, error.localizedDescription);
-            }
-        } else {
-            NSLog(@"Directory already exists: %@", directoryURL.path);
-        }
-    }
-    
-    /// Copy file from Bundle to destination path
-    + (void)copyFileFromBundle:(NSString *)fileName toDestinationURL:(NSURL *)destinationURL {
-        // Get the file path in the Bundle
-        NSURL *sourceURL = [[NSBundle mainBundle] URLForResource:[fileName stringByDeletingPathExtension]
-                                                    withExtension:[fileName pathExtension]];
-        if (!sourceURL) {
-            NSLog(@"File not found in Bundle: %@", fileName);
-            return;
-        }
-        
-        // Destination file path (destination directory + file name)
-        NSURL *destFileURL = [destinationURL URLByAppendingPathComponent:fileName];
-        
-        // Copy file (if it doesn't exist)
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        if (![fileManager fileExistsAtPath:destFileURL.path]) {
-            NSError *error;
-            BOOL success = [fileManager copyItemAtURL:sourceURL toURL:destFileURL error:&error];
-            if (success) {
-                NSLog(@"File copied successfully: %@ -> %@", fileName, destFileURL.path);
-            } else {
-                NSLog(@"File copy failed: %@, error: %@", fileName, error.localizedDescription);
-            }
-        } else {
-            NSLog(@"File already exists: %@", destFileURL.path);
-        }
-    }
-    
-    @end
-    
-    ```
-  - ViewController.m：程序主入口，进行SDK方法调用
+      ```objective-c
+      //
+      //  FileCopyManager.m
+      //  TestXCFramework
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      #import "FileCopyManager.h"
+      #import <Foundation/Foundation.h>
+      
+      @implementation FileCopyManager
+      
+      /// Copy the specified file(s) to the etc and certs directories in the application's home directory
+      + (void)copyFilesToSandboxEtc {
+          // 1. Retrieve the sandboxed Documents directory
+          NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
+          NSURL *documentsURL = [documentsURLs firstObject];
+          if (!documentsURL) {
+              NSLog(@"Failed to retrieve Documents directory");
+              return;
+          }
+          
+          // 2. Define paths for etc and certs directories within the sandbox
+          NSURL *etcURL = [documentsURL URLByAppendingPathComponent:@"etc"];
+          NSURL *certsURL = [etcURL URLByAppendingPathComponent:@"certs"];
+          
+          // 3. Create etc and certs directories (if they don't exist)
+          [self createDirectoryIfNotExists:etcURL];
+          [self createDirectoryIfNotExists:certsURL];
+          
+          // 4. Copy toml files to the etc directory
+          NSArray *tomlFiles = @[@"server.toml", @"config.toml", @"dhp.toml", @"resource.toml"];
+          for (NSString *fileName in tomlFiles) {
+              [self copyFileFromBundle:fileName toDestinationURL:etcURL];
+          }
+          
+          // 5. Copy certificate files to the etc/certs directory
+          NSArray *certFiles = @[@"server.crt", @"server.key"];
+          for (NSString *fileName in certFiles) {
+              [self copyFileFromBundle:fileName toDestinationURL:certsURL];
+          }
+      }
+      
+      /// Create directory if it does not exist
+      + (void)createDirectoryIfNotExists:(NSURL *)directoryURL {
+          NSFileManager *fileManager = [NSFileManager defaultManager];
+          if (![fileManager fileExistsAtPath:directoryURL.path]) {
+              NSError *error;
+              BOOL success = [fileManager createDirectoryAtURL:directoryURL
+                                    withIntermediateDirectories:YES
+                                                     attributes:nil
+                                                          error:&error];
+              if (success) {
+                  NSLog(@"Directory created successfully: %@", directoryURL.path);
+              } else {
+                  NSLog(@"Failed to create directory: %@, error: %@", directoryURL.path, error.localizedDescription);
+              }
+          } else {
+              NSLog(@"Directory already exists: %@", directoryURL.path);
+          }
+      }
+      
+      /// Copy file from Bundle to destination path
+      + (void)copyFileFromBundle:(NSString *)fileName toDestinationURL:(NSURL *)destinationURL {
+          // Get the file path in the Bundle
+          NSURL *sourceURL = [[NSBundle mainBundle] URLForResource:[fileName stringByDeletingPathExtension]
+                                                      withExtension:[fileName pathExtension]];
+          if (!sourceURL) {
+              NSLog(@"File not found in Bundle: %@", fileName);
+              return;
+          }
+          
+          // Destination file path (destination directory + file name)
+          NSURL *destFileURL = [destinationURL URLByAppendingPathComponent:fileName];
+          
+          // Copy file (if it doesn't exist)
+          NSFileManager *fileManager = [NSFileManager defaultManager];
+          if (![fileManager fileExistsAtPath:destFileURL.path]) {
+              NSError *error;
+              BOOL success = [fileManager copyItemAtURL:sourceURL toURL:destFileURL error:&error];
+              if (success) {
+                  NSLog(@"File copied successfully: %@ -> %@", fileName, destFileURL.path);
+              } else {
+                  NSLog(@"File copy failed: %@, error: %@", fileName, error.localizedDescription);
+              }
+          } else {
+              NSLog(@"File already exists: %@", destFileURL.path);
+          }
+      }
+      
+      @end
+      
+      ```
+    - ViewController.m：程序主入口，进行SDK方法调用
 
-    ```objective-c
-    //
-    //  ViewController.m
-    //  TestXCFramework
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    #import "ViewController.h"
-    #import <Nhpagent/Nhpagent.h>
-    #import "FileCopyManager.h"
-    
-    @interface ViewController ()
-    
-    @end
-    
-    @implementation ViewController
-    
-    - (void)viewDidLoad {
-        [super viewDidLoad];
-        // Do any additional setup after loading the view.
-        // Invoke method to copy files from etc folder to sandbox etc directory
-        [FileCopyManager copyFilesToSandboxEtc];
-        // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
-        NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
-        NSURL *documentsURL = [documentsURLs firstObject];
-        if (!documentsURL) {
-            NSLog(@"Error: Failed to read Documents directory");
-        }
-        // Get the parent directory path of the etc folder
-        NSString *etcPath = documentsURL.path;
-        // SdkNhpAgentInit
-        BOOL initFlag = SdkNhpAgentInit(etcPath, 3);
-        if (!initFlag) {
-            NSLog(@"NHP Agent init failed");
-            return;
-        }
-        // knockloop_start
-        long value = SdkNhpAgentKnockloopStart();
-        NSLog(@"SdkNhpAgentKnockloopStart value : %ld", value);
-    }
-    
-    @end
-    
-    ```
+      ```objective-c
+      //
+      //  ViewController.m
+      //  TestXCFramework
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      #import "ViewController.h"
+      #import <Nhpagent/Nhpagent.h>
+      #import "FileCopyManager.h"
+      
+      @interface ViewController ()
+      
+      @end
+      
+      @implementation ViewController
+      
+      - (void)viewDidLoad {
+          [super viewDidLoad];
+          // Do any additional setup after loading the view.
+          // Invoke method to copy files from etc folder to sandbox etc directory
+          [FileCopyManager copyFilesToSandboxEtc];
+          // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
+          NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
+          NSURL *documentsURL = [documentsURLs firstObject];
+          if (!documentsURL) {
+              NSLog(@"Error: Failed to read Documents directory");
+          }
+          // Get the parent directory path of the etc folder
+          NSString *etcPath = documentsURL.path;
+          // SdkNhpAgentInit
+          BOOL initFlag = IossdkNhpAgentInit(etcPath, 3);
+          if (!initFlag) {
+              NSLog(@"NHP Agent init failed");
+              return;
+          }
+          // knockloop_start
+          long value = IossdkNhpAgentKnockloopStart();
+          NSLog(@"SdkNhpAgentKnockloopStart value : %ld", value);
+      }
+      
+      @end
+      
+      ```
 
 - **Swift**
-  - FileCopyManager.swift：将SDK所需配置文件拷贝到沙盒方法
+    - FileCopyManager.swift：将SDK所需配置文件拷贝到沙盒方法
 
-    ```sw
-    //
-    //  FileCopyManager.swift
-    //  TestXCFrameworkSwift
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    import UIKit
-    import Foundation
-    
-    class FileCopyManager {
-        
-        /// Copy specified files to the etc and certs directories in the sandbox
-        static func copyFilesToSandboxEtc() {
-            // 1. Get the Documents directory in the sandbox
-            guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-                print("Failed to get Documents directory")
-                return
-            }
-            
-            // 2. Define paths for etc and certs directories in the sandbox
-            let etcURL = documentsURL.appendingPathComponent("etc")
-            let certsURL = etcURL.appendingPathComponent("certs")
-            
-            // 3. Create etc and certs directories (if they don't exist)
-            createDirectoryIfNotExists(at: etcURL)
-            createDirectoryIfNotExists(at: certsURL)
-            
-            // 4. Copy toml files to the etc directory
-            let tomlFiles = ["server.toml", "config.toml", "dhp.toml", "resource.toml"]
-            tomlFiles.forEach { fileName in
-                copyFileFromBundle(fileName: fileName, to: etcURL)
-            }
-            
-            // 5. Copy certificate files to the etc/certs directory
-            let certFiles = ["server.crt", "server.key"]
-            certFiles.forEach { fileName in
-                copyFileFromBundle(fileName: fileName, to: certsURL)
-            }
-        }
-        
-        /// Create directory if it doesn't exist
-        private static func createDirectoryIfNotExists(at url: URL) {
-            let fileManager = FileManager.default
-            guard !fileManager.fileExists(atPath: url.path) else {
-                print("Directory already exists: \(url.path)")
-                return
-            }
-            
-            do {
-                try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
-                print("Directory created successfully: \(url.path)")
-            } catch {
-                print("Failed to create directory: \(url.path), error: \(error.localizedDescription)")
-            }
-        }
-        
-        /// Copy file from Bundle to destination path
-        private static func copyFileFromBundle(fileName: String, to destinationURL: URL) {
-            // Split filename and extension (handling files with extensions)
-            let fileNameWithoutExt = (fileName as NSString).deletingPathExtension
-            let fileExt = (fileName as NSString).pathExtension
-            
-            // Get the file path in the Bundle
-            guard let sourceURL = Bundle.main.url(forResource: fileNameWithoutExt, withExtension: fileExt) else {
-                print("File not found in Bundle: \(fileName)")
-                return
-            }
-            
-            // Destination file path (destination directory + filename)
-            let destFileURL = destinationURL.appendingPathComponent(fileName)
-            let fileManager = FileManager.default
-            
-            // Copy file (if it doesn't exist)
-            guard !fileManager.fileExists(atPath: destFileURL.path) else {
-                print("File already exists: \(destFileURL.path)")
-                return
-            }
-            
-            do {
-                try fileManager.copyItem(at: sourceURL, to: destFileURL)
-                print("File copied successfully: \(fileName) -> \(destFileURL.path)")
-            } catch {
-                print("File copy failed: \(fileName), error: \(error.localizedDescription)")
-            }
-        }
-    }
-    
-    ```
-  - ViewController.swift：程序主入口，进行SDK方法调用
-  
-    ```swift
-    //
-    //  ViewController.swift
-    //  TestXCFrameworkSwift
-    //
-    //  Created by haochangjiu on 2025/10/30.
-    //
-    
-    import UIKit
-    import Nhpagent
-    
-    class ViewController: UIViewController {
-        override func viewDidLoad() {
-            super.viewDidLoad()
-            // Do any additional setup after loading the view.
-            // Call method to copy files from etc folder to sandbox etc directory
-            FileCopyManager.copyFilesToSandboxEtc()
-            // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
-            guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-                print("Error: Failed to read Documents directory")
-                return
-            }
-            // Get the parent directory path of the etc folder
-            let etcPath: String = documentsURL.path
-            // Call SdkNhpAgentInit for initialization
-            let initFlag: Bool = SdkNhpAgentInit(etcPath, 3)
-            if !initFlag {
-                print("NHP Agent init failed")
-            }
-            // Call knockloop_start
-            let value = SdkNhpAgentKnockloopStart()
-            print("SdkNhpAgentKnockloopStart value: %ld", value)
+      ```sw
+      //
+      //  FileCopyManager.swift
+      //  TestXCFrameworkSwift
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      import UIKit
+      import Foundation
+      
+      class FileCopyManager {
+          
+          /// Copy specified files to the etc and certs directories in the sandbox
+          static func copyFilesToSandboxEtc() {
+              // 1. Get the Documents directory in the sandbox
+              guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                  print("Failed to get Documents directory")
+                  return
+              }
+              
+              // 2. Define paths for etc and certs directories in the sandbox
+              let etcURL = documentsURL.appendingPathComponent("etc")
+              let certsURL = etcURL.appendingPathComponent("certs")
+              
+              // 3. Create etc and certs directories (if they don't exist)
+              createDirectoryIfNotExists(at: etcURL)
+              createDirectoryIfNotExists(at: certsURL)
+              
+              // 4. Copy toml files to the etc directory
+              let tomlFiles = ["server.toml", "config.toml", "dhp.toml", "resource.toml"]
+              tomlFiles.forEach { fileName in
+                  copyFileFromBundle(fileName: fileName, to: etcURL)
+              }
+              
+              // 5. Copy certificate files to the etc/certs directory
+              let certFiles = ["server.crt", "server.key"]
+              certFiles.forEach { fileName in
+                  copyFileFromBundle(fileName: fileName, to: certsURL)
+              }
+          }
+          
+          /// Create directory if it doesn't exist
+          private static func createDirectoryIfNotExists(at url: URL) {
+              let fileManager = FileManager.default
+              guard !fileManager.fileExists(atPath: url.path) else {
+                  print("Directory already exists: \(url.path)")
+                  return
+              }
+              
+              do {
+                  try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+                  print("Directory created successfully: \(url.path)")
+              } catch {
+                  print("Failed to create directory: \(url.path), error: \(error.localizedDescription)")
+              }
+          }
+          
+          /// Copy file from Bundle to destination path
+          private static func copyFileFromBundle(fileName: String, to destinationURL: URL) {
+              // Split filename and extension (handling files with extensions)
+              let fileNameWithoutExt = (fileName as NSString).deletingPathExtension
+              let fileExt = (fileName as NSString).pathExtension
+              
+              // Get the file path in the Bundle
+              guard let sourceURL = Bundle.main.url(forResource: fileNameWithoutExt, withExtension: fileExt) else {
+                  print("File not found in Bundle: \(fileName)")
+                  return
+              }
+              
+              // Destination file path (destination directory + filename)
+              let destFileURL = destinationURL.appendingPathComponent(fileName)
+              let fileManager = FileManager.default
+              
+              // Copy file (if it doesn't exist)
+              guard !fileManager.fileExists(atPath: destFileURL.path) else {
+                  print("File already exists: \(destFileURL.path)")
+                  return
+              }
+              
+              do {
+                  try fileManager.copyItem(at: sourceURL, to: destFileURL)
+                  print("File copied successfully: \(fileName) -> \(destFileURL.path)")
+              } catch {
+                  print("File copy failed: \(fileName), error: \(error.localizedDescription)")
+              }
+          }
       }
-    }
-    ```
+      
+      ```
+    - ViewController.swift：程序主入口，进行SDK方法调用
+
+      ```swift
+      //
+      //  ViewController.swift
+      //  TestXCFrameworkSwift
+      //
+      //  Created by haochangjiu on 2025/10/30.
+      //
+      
+      import UIKit
+      import Nhpagent
+      
+      class ViewController: UIViewController {
+          override func viewDidLoad() {
+              super.viewDidLoad()
+              // Do any additional setup after loading the view.
+              // Call method to copy files from etc folder to sandbox etc directory
+              FileCopyManager.copyFilesToSandboxEtc()
+              // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
+              guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                  print("Error: Failed to read Documents directory")
+                  return
+              }
+              // Get the parent directory path of the etc folder
+              let etcPath: String = documentsURL.path
+              // Call SdkNhpAgentInit for initialization
+              let initFlag: Bool = IossdkNhpAgentInit(etcPath, 3)
+              if !initFlag {
+                  print("NHP Agent init failed")
+              }
+              // Call knockloop_start
+              let value = IossdkNhpAgentKnockloopStart()
+              print("SdkNhpAgentKnockloopStart value: %ld", value)
+        }
+      }
+      ```
     
     

--- a/docs/zh-cn/index.zh-cn.md
+++ b/docs/zh-cn/index.zh-cn.md
@@ -1,6 +1,6 @@
 ---
 title: 中文版
-nav_order: 11
+nav_order: 12
 layout: page
 has_children: true
 has_toc: true

--- a/endpoints/agent/androidsdkdemo/java/MainActivity.java
+++ b/endpoints/agent/androidsdkdemo/java/MainActivity.java
@@ -1,0 +1,37 @@
+package org.example;
+
+import android.os.Bundle;
+import android.os.Environment;
+import android.util.Log;
+import androidx.appcompat.app.AppCompatActivity;
+
+
+import com.OpennhpLibrary;
+import com.fancy.zerotrust.R;
+
+import java.io.File;
+
+public class MainActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Read the phone's storage download directory.
+        String appDir = Environment.getExternalStorageDirectory() + File.separator + "download";
+        // Does the nhp directory exist in the downloads
+        File file = new File(appDir);
+        if (!file.exists()) {
+            Log.d("MainActivity","download file not exist！");
+            return;
+        }
+        Log.d("MainActivity","download file exist！");
+        String appDir1 = Environment.getExternalStorageDirectory() + File.separator + "download"+ File.separator + "nhp";
+        boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init(appDir1, 3);
+        if (!initFlag) {
+            System.out.println("NHP Agent init failed");
+            System.exit(0);
+        }
+        System.out.println("start the loop knocking thread...");
+        OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
+    }
+}

--- a/endpoints/agent/androidsdkdemo/java/OpennhpLibrary.java
+++ b/endpoints/agent/androidsdkdemo/java/OpennhpLibrary.java
@@ -1,0 +1,55 @@
+package org.example;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+
+/**
+ * OpenNHP agent sdk interface
+ *
+ * @author haochangjiu
+ * @version JDK 8
+ * @className OpennhpLibrary
+ * @date 2025/10/27
+ */
+public interface OpennhpLibrary extends Library {
+    // load OpenNHP agent sdk
+    OpennhpLibrary INSTANCE = Native.load("nhpagent", OpennhpLibrary.class);
+
+    /**
+     * @description Initialization of the nhp_agent instance working directory path:
+     *              The configuration files to be read are located under workingdir/etc/,
+     *              and log files will be generated under workingdir/logs/.
+     * @param workingDir: the working directory path for the agent
+     * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
+     *                    return boolean Whether agent instance has been initialized successfully.
+     * @return boolean
+     * @author haochangjiu
+     * @date 2025/10/27
+     * {@link boolean}
+     */
+    boolean nhp_agent_init(String workingDir, int logLevel);
+
+    /**
+     * @description Synchronously stop and release nhp_agent.
+     * @author haochangjiu
+     * @date 2025/10/27
+     */
+    void nhp_agent_close();
+    /**
+     * @description Read the user information, resource information, server information,
+     *              and other configuration files written under workingdir/etc,
+     *              and asynchronously start the loop knocking thread.
+     * @return int
+     * @author haochangjiu
+     * @date 2025/10/27
+     * {@link int}
+     */
+    int nhp_agent_knockloop_start();
+
+    /**
+     * @description Synchronously stop the loop, knock-on sub thread
+     * @author hangchangjiu
+     * @date 2025/10/27
+     */
+    void nhp_agent_knockloop_stop();
+}

--- a/endpoints/agent/androidsdkdemo/kotlin/MainActivity.kt
+++ b/endpoints/agent/androidsdkdemo/kotlin/MainActivity.kt
@@ -1,0 +1,110 @@
+package com.example.androidtestsoapp
+
+import android.os.Bundle
+import android.os.Environment
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.androidtestsoapp.ui.theme.AndroidTestSoAppTheme
+import com.hjq.permissions.Permission
+import com.hjq.permissions.XXPermissions
+import java.io.File
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            AndroidTestSoAppTheme {
+                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                    Greeting(
+                        name = "Android",
+                        modifier = Modifier.padding(innerPadding)
+                    )
+                }
+            }
+        }
+        // Request permissions - read/write
+        XXPermissions.with(this)
+            .permission(Permission.WRITE_EXTERNAL_STORAGE)
+            .permission(Permission.READ_MEDIA_IMAGES)
+            .permission(Permission.READ_MEDIA_VIDEO)
+            .permission(Permission.READ_MEDIA_AUDIO)
+            .request { permissions, allGranted ->
+                if (allGranted) {
+                    Log.d("MainActivity", "Permissions granted")
+                    performFileOperations()
+                } else {
+                    Log.d("MainActivity", "Permissions not granted")
+                }
+            }
+    }
+}
+
+/**
+ * Need to place the nhp folder containing the etc folder in the phone's download folder
+ * After reading the phone storage download directory, call OpennhpLibrary
+ */
+private fun performFileOperations() {
+    // Read phone storage download directory
+    val appDir = Environment.getExternalStorageDirectory().toString() + File.separator + "download"
+    // Check if zero folder exists in download
+    val file = File(appDir)
+    if (!file.exists()) {
+        Log.d("MainActivity", "Download folder does not exist")
+        return
+    }
+    Log.d("MainActivity", "Download folder exists")
+    val appDir1 = Environment.getExternalStorageDirectory().toString() + File.separator + "download" + File.separator + "nhp"
+    // Check if nhp folder exists in download
+    val file1 = File(appDir1)
+    if (!file1.exists()) {
+        Log.d("MainActivity", "nhp folder does not exist")
+        return
+    }
+    val appDir2 = Environment.getExternalStorageDirectory().toString() + File.separator + "download" + File.separator + "nhp"+ File.separator + "etc"
+    // Check if etc folder exists in download
+    val file2 = File(appDir2)
+    if (!file2.exists()) {
+        Log.d("MainActivity", "Etc folder does not exist")
+        return
+    }
+
+    val initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init(appDir1, 2)
+    if (!initFlag) {
+        println("NHP Agent init failed")
+        return
+    }
+    println("start the loop knocking thread...")
+    val flag:Int = OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start()
+    // Print result
+    if (flag > 0) {
+        println("NHP Agent knockloop start success")
+    } else {
+        println("NHP Agent knockloop start failed")
+    }
+}
+
+@Composable
+fun Greeting(name: String, modifier: Modifier = Modifier) {
+    Text(
+        text = "Hello $name!",
+        modifier = modifier
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GreetingPreview() {
+    AndroidTestSoAppTheme {
+        Greeting("Android")
+    }
+}

--- a/endpoints/agent/desktopsdkdemo/c/nhp-agent-demo.c
+++ b/endpoints/agent/desktopsdkdemo/c/nhp-agent-demo.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <unistd.h>
+#include "nhp-agent.h"
+
+int main() {
+    // Initialize nhp_agent, only one nhp_agent singleton is allowed per process.
+    nhp_agent_init(".", 3);
+
+    // Set the user information for the knock-on-the-door feature.
+    nhp_agent_set_knock_user("zengl", NULL, NULL, NULL);
+
+    // Set NHP server information
+    // If there is already a configuration file for the server, the call to nhp_agent_add_server can be omitted
+    // Timestamp date is visible at https://unixtime.org/
+    nhp_agent_add_server("replace_with_actual_publickeybase64", "192.168.1.66", NULL, 62206, 1748908471);
+
+    // Send a request to the server to access the resource example/demo, and return information in the form of a JSON format string
+    // Note: The resource information here is an independent input, and is unrelated to the resource information saved in the configuration file
+    char *ret = nhp_agent_knock_resource("example", "demo", "192.168.1.66", NULL, 62206);
+    printf("knock return: %s\n", ret);
+
+    // Immediately close the agent's access to the example/demo resources,
+    // if not invoked, access permission will automatically close after the door opening duration has passed.
+    nhp_agent_exit_resource("example", "demo", "192.168.1.66", NULL, 62206);
+
+    // Turn off and release nhp_agent.
+    nhp_agent_close();
+    return 0;
+}
+

--- a/endpoints/agent/desktopsdkdemo/java/App.java
+++ b/endpoints/agent/desktopsdkdemo/java/App.java
@@ -1,0 +1,45 @@
+package org.example;
+
+import java.util.Scanner;
+
+/**
+ * Application for calling the OpenNHP agent SDK
+ *
+ * @author haochangjiu
+ * @version JDK 8
+ * @className App
+ * @date 2025/10/27
+ */
+public class App {
+    public static void main(String[] args) throws Exception {
+//        Initialize and start the OpenNHP agent SDK service
+        boolean initFlag = OpennhpLibrary.INSTANCE.nhp_agent_init("D:\\console-workspace\\opennhp-knock", 3);
+        if (!initFlag) {
+            System.out.println("NHP Agent init failed");
+            System.exit(0);
+        }
+//        Invoke methods in the OpenNHP agent SDK via input commands
+        Scanner scanner = new Scanner(System.in);
+
+        while (true) {
+            System.out.print("> ");
+            if (scanner.hasNextLine()) {
+                String input = scanner.nextLine().trim();
+                if ("knock".equalsIgnoreCase(input)) {
+                    System.out.println("start the loop knocking thread...");
+                    OpennhpLibrary.INSTANCE.nhp_agent_knockloop_start();
+                } else if ("cancel".equalsIgnoreCase(input)) {
+                    System.out.println("stop the loop knocking thread...");
+                    OpennhpLibrary.INSTANCE.nhp_agent_knockloop_stop();
+                } else if ("exit".equalsIgnoreCase(input)) {
+                    System.out.println("exit nhp agent service...");
+                    OpennhpLibrary.INSTANCE.nhp_agent_close();
+                    break;
+                } else {
+                    System.out.println("invalid input");
+                }
+            }
+        }
+        scanner.close();
+    }
+}

--- a/endpoints/agent/desktopsdkdemo/java/OpennhpLibrary.java
+++ b/endpoints/agent/desktopsdkdemo/java/OpennhpLibrary.java
@@ -1,0 +1,55 @@
+package org.example;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+
+/**
+ * OpenNHP agent sdk interface
+ *
+ * @author haochangjiu
+ * @version JDK 8
+ * @className OpennhpLibrary
+ * @date 2025/10/27
+ */
+public interface OpennhpLibrary extends Library {
+    // load OpenNHP agent sdk
+    OpennhpLibrary INSTANCE = Native.load("nhp-agent", OpennhpLibrary.class);
+
+    /**
+     * @description Initialization of the nhp_agent instance working directory path:
+     *              The configuration files to be read are located under workingdir/etc/,
+     *              and log files will be generated under workingdir/logs/.
+     * @param workingDir: the working directory path for the agent
+     * @param logLevel:   0: silent, 1: error, 2: info, 3: debug, 4: verbose
+     *                    return boolean Whether agent instance has been initialized successfully.
+     * @return boolean
+     * @author haochangjiu
+     * @date 2025/10/27
+     * {@link boolean}
+     */
+    boolean nhp_agent_init(String workingDir, int logLevel);
+
+    /**
+     * @description Synchronously stop and release nhp_agent.
+     * @author haochangjiu
+     * @date 2025/10/27
+     */
+    void nhp_agent_close();
+    /**
+     * @description Read the user information, resource information, server information,
+     *              and other configuration files written under workingdir/etc,
+     *              and asynchronously start the loop knocking thread.
+     * @return int
+     * @author haochangjiu
+     * @date 2025/10/27
+     * {@link int}
+     */
+    int nhp_agent_knockloop_start();
+
+    /**
+     * @description Synchronously stop the loop, knock-on sub thread
+     * @author hangchangjiu
+     * @date 2025/10/27
+     */
+    void nhp_agent_knockloop_stop();
+}

--- a/endpoints/agent/desktopsdkdemo/python/nhp-agent-demo.py
+++ b/endpoints/agent/desktopsdkdemo/python/nhp-agent-demo.py
@@ -1,0 +1,34 @@
+import ctypes
+from time import sleep
+
+# Windows
+nhp_agent = ctypes.CDLL('nhp-agent.dll')
+# Linux
+# mylib = ctypes.CDLL('./nhp-agent.so')
+# macOS
+# mylib = ctypes.CDLL('./nhp-agent.dylib')
+
+nhp_agent.nhp_agent_init.argtypes = [ctypes.c_char_p, ctypes.c_int]
+nhp_agent.nhp_agent_init.restype = ctypes.c_bool
+
+nhp_agent.nhp_agent_init.restype = ctypes.c_int
+
+
+
+if __name__ == '__main__':
+    flag = nhp_agent.nhp_agent_init(ctypes.c_char_p(b"D:\\nhpagent"),3)
+    if flag:
+        print("nhp-agent init success")
+    else:
+        print("nhp-agent init failed")
+    # start the loop knocking thread
+    status = nhp_agent.nhp_agent_knockloop_start()
+    if status >= 0:
+        print("nhp-agent knockloop success")
+        # Delay between calls
+        sleep(30)
+    else:
+        print("nhp-agent knockloop failed")
+
+    # stop nhp_agent
+    nhp_agent.nhp_agent_close()

--- a/endpoints/agent/iosagentsdkdemo/objectivec/FileCopyManager.h
+++ b/endpoints/agent/iosagentsdkdemo/objectivec/FileCopyManager.h
@@ -1,0 +1,17 @@
+//
+//  FileCopyManager.h
+//  TestXCFramework
+//
+//  Created by haochangjiu on 2025/10/30.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FileCopyManager : NSObject
+/// Copy the specified file(s) to the etc and certs directories in the application's home directory
++ (void)copyFilesToSandboxEtc;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/endpoints/agent/iosagentsdkdemo/objectivec/FileCopyManager.m
+++ b/endpoints/agent/iosagentsdkdemo/objectivec/FileCopyManager.m
@@ -1,0 +1,91 @@
+//
+//  FileCopyManager.m
+//  TestXCFramework
+//
+//  Created by haochangjiu on 2025/10/30.
+//
+
+#import "FileCopyManager.h"
+#import <Foundation/Foundation.h>
+
+@implementation FileCopyManager
+
+/// Copy the specified file(s) to the etc and certs directories in the application's home directory
++ (void)copyFilesToSandboxEtc {
+    // 1. Retrieve the sandboxed Documents directory
+    NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
+    NSURL *documentsURL = [documentsURLs firstObject];
+    if (!documentsURL) {
+        NSLog(@"Failed to retrieve Documents directory");
+        return;
+    }
+
+    // 2. Define paths for etc and certs directories within the sandbox
+    NSURL *etcURL = [documentsURL URLByAppendingPathComponent:@"etc"];
+    NSURL *certsURL = [etcURL URLByAppendingPathComponent:@"certs"];
+
+    // 3. Create etc and certs directories (if they don't exist)
+    [self createDirectoryIfNotExists:etcURL];
+    [self createDirectoryIfNotExists:certsURL];
+
+    // 4. Copy toml files to the etc directory
+    NSArray *tomlFiles = @[@"server.toml", @"config.toml", @"dhp.toml", @"resource.toml"];
+    for (NSString *fileName in tomlFiles) {
+        [self copyFileFromBundle:fileName toDestinationURL:etcURL];
+    }
+
+    // 5. Copy certificate files to the etc/certs directory
+    NSArray *certFiles = @[@"server.crt", @"server.key"];
+    for (NSString *fileName in certFiles) {
+        [self copyFileFromBundle:fileName toDestinationURL:certsURL];
+    }
+}
+
+/// Create directory if it does not exist
++ (void)createDirectoryIfNotExists:(NSURL *)directoryURL {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if (![fileManager fileExistsAtPath:directoryURL.path]) {
+        NSError *error;
+        BOOL success = [fileManager createDirectoryAtURL:directoryURL
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:&error];
+        if (success) {
+            NSLog(@"Directory created successfully: %@", directoryURL.path);
+        } else {
+            NSLog(@"Failed to create directory: %@, error: %@", directoryURL.path, error.localizedDescription);
+        }
+    } else {
+        NSLog(@"Directory already exists: %@", directoryURL.path);
+    }
+}
+
+/// Copy file from Bundle to destination path
++ (void)copyFileFromBundle:(NSString *)fileName toDestinationURL:(NSURL *)destinationURL {
+    // Get the file path in the Bundle
+    NSURL *sourceURL = [[NSBundle mainBundle] URLForResource:[fileName stringByDeletingPathExtension]
+                                                withExtension:[fileName pathExtension]];
+    if (!sourceURL) {
+        NSLog(@"File not found in Bundle: %@", fileName);
+        return;
+    }
+
+    // Destination file path (destination directory + file name)
+    NSURL *destFileURL = [destinationURL URLByAppendingPathComponent:fileName];
+
+    // Copy file (if it doesn't exist)
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if (![fileManager fileExistsAtPath:destFileURL.path]) {
+        NSError *error;
+        BOOL success = [fileManager copyItemAtURL:sourceURL toURL:destFileURL error:&error];
+        if (success) {
+            NSLog(@"File copied successfully: %@ -> %@", fileName, destFileURL.path);
+        } else {
+            NSLog(@"File copy failed: %@, error: %@", fileName, error.localizedDescription);
+        }
+    } else {
+        NSLog(@"File already exists: %@", destFileURL.path);
+    }
+}
+
+@end

--- a/endpoints/agent/iosagentsdkdemo/objectivec/ViewController.m
+++ b/endpoints/agent/iosagentsdkdemo/objectivec/ViewController.m
@@ -1,0 +1,42 @@
+//
+//  ViewController.m
+//  TestXCFramework
+//
+//  Created by haochangjiu on 2025/10/30.
+//
+
+#import "ViewController.h"
+#import <Nhpagent/Nhpagent.h>
+#import "FileCopyManager.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    // Invoke method to copy files from etc folder to sandbox etc directory
+    [FileCopyManager copyFilesToSandboxEtc];
+    // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
+    NSArray *documentsURLs = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
+    NSURL *documentsURL = [documentsURLs firstObject];
+    if (!documentsURL) {
+        NSLog(@"Error: Failed to read Documents directory");
+    }
+    // Get the parent directory path of the etc folder
+    NSString *etcPath = documentsURL.path;
+    // SdkNhpAgentInit
+    BOOL initFlag = IossdkNhpAgentInit(etcPath, 3);
+    if (!initFlag) {
+        NSLog(@"NHP Agent init failed");
+        return;
+    }
+    // knockloop_start
+    long value = IossdkNhpAgentKnockloopStart();
+    NSLog(@"SdkNhpAgentKnockloopStart value : %ld", value);
+}
+
+@end

--- a/endpoints/agent/iosagentsdkdemo/swift/FileCopyManager.swift
+++ b/endpoints/agent/iosagentsdkdemo/swift/FileCopyManager.swift
@@ -1,0 +1,87 @@
+//
+//  FileCopyManager.swift
+//  TestXCFrameworkSwift
+//
+//  Created by haochangjiu on 2025/10/30.
+//
+
+import UIKit
+import Foundation
+
+class FileCopyManager {
+
+    /// Copy specified files to the etc and certs directories in the sandbox
+    static func copyFilesToSandboxEtc() {
+        // 1. Get the Documents directory in the sandbox
+        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            print("Failed to get Documents directory")
+            return
+        }
+
+        // 2. Define paths for etc and certs directories in the sandbox
+        let etcURL = documentsURL.appendingPathComponent("etc")
+        let certsURL = etcURL.appendingPathComponent("certs")
+
+        // 3. Create etc and certs directories (if they don't exist)
+        createDirectoryIfNotExists(at: etcURL)
+        createDirectoryIfNotExists(at: certsURL)
+
+        // 4. Copy toml files to the etc directory
+        let tomlFiles = ["server.toml", "config.toml", "dhp.toml", "resource.toml"]
+        tomlFiles.forEach { fileName in
+            copyFileFromBundle(fileName: fileName, to: etcURL)
+        }
+
+        // 5. Copy certificate files to the etc/certs directory
+        let certFiles = ["server.crt", "server.key"]
+        certFiles.forEach { fileName in
+            copyFileFromBundle(fileName: fileName, to: certsURL)
+        }
+    }
+
+    /// Create directory if it doesn't exist
+    private static func createDirectoryIfNotExists(at url: URL) {
+        let fileManager = FileManager.default
+        guard !fileManager.fileExists(atPath: url.path) else {
+            print("Directory already exists: \(url.path)")
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+            print("Directory created successfully: \(url.path)")
+        } catch {
+            print("Failed to create directory: \(url.path), error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Copy file from Bundle to destination path
+    private static func copyFileFromBundle(fileName: String, to destinationURL: URL) {
+        // Split filename and extension (handling files with extensions)
+        let fileNameWithoutExt = (fileName as NSString).deletingPathExtension
+        let fileExt = (fileName as NSString).pathExtension
+
+        // Get the file path in the Bundle
+        guard let sourceURL = Bundle.main.url(forResource: fileNameWithoutExt, withExtension: fileExt) else {
+            print("File not found in Bundle: \(fileName)")
+            return
+        }
+
+        // Destination file path (destination directory + filename)
+        let destFileURL = destinationURL.appendingPathComponent(fileName)
+        let fileManager = FileManager.default
+
+        // Copy file (if it doesn't exist)
+        guard !fileManager.fileExists(atPath: destFileURL.path) else {
+            print("File already exists: \(destFileURL.path)")
+            return
+        }
+
+        do {
+            try fileManager.copyItem(at: sourceURL, to: destFileURL)
+            print("File copied successfully: \(fileName) -> \(destFileURL.path)")
+        } catch {
+            print("File copy failed: \(fileName), error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/endpoints/agent/iosagentsdkdemo/swift/ViewController.swift
+++ b/endpoints/agent/iosagentsdkdemo/swift/ViewController.swift
@@ -1,0 +1,33 @@
+//
+//  ViewController.swift
+//  TestXCFrameworkSwift
+//
+//  Created by haochangjiu on 2025/10/30.
+//
+
+import UIKit
+import Nhpagent
+
+class ViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+        // Call method to copy files from etc folder to sandbox etc directory
+        FileCopyManager.copyFilesToSandboxEtc()
+        // Retrieve the sandbox target path (Documents), which is the parent directory of the etc folder
+        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            print("Error: Failed to read Documents directory")
+            return
+        }
+        // Get the parent directory path of the etc folder
+        let etcPath: String = documentsURL.path
+        // Call SdkNhpAgentInit for initialization
+        let initFlag: Bool = IossdkNhpAgentInit(etcPath, 3)
+        if !initFlag {
+            print("NHP Agent init failed")
+        }
+        // Call knockloop_start
+        let value = IossdkNhpAgentKnockloopStart()
+        print("SdkNhpAgentKnockloopStart value: %ld", value)
+  }
+}

--- a/endpoints/agent/iossdk/export.go
+++ b/endpoints/agent/iossdk/export.go
@@ -1,0 +1,382 @@
+package iossdk
+
+import "C"
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/OpenNHP/opennhp/endpoints/agent"
+	"github.com/OpenNHP/opennhp/nhp/common"
+	"github.com/OpenNHP/opennhp/nhp/core"
+	_ "golang.org/x/mobile/bind"
+)
+
+var gAgentInstance *agent.UdpAgent
+var gWorkingDir string
+var gLogLevel int
+
+// Initialization of the nhp_agent instance working directory path:
+// The configuration files to be read are located under workingdir/etc/,
+// and log files will be generated under workingdir/logs/.
+//
+// Input:
+// workingDir: the working directory path for the agent
+// logLevel: 0: silent, 1: error, 2: info, 3: debug, 4: verbose
+//
+// Return:
+// Whether agent instance has been initialized successfully.
+func NhpAgentInit(workingDir string, logLevel int) bool {
+	if gAgentInstance != nil {
+		return true
+	}
+
+	gAgentInstance = &agent.UdpAgent{}
+	err := gAgentInstance.Start(workingDir, logLevel)
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+// Synchronously stop and release nhp_
+func NhpAgentClose() {
+	if gAgentInstance == nil {
+		return
+	}
+
+	gAgentInstance.Stop()
+	gAgentInstance = nil
+}
+
+// Read the user information, resource information, server information,
+// and other configuration files written under workingdir/etc,
+// and asynchronously start the loop knocking thread.
+//
+// Input: None
+//
+// Return:
+// -1: Uninitialized error
+// >=0: The number of resources requested to knock by the knocking thread at the time of the call
+//
+//	(knocking resources will be synchronized with changes in the configuration in workingdir/etc/resource.toml).
+//
+//export NhpAgentKnockloopStart
+func NhpAgentKnockloopStart() int {
+	if gAgentInstance == nil {
+		return -1
+	}
+
+	count := gAgentInstance.StartKnockLoop()
+	return count
+}
+
+// Synchronously stop the loop, knock-on sub thread.
+func NhpAgentKnockloopStop() {
+	if gAgentInstance == nil {
+		return
+	}
+
+	gAgentInstance.StopKnockLoop()
+}
+
+// Setting agent's represented user information
+//
+// Input:
+// userId: User identification (optional, but not recommended to be empty)
+// devId: Device identification (optional)
+// orgId: Organization or company identification (optional)
+// userData: Additional fields required to interface with backend services (json format string, optional)
+//
+// Return:
+// Whether the user information is set successfully
+func NhpAgentSetKnockUser(userId string, devId string, orgId string, userData string) bool {
+	if gAgentInstance == nil {
+		return false
+	}
+	var data map[string]any
+	if len(userData) > 0 {
+		err := json.Unmarshal([]byte(userData), &data)
+		if err != nil {
+			return false
+		}
+	}
+
+	gAgentInstance.SetDeviceId(devId)
+	gAgentInstance.SetKnockUser(userId, orgId, data)
+	return true
+}
+
+// Add an NHP server information to the agent for use in knocking on the door
+// (the agent can initiate different knocking requests to multiple NHP servers).
+//
+// Input:
+// pubkey: Public key of the NHP server
+// ip: IP address of the NHP server
+// host: Domain name of the NHP server (if a domain name is set, the ip item is optional)
+// port: Port number for the NHP server to operate (if set to 0, the default port 62206 will be used)
+// expire: Expiration time of the NHP server's public key (in epoch seconds, set to 0 for permanent)
+//
+// Return:
+// Whether the server information has been successfully added.
+func NhpAgentAddServer(pubkey string, ip string, host string, port int, expire int64) bool {
+	if gAgentInstance == nil {
+		return false
+	}
+
+	if len(pubkey) == 0 || (len(ip) == 0 && len(host) == 0) {
+		return false
+	}
+
+	serverPort := int(port)
+	if serverPort == 0 {
+		serverPort = 62206 // use default server listening port
+	}
+
+	serverPeer := &core.UdpPeer{
+		Type:         core.NHP_SERVER,
+		PubKeyBase64: pubkey,
+		Ip:           ip,
+		Port:         serverPort,
+		Hostname:     host,
+		ExpireTime:   expire,
+	}
+	gAgentInstance.AddServer(serverPeer)
+	return true
+}
+
+// Delete NHP server information from the agent
+//
+// Input:
+// pubkey: NHP server public key
+func NhpAgentRemoveServer(pubkey string) {
+	if gAgentInstance == nil {
+		return
+	}
+	if len(pubkey) == 0 {
+		return
+	}
+
+	gAgentInstance.RemoveServer(pubkey)
+}
+
+// Please add a resource information for the agent to use for knocking on the door
+// (the agent can initiate a knock-on request for different resources)
+//
+// Input:
+// aspId: Authentication Service Provider Identifier
+// resId: Resource Identifier
+// serverIp: NHP server IP address or domain name (the NHP server managing the resource)
+// serverHostname: NHP server domain name (the NHP server managing the resource)
+// serverPort: NHP server port (the NHP server managing the resource)
+//
+// Return:
+// Whether the resource information has been added successfully
+func NhpAgentAddResource(aspId string, resId string, serverIp string, serverHostname string, serverPort int) bool {
+	if gAgentInstance == nil {
+		return false
+	}
+
+	if len(aspId) == 0 || len(resId) == 0 || (len(serverIp) == 0 && len(serverHostname) == 0) {
+		return false
+	}
+
+	resource := &agent.KnockResource{
+		AuthServiceId:  aspId,
+		ResourceId:     resId,
+		ServerIp:       serverIp,
+		ServerHostname: serverHostname,
+		ServerPort:     serverPort,
+	}
+	err := gAgentInstance.AddResource(resource)
+	return err == nil
+}
+
+// Delete resource information from the agent
+//
+// Input:
+// aspId: Authentication Service Provider Identifier
+// resId: Resource Identifier
+func NhpAgentRemoveResource(aspId string, resId string) {
+	if gAgentInstance == nil {
+		return
+	}
+
+	if len(aspId) == 0 || len(resId) == 0 {
+		return
+	}
+
+	gAgentInstance.RemoveResource(aspId, resId)
+}
+
+// The agent initiates a single knock on the door request to the server hosting the resource
+//
+// Input:
+// aspId: Authentication service provider identifier
+// resId: Resource identifier
+// serverIp: NHP server IP address or domain name (the NHP server managing the resource)
+// serverHostname: NHP server domain name (the NHP server managing the resource)
+// serverPort: NHP server port (the NHP server managing the resource)
+//
+// Returns:
+// The server's response message (json format string buffer pointer):
+// "errCode": Error code (string, "0" indicates success)
+// "errMsg": Error message (string)
+// "resHost": Resource server address ("resHost": {"Server Name 1":"Server Hostname 1", "Server Name 2":"Server Hostname 2", ...})
+// "opnTime": Door opening duration (integer, in seconds)
+// "aspToken": Token generated after authentication by the ASP (optional)
+// "agentAddr": Agent's IP address from the perspective of the NHP server
+// "preActs": Pre-connection information related to the resource (optional)
+// "redirectUrl": HTTP redirection link (optional)
+//
+// It is necessary to call NhpAgentAddServer before calling,
+// to add the NHP server's public key, address, and other information to the agent
+// The caller is responsible for calling NhpFreeCstring to release the returned char* pointer
+func NhpAgentKnockResource(aspId string, resId string, serverIp string, serverHostname string, serverPort int) string {
+	ackMsg := &common.ServerKnockAckMsg{}
+
+	func() {
+		if gAgentInstance == nil {
+			ackMsg.ErrCode = common.ErrNoAgentInstance.ErrorCode()
+			ackMsg.ErrMsg = common.ErrNoAgentInstance.Error()
+			return
+		}
+
+		if len(aspId) == 0 || len(resId) == 0 || (len(serverIp) == 0 && len(serverHostname) == 0) {
+			ackMsg.ErrCode = common.ErrInvalidInput.ErrorCode()
+			ackMsg.ErrMsg = common.ErrInvalidInput.Error()
+			return
+		}
+
+		resource := &agent.KnockResource{
+			AuthServiceId:  aspId,
+			ResourceId:     resId,
+			ServerIp:       serverIp,
+			ServerHostname: serverHostname,
+			ServerPort:     serverPort,
+		}
+
+		peer := gAgentInstance.FindServerPeerFromResource(resource)
+		if peer == nil {
+			ackMsg.ErrCode = common.ErrKnockServerNotFound.ErrorCode()
+			ackMsg.ErrMsg = common.ErrKnockServerNotFound.Error()
+			return
+		}
+
+		target := &agent.KnockTarget{
+			KnockResource: *resource,
+			ServerPeer:    peer,
+		}
+
+		ackMsg, _ = gAgentInstance.Knock(target)
+	}()
+
+	bytes, _ := json.Marshal(ackMsg)
+
+	return string(bytes)
+}
+
+// The agent explicitly informs the NHP server to exit its access permission to the resource.
+//
+// Input:
+// aspId: Authentication Service Provider Identifier
+// resId: Resource Identifier
+// serverIp: NHP server IP address or domain name (the NHP server managing the resource)
+// serverHostname: NHP server domain name (the NHP server managing the resource)
+// serverPort: NHP server port (the NHP server managing the resource)
+//
+// Return:
+// Whether the exit was successful
+//
+// It is necessary to call NhpAgentAddServer before calling, to add the NHP server's public key, address, and other information to the
+func NhpAgentExitResource(aspId string, resId string, serverIp string, serverHostname string, serverPort int) bool {
+	var err error
+	ackMsg := &common.ServerKnockAckMsg{}
+
+	func() {
+		if gAgentInstance == nil {
+			ackMsg.ErrCode = common.ErrNoAgentInstance.ErrorCode()
+			ackMsg.ErrMsg = common.ErrNoAgentInstance.Error()
+			err = common.ErrNoAgentInstance
+			return
+		}
+
+		if len(aspId) == 0 || len(resId) == 0 || (len(serverIp) == 0 && len(serverHostname) == 0) {
+			ackMsg.ErrCode = common.ErrInvalidInput.ErrorCode()
+			ackMsg.ErrMsg = common.ErrInvalidInput.Error()
+			err = common.ErrInvalidInput
+			return
+		}
+
+		resource := &agent.KnockResource{
+			AuthServiceId:  aspId,
+			ResourceId:     resId,
+			ServerIp:       serverIp,
+			ServerHostname: serverHostname,
+			ServerPort:     serverPort,
+		}
+
+		peer := gAgentInstance.FindServerPeerFromResource(resource)
+		if peer == nil {
+			ackMsg.ErrCode = common.ErrKnockServerNotFound.ErrorCode()
+			ackMsg.ErrMsg = common.ErrKnockServerNotFound.Error()
+			err = common.ErrKnockServerNotFound
+			return
+		}
+
+		target := &agent.KnockTarget{
+			KnockResource: *resource,
+			ServerPeer:    peer,
+		}
+
+		ackMsg, err = gAgentInstance.ExitKnockRequest(target)
+	}()
+
+	return err == nil
+}
+
+// cipherType: 0-curve25519; 1-sm2
+// result: "privatekey"|"publickey"
+// caller is responsible to free the returned char* pointer
+//
+//export NhpGenerateKeys
+func NhpGenerateKeys(cipherType int) string {
+	var e core.Ecdh
+	switch core.EccTypeEnum(cipherType) {
+	case core.ECC_SM2:
+		e = core.NewECDH(core.ECC_SM2)
+	case core.ECC_CURVE25519:
+		fallthrough
+	default:
+		e = core.NewECDH(core.ECC_CURVE25519)
+	}
+	pub := e.PublicKeyBase64()
+	priv := e.PrivateKeyBase64()
+
+	res := fmt.Sprintf("%s|%s", priv, pub)
+
+	return res
+}
+
+// cipherType: 0-curve25519; 1-sm2
+// privateBase64: private key in base64 format
+// result: "publickey"
+// caller is responsible to free the returned char* pointer
+//
+//export NhpPrivkeyToPubkey
+func NhpPrivkeyToPubkey(cipherType int, privateBase64 string) string {
+	privKey := privateBase64
+	privKeyBytes, err := base64.StdEncoding.DecodeString(privKey)
+	if err != nil {
+		return ""
+	}
+
+	e := core.ECDHFromKey(core.EccTypeEnum(cipherType), privKeyBytes)
+	if e == nil {
+		return ""
+	}
+	pub := e.PublicKeyBase64()
+
+	return pub
+}


### PR DESCRIPTION
fix: 1.Modify the Android build environment configuration to prevent overriding the Golang CC and CXX environment variables, and adjust the standalone Android SDK build commands.
     2.Adjust the sequence of the OpenNHP's. documents
add: 1.Add a command in the Makefile: executing the make command on Linux compiles dynamic library .so files for Linux and Android, while executing the make command on macOS compiles .dylib and .xcframework files.
     2.Add ios sdk core opennhp/endpoints/agent/iossdk/export.go