### PR TITLE
1314 allow GOPROXY and GO_VERSION overrides in docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ docker/*/logs/
 go.sum
 
 release/
+
+.DS_Store
+__*

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@ docker/*/logs/
 go.sum
 
 release/
-
-.DS_Store
-__*

--- a/docker/Dockerfile.ac
+++ b/docker/Dockerfile.ac
@@ -4,8 +4,6 @@ WORKDIR /nhp-server
 COPY . .
 
 RUN echo "Building for architecture: ${TARGETARCH}"
-##
-ENV GOPROXY=https://goproxy.cn,direct
 
 RUN cd /nhp-server &&  make init acd test
 

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -5,8 +5,6 @@ WORKDIR /workdir
 COPY . .
 
 RUN echo "Building for architecture: ${TARGETARCH}"
-##
-ENV GOPROXY=https://goproxy.cn,direct
 
 RUN cd /workdir && cat Makefile && make init agentd test
 

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -46,7 +46,6 @@ ENV PATH="${GOPATH}/bin:${PATH}"
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
 ENV CGO_ENABLED=1
-ENV GOPROXY=https://goproxy.cn,direct
 
 # Verify installations
 RUN go version && \
@@ -58,7 +57,6 @@ WORKDIR /app
 # Copy the source code
 COPY ./web-app .
 ##
-ENV GOPROXY=https://goproxy.cn,direct
 # Build the application
 RUN CGO_ENABLED=0 GOOS=linux go mod tidy && go build -o app
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -3,6 +3,11 @@ FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS builder
 # Get target platform architecture
 ARG TARGETARCH
 ARG TARGETOS
+ARG GOPROXY=https://goproxy.cn,direct
+ARG GO_VERSION=1.21.2
+
+# Set Proxy
+ENV GOPROXY=${GOPROXY}
 
 # Install basic tools
 RUN apt-get update && \
@@ -16,10 +21,11 @@ RUN apt-get update && \
     ipset \
     git \
     vim \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Go version
-ENV GO_VERSION=1.21.2
+ENV GO_VERSION=${GO_VERSION}
 
 # Set Go download URL based on architecture
 RUN case "${TARGETARCH}" in \
@@ -47,7 +53,6 @@ ENV PATH="${GOPATH}/bin:${PATH}"
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
 ENV CGO_ENABLED=1
-ENV GOPROXY=https://goproxy.cn,direct
 
 # Verify installations
 RUN go version && \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -21,7 +21,6 @@ RUN apt-get update && \
     ipset \
     git \
     vim \
-    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Go version

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -5,8 +5,6 @@ WORKDIR /workdir
 COPY . .
 
 RUN echo "Building for architecture: ${TARGETARCH}"
-##
-ENV GOPROXY=https://goproxy.cn,direct
 
 RUN cd /workdir && cat Makefile && make init db test
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -5,8 +5,6 @@ WORKDIR /nhp-server
 COPY . .
 
 RUN echo "Building for architecture: ${TARGETARCH}"
-##
-ENV GOPROXY=https://goproxy.cn,direct
 
 RUN cd /nhp-server &&  make init serverd plugins test
 

--- a/docs/nhp_quick_start.md
+++ b/docs/nhp_quick_start.md
@@ -81,6 +81,10 @@ git clone https://github.com/OpenNHP/opennhp.git
 cd ./docker
 docker build --no-cache -t opennhp-base:latest -f Dockerfile.base ../..
 ```
+If build issues are encountered, `GO_VERSION` and `GOPROXY` may be overridden by adding a build argument, as in:
+```
+--build-arg GOPROXY=direct
+```
 
 ## 4. Running and Testing the Environment
 


### PR DESCRIPTION
Sometimes certain GO proxies are out of sync or contain corrupt bits.

This change allows the user to override GOPROXY and GO_VERSION with a build argument during docker build.

It has been spot-tested, but it fails safely, as the code runs as before if they overrides are not used.

The quick start documentation has been updated, although one could argue that a superuser could review `Dockerfile.base` and figure it out; still, there is some value to alerting new users as issues have recently surfaced on [GOPROXY.IO](https://goproxy.io/) for certain modules.
