### PR TITLE
fix(security): Set Secure flag on cookies and add workflow permissions

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/endpoints/server/kbs/attest/attest.go
+++ b/endpoints/server/kbs/attest/attest.go
@@ -90,7 +90,7 @@ func Attest(c *gin.Context) {
 		"kbs-session-id",
 		sessionID,
 		3600,
-		"/", "", false, true,
+		"/", "", true, true, // Secure: only send over HTTPS
 	)
 
 	c.JSON(http.StatusOK, gin.H{

--- a/endpoints/server/kbs/auth/auth.go
+++ b/endpoints/server/kbs/auth/auth.go
@@ -70,7 +70,7 @@ func Auth(c *gin.Context) {
 		3600, // the unit is second
 		"/",
 		"",
-		false,
+		true, // Secure: only send over HTTPS
 		true,
 	)
 


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities identified by code scanning tools:

- **Cookie Secure Flag (MEDIUM severity)**: Set the `Secure` attribute to `true` for session cookies in KBS auth and attest handlers. This ensures cookies are only transmitted over HTTPS connections, preventing potential session hijacking via man-in-the-middle attacks on HTTP connections.

- **Workflow Permissions (MEDIUM severity)**: Added explicit `permissions: contents: read` block to the ubuntu-build.yml workflow, following GitHub Actions security best practices (principle of least privilege).

## Changes

| File | Change |
|------|--------|
| `endpoints/server/kbs/auth/auth.go` | Set Cookie Secure flag to `true` |
| `endpoints/server/kbs/attest/attest.go` | Set Cookie Secure flag to `true` |
| `.github/workflows/ubuntu-build.yml` | Add explicit permissions block |

## Test plan

- [ ] Verify build passes with workflow changes
- [ ] Verify cookies are correctly set with Secure flag in HTTPS environments
- [ ] Confirm KBS authentication flow still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)