### PR TITLE
fix(ci): Update Go version and fix grpc-gcp-go dependency

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:  # 支持手动触发
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.24'
   GOMODULE: github.com/OpenNHP/opennhp/nhp
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0  # 获取完整历史以便获取commit信息
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/endpoints/go.mod
+++ b/endpoints/go.mod
@@ -33,7 +33,7 @@ require (
 	cloud.google.com/go/monitoring v1.24.2 // indirect
 	cloud.google.com/go/spanner v1.82.0 // indirect
 	cloud.google.com/go/storage v1.55.0 // indirect
-	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.2 // indirect
+	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect


### PR DESCRIPTION
## Summary

- Update `GO_VERSION` from 1.21 to 1.24 to match go.mod requirements
- Update `actions/setup-go` from v4 to v5 for Go 1.24 support
- Upgrade `grpc-gcp-go/grpcgcp` from v1.5.2 to v1.6.0 for grpc v1.78.0 compatibility

## Problem

The build workflow was failing with the error:
```
*gcpBalancer does not implement balancer.Balancer (missing method ExitIdle)
```

**Root causes:**
1. The workflow was using Go 1.21 but the go.mod files require Go 1.24.x
2. The `grpc-gcp-go/grpcgcp@v1.5.2` package is incompatible with `google.golang.org/grpc v1.78.0` - it doesn't implement the `ExitIdle` method required by the `balancer.Balancer` interface

## Test plan

- [ ] Verify Build Binaries workflow passes on all platforms (ubuntu, windows, macos)
- [ ] Verify all binaries are built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)