### PR TITLE
fix(ci): Add explicit permissions to workflow

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
## Summary

Add explicit `permissions` block to the ubuntu-build.yml workflow.

## Problem

The workflow was missing explicit permissions configuration. Without this, workflows use default token permissions which may be broader than necessary.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ubuntu-build.yml` | Add `permissions: contents: read` |

This follows GitHub Actions security best practices by applying the principle of least privilege.

## Test plan

- [ ] Verify workflow still runs successfully on push/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)