### PR TITLE
fix(ci): Skip latest-release job on pull requests

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -211,9 +211,10 @@ jobs:
           path: all-artifacts/opennhp-*/
           retention-days: 30
 
-  # Update latest release (always keep the latest build)
+  # Update latest release (only on main branch, not PRs)
   latest-release:
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

The `latest-release` job was failing on PRs with the error:
```
Resource not accessible by integration
```

This happens because PRs don't have permission to create GitHub releases. This fix adds a condition to only run the `latest-release` job on pushes to the main branch.

## Changes

- Added `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` condition to `latest-release` job

## Test plan

- [ ] Verify this PR's CI passes (latest-release should be skipped)
- [ ] Verify pushes to main still update the latest release

🤖 Generated with [Claude Code](https://claude.com/claude-code)