### PR TITLE
docs(ci): Replace Chinese comments with English in build workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,4 +1,3 @@
-# 编译二进制文件并打包成产物的流水线
 # This workflow builds binaries for all modules and uploads them as artifacts
 
 name: Build Binaries
@@ -10,7 +9,7 @@ on:
       - 'v*'
   pull_request:
     branches: ["main"]
-  workflow_dispatch:  # 支持手动触发
+  workflow_dispatch:  # Manual trigger support
 
 env:
   GO_VERSION: '1.21'
@@ -44,7 +43,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # 获取完整历史以便获取commit信息
+          fetch-depth: 0  # Get full history for commit info
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -129,7 +128,7 @@ jobs:
           go build -trimpath -ldflags "${{ steps.ldflags.outputs.ldflags }}" -v -o ../output/nhp-kgc/nhp-kgc${{ matrix.ext }} ./kgc/main/main.go
           cp ./kgc/main/etc/*.toml ../output/nhp-kgc/etc/
 
-      # 上传各模块作为独立产物
+      # Upload each module as independent artifact
       - name: Upload nhp-agent artifact
         uses: actions/upload-artifact@v4
         with:
@@ -165,7 +164,7 @@ jobs:
           path: output/nhp-kgc/
           retention-days: 30
 
-      # 创建完整的打包产物
+      # Create complete package artifact
       - name: Create archive (Unix)
         if: matrix.os != 'windows-latest'
         shell: bash
@@ -187,7 +186,7 @@ jobs:
           path: output/opennhp-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive_ext }}
           retention-days: 30
 
-  # 汇总所有平台的产物
+  # Aggregate artifacts from all platforms
   summary:
     needs: build
     runs-on: ubuntu-latest
@@ -212,7 +211,7 @@ jobs:
           path: all-artifacts/opennhp-*/
           retention-days: 30
 
-  # 更新 latest release（永久保留最新构建）
+  # Update latest release (always keep the latest build)
   latest-release:
     needs: build
     runs-on: ubuntu-latest
@@ -238,18 +237,17 @@ jobs:
           tag_name: latest
           name: Latest Build
           body: |
-            🚀 **最新构建产物 / Latest Build Artifacts**
-            
-            此 Release 会在每次构建后自动更新，包含最新的二进制文件。
+            **Latest Build Artifacts**
+
             This release is automatically updated after each build with the latest binaries.
-            
-            构建时间 / Build Time: ${{ github.event.head_commit.timestamp }}
-            提交 / Commit: ${{ github.sha }}
+
+            Build Time: ${{ github.event.head_commit.timestamp }}
+            Commit: ${{ github.sha }}
           files: release-files/*
           prerelease: true
           make_latest: false
 
-  # 当推送tag时创建正式Release
+  # Create official release when a tag is pushed
   release:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary

Translate all Chinese comments and release notes to English for consistency and broader accessibility in the open source project.

## Changes

- Remove Chinese header comment
- Translate inline comments to English
- Update release body text to English-only

## Before
```
🚀 **最新构建产物 / Latest Build Artifacts**

此 Release 会在每次构建后自动更新，包含最新的二进制文件。
This release is automatically updated after each build with the latest binaries.

构建时间 / Build Time: ...
提交 / Commit: ...
```

## After
```
**Latest Build Artifacts**

This release is automatically updated after each build with the latest binaries.

Build Time: ...
Commit: ...
```

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Verify release notes appear correctly on next build

🤖 Generated with [Claude Code](https://claude.com/claude-code)