### PR TITLE
fix(docker): Make GOPROXY configurable instead of hardcoded

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS builder
 # Get target platform architecture
 ARG TARGETARCH
 ARG TARGETOS
-ARG GOPROXY=https://goproxy.cn,direct
+ARG GOPROXY=https://proxy.golang.org,direct
 ARG GO_VERSION=1.21.2
 
 # Set Proxy

--- a/docker/docker-compose.dhp.yaml
+++ b/docker/docker-compose.dhp.yaml
@@ -14,6 +14,8 @@ services:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile.server
+      args:
+        - GOPROXY=${GOPROXY:-}
     container_name: nhp-server
     restart: always
     networks:
@@ -31,6 +33,8 @@ services:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile.db
+      args:
+        - GOPROXY=${GOPROXY:-}
     volumes:
       - ./nhp-db/etc/:/nhp-db/etc/
       - ./nhp-db/logs/:/nhp-db/logs/
@@ -49,6 +53,8 @@ services:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile.agent
+      args:
+        - GOPROXY=${GOPROXY:-}
     container_name: nhp-agent
     restart: always
     #command: []

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,9 +11,11 @@ volumes:
 services:
   nhp-server:
     image: opennhp-server
-    build: 
+    build:
       context: ..
       dockerfile: ./docker/Dockerfile.server
+      args:
+        - GOPROXY=${GOPROXY:-}
     container_name: nhp-server
     restart: always
     networks:
@@ -28,9 +30,11 @@ services:
   nhp-ac:
     image: opennhp-ac
     container_name: nhp-ac
-    build: 
+    build:
       context: ..
       dockerfile: ./docker/Dockerfile.ac
+      args:
+        - GOPROXY=${GOPROXY:-}
     volumes:
       - ./nhp-ac/etc/:/nhp-ac/etc/
       - ./nhp-ac/traefik/etc/traefik.toml:/opt/traefik/traefik.toml
@@ -48,9 +52,11 @@ services:
   web-app:
     image: web-app
     container_name: web-app
-    build: 
+    build:
       context: .
       dockerfile: ./Dockerfile.app
+      args:
+        - GOPROXY=${GOPROXY:-}
     restart: always
     cap_add:
       - NET_ADMIN
@@ -60,9 +66,11 @@ services:
 
   nhp-agent:
     image: opennhp-agent:latest
-    build: 
+    build:
       context: ..
       dockerfile: ./docker/Dockerfile.agent
+      args:
+        - GOPROXY=${GOPROXY:-}
     container_name: nhp-agent
     restart: always
     #command: []


### PR DESCRIPTION
## Summary
- Changes default GOPROXY from `goproxy.cn` to `proxy.golang.org` (official Go proxy)
- Adds GOPROXY build args to docker-compose files to enable overrides
- Maintains backward compatibility - users can override for their region

## Usage

**Override via environment variable:**
```bash
GOPROXY=https://goproxy.cn,direct docker-compose up --build
```

**Override via .env file:**
```
GOPROXY=https://goproxy.cn,direct
```

**Override via build argument:**
```bash
docker build --build-arg GOPROXY=https://goproxy.cn,direct .
```

## Regional Recommendations
| Region | GOPROXY |
|--------|---------|
| Global (default) | `https://proxy.golang.org,direct` |
| China | `https://goproxy.cn,direct` |

Fixes #1314