### PR TITLE
fix(crypto): Use full 12-byte GCM nonce with random prefix

### DIFF
--- a/nhp/core/initiator.go
+++ b/nhp/core/initiator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OpenNHP/opennhp/nhp/common"
 	"github.com/OpenNHP/opennhp/nhp/log"
+	utils "github.com/OpenNHP/opennhp/nhp/utils"
 )
 
 type InitiatorScheme interface {
@@ -126,8 +127,9 @@ func (d *Device) createMsgAssemblerData(md *MsgData) (mad *MsgAssemblerData, err
 		// init version
 		mad.header.SetVersion(ProtocolVersionMajor, ProtocolVersionMinor)
 
-		// init header counter
+		// init header counter and nonce prefix
 		mad.header.SetCounter(mad.TransactionId)
+		mad.header.SetNoncePrefix(utils.GetRandomUint32())
 
 		// init chain hash -> ChainHash0
 		mad.chainHash = NewHash(mad.ciphers.HashType)

--- a/nhp/core/packet.go
+++ b/nhp/core/packet.go
@@ -142,6 +142,7 @@ type Header interface {
 	Flag() uint16
 	SetCounter(uint64)
 	Counter() uint64
+	SetNoncePrefix(uint32)
 	Bytes() []byte
 	NonceBytes() []byte
 	EphermeralBytes() []byte

--- a/nhp/core/scheme/curve/header.go
+++ b/nhp/core/scheme/curve/header.go
@@ -72,8 +72,13 @@ func (h *HeaderCurve) SetFlag(flag uint16) {
 
 func (h *HeaderCurve) NonceBytes() []byte {
 	var nonce [GCMNonceSize]byte
-	copy(nonce[4:GCMNonceSize], h.HeaderCommon[16:24])
+	copy(nonce[0:4], h.HeaderCommon[12:16])  // Nonce prefix (4 bytes)
+	copy(nonce[4:12], h.HeaderCommon[16:24]) // Counter (8 bytes)
 	return nonce[:]
+}
+
+func (h *HeaderCurve) SetNoncePrefix(prefix uint32) {
+	binary.BigEndian.PutUint32(h.HeaderCommon[12:16], prefix)
 }
 
 func (h *HeaderCurve) SetCounter(counter uint64) {

--- a/nhp/core/scheme/curve/header_test.go
+++ b/nhp/core/scheme/curve/header_test.go
@@ -1,0 +1,71 @@
+package curve
+
+import (
+	"testing"
+)
+
+func TestNonceBytesLength(t *testing.T) {
+	var header HeaderCurve
+	header.SetCounter(12345)
+	header.SetNoncePrefix(0xABCDEF01)
+
+	nonce := header.NonceBytes()
+	if len(nonce) != GCMNonceSize {
+		t.Errorf("Expected nonce length %d, got %d", GCMNonceSize, len(nonce))
+	}
+}
+
+func TestNonceBytesContent(t *testing.T) {
+	var header HeaderCurve
+	header.SetCounter(0x0102030405060708)
+	header.SetNoncePrefix(0xAABBCCDD)
+
+	nonce := header.NonceBytes()
+
+	// Check first 4 bytes are the nonce prefix
+	expectedPrefix := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+	for i := 0; i < 4; i++ {
+		if nonce[i] != expectedPrefix[i] {
+			t.Errorf("Nonce prefix byte %d: expected 0x%02X, got 0x%02X", i, expectedPrefix[i], nonce[i])
+		}
+	}
+
+	// Check last 8 bytes are the counter
+	expectedCounter := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	for i := 0; i < 8; i++ {
+		if nonce[4+i] != expectedCounter[i] {
+			t.Errorf("Nonce counter byte %d: expected 0x%02X, got 0x%02X", i, expectedCounter[i], nonce[4+i])
+		}
+	}
+}
+
+func TestNonceNoZeroGap(t *testing.T) {
+	var header HeaderCurve
+	header.SetCounter(0xFFFFFFFFFFFFFFFF)
+	header.SetNoncePrefix(0xFFFFFFFF)
+
+	nonce := header.NonceBytes()
+
+	// Verify no zero bytes when both prefix and counter are set to non-zero
+	for i, b := range nonce {
+		if b == 0 {
+			t.Errorf("Unexpected zero byte at position %d", i)
+		}
+	}
+}
+
+func TestNonceUniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+
+	for i := uint64(0); i < 100; i++ {
+		var header HeaderCurve
+		header.SetCounter(i)
+		header.SetNoncePrefix(uint32(i * 12345))
+
+		nonce := string(header.NonceBytes())
+		if seen[nonce] {
+			t.Errorf("Duplicate nonce detected at iteration %d", i)
+		}
+		seen[nonce] = true
+	}
+}

--- a/nhp/core/scheme/gmsm/header.go
+++ b/nhp/core/scheme/gmsm/header.go
@@ -73,8 +73,13 @@ func (h *HeaderGmsm) SetFlag(flag uint16) {
 
 func (h *HeaderGmsm) NonceBytes() []byte {
 	var nonce [GCMNonceSize]byte
-	copy(nonce[4:GCMNonceSize], h.HeaderCommon[16:24])
+	copy(nonce[0:4], h.HeaderCommon[12:16])  // Nonce prefix (4 bytes)
+	copy(nonce[4:12], h.HeaderCommon[16:24]) // Counter (8 bytes)
 	return nonce[:]
+}
+
+func (h *HeaderGmsm) SetNoncePrefix(prefix uint32) {
+	binary.BigEndian.PutUint32(h.HeaderCommon[12:16], prefix)
 }
 
 func (h *HeaderGmsm) SetCounter(counter uint64) {


### PR DESCRIPTION
## Summary
- Fix GCM nonce to use all 12 bytes instead of only 8
- Add random 4-byte prefix to increase nonce entropy
- Maintain backward compatibility with existing implementations

## Problem
The GCM nonce only used 8 of 12 bytes. Bytes 0-4 were always zero:

```go
// Before (only 8 bytes used):
func (h *HeaderCurve) NonceBytes() []byte {
    var nonce [GCMNonceSize]byte  // 12 bytes, initialized to zero
    copy(nonce[4:12], h.HeaderCommon[16:24])  // Only 8 bytes!
    return nonce[:]  // nonce[0:4] always zero
}
```

This reduced effective nonce entropy and made patterns more predictable.

## Solution
Use HeaderCommon bytes 12-16 (previously unused) as a random nonce prefix:

```go
// After (all 12 bytes used):
func (h *HeaderCurve) NonceBytes() []byte {
    var nonce [GCMNonceSize]byte
    copy(nonce[0:4], h.HeaderCommon[12:16])  // Nonce prefix (4 bytes)
    copy(nonce[4:12], h.HeaderCommon[16:24]) // Counter (8 bytes)
    return nonce[:]
}
```

## HeaderCommon Layout (24 bytes)
| Bytes | Field | Usage |
|-------|-------|-------|
| 0-4 | Preamble | Random |
| 4-8 | Type/Size | XOR'd with preamble |
| 8-10 | Version | Major/Minor |
| 10-12 | Flags | Protocol flags |
| **12-16** | **Nonce Prefix** | **NEW: Random prefix** |
| 16-24 | Counter | Transaction ID |

## Files Modified
| File | Change |
|------|--------|
| `nhp/core/scheme/curve/header.go` | Add SetNoncePrefix(), fix NonceBytes() |
| `nhp/core/scheme/gmsm/header.go` | Add SetNoncePrefix(), fix NonceBytes() |
| `nhp/core/packet.go` | Add SetNoncePrefix() to Header interface |
| `nhp/core/initiator.go` | Call SetNoncePrefix() with random value |
| `nhp/core/scheme/curve/header_test.go` | Add nonce verification tests |

## Backward Compatibility
- **Old senders**: bytes 12-15 are zero → still works, just less entropy
- **New senders**: bytes 12-15 are random → full entropy
- No protocol version bump needed - responders just read bytes as-is

## Test Plan
- [x] `TestNonceBytesLength` - Verify 12 bytes returned
- [x] `TestNonceBytesContent` - Verify prefix and counter placement
- [x] `TestNonceNoZeroGap` - Verify no zero gaps when values set
- [x] `TestNonceUniqueness` - Verify different inputs produce unique nonces