### PR TITLE
fix(security): Set Secure flag on session cookies

### DIFF
--- a/endpoints/server/kbs/attest/attest.go
+++ b/endpoints/server/kbs/attest/attest.go
@@ -90,7 +90,7 @@ func Attest(c *gin.Context) {
 		"kbs-session-id",
 		sessionID,
 		3600,
-		"/", "", false, true,
+		"/", "", true, true, // Secure: only send over HTTPS
 	)
 
 	c.JSON(http.StatusOK, gin.H{

--- a/endpoints/server/kbs/auth/auth.go
+++ b/endpoints/server/kbs/auth/auth.go
@@ -70,7 +70,7 @@ func Auth(c *gin.Context) {
 		3600, // the unit is second
 		"/",
 		"",
-		false,
+		true, // Secure: only send over HTTPS
 		true,
 	)
 


### PR DESCRIPTION
## Summary

Set the Cookie `Secure` attribute to `true` for session cookies in KBS auth and attest handlers.

## Problem

Session cookies were being set with `Secure: false`, allowing them to be transmitted over unencrypted HTTP connections. This could expose session IDs to interception via man-in-the-middle attacks.

## Changes

| File | Change |
|------|--------|
| `endpoints/server/kbs/auth/auth.go` | Set Cookie Secure flag to `true` |
| `endpoints/server/kbs/attest/attest.go` | Set Cookie Secure flag to `true` |

## Test plan

- [ ] Verify build passes
- [ ] Verify cookies are correctly set with Secure flag in HTTPS environments
- [ ] Confirm KBS authentication flow still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)