### PR TITLE
fix(ci): Add default permissions to build-binaries workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -11,6 +11,10 @@ on:
     branches: ["main"]
   workflow_dispatch:  # Manual trigger support
 
+# Restrict default permissions for security (CodeQL alert fix)
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.24'
   GOMODULE: github.com/OpenNHP/opennhp/nhp


### PR DESCRIPTION
## Summary

Adds top-level `permissions: contents: read` to the build-binaries workflow to restrict GITHUB_TOKEN permissions by default.

Jobs that need write access (`latest-release`, `release`) already have explicit permissions blocks that override this default.

## CodeQL Alerts Fixed

- Alert #9: `actions/missing-workflow-permissions` at line 20 (build job)
- Alert #10: `actions/missing-workflow-permissions` at line 191 (summary job)

## Test plan

- [x] Verify CI passes
- [ ] Verify CodeQL alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)