### PR TITLE
fix(log): Add error handling for file sync and close operations

### DIFF
--- a/nhp/log/logger.go
+++ b/nhp/log/logger.go
@@ -149,8 +149,12 @@ func (lw *AsyncLogWriter) writeRoutine() {
 
 			// close after all writes
 			if !useStdout {
-				file.Sync()
-				file.Close()
+				if err := file.Sync(); err != nil {
+					fmt.Printf("Error: AsyncLogWriter failed to sync file %s (%v)\n", file.Name(), err)
+				}
+				if err := file.Close(); err != nil {
+					fmt.Printf("Error: AsyncLogWriter failed to close file %s (%v)\n", file.Name(), err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Add error handling for `file.Sync()` and `file.Close()` operations in the async log writer.

## Problem

The `writeRoutine()` function in `AsyncLogWriter` was not checking errors from:
- `file.Sync()` - could fail if disk is full or I/O error occurs
- `file.Close()` - could indicate buffered writes didn't flush properly

According to Go best practices, errors from closing writable files should be checked as they can indicate data loss.

## Changes

| File | Change |
|------|--------|
| `nhp/log/logger.go` | Add error handling for `file.Sync()` and `file.Close()` |

## Test plan

- [ ] Verify build passes
- [ ] Verify logging still works correctly
- [ ] Error messages are printed when sync/close fails (e.g., disk full scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)