### PR TITLE
docs: add CONTRIBUTING.md and expand code architecture docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,159 @@
+# Contributing to OpenNHP
+
+Thank you for your interest in contributing to OpenNHP! This document provides guidelines and information for contributors.
+
+## Code of Conduct
+
+Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) to maintain a welcoming and inclusive community.
+
+## Getting Started
+
+### Prerequisites
+
+- **Go 1.24+** - Required for building the project
+- **Make** - Build automation
+- **Git** - Version control
+- **golangci-lint** (optional) - For code linting
+
+### Clone and Build
+
+```bash
+# Clone the repository
+git clone https://github.com/OpenNHP/opennhp.git
+cd opennhp
+
+# Initialize dependencies
+make init
+
+# Build all binaries
+make
+```
+
+### Project Structure
+
+```
+opennhp/
+├── nhp/                 # Core NHP protocol library
+│   ├── core/            # Protocol implementation
+│   ├── common/          # Shared types and utilities
+│   ├── utils/           # Helper functions
+│   ├── plugins/         # Plugin system
+│   └── test/            # Unit tests
+├── endpoints/           # Network daemon implementations
+│   ├── agent/           # NHP Agent (client)
+│   ├── server/          # NHP Server
+│   ├── ac/              # Access Controller
+│   ├── db/              # Database component
+│   └── kgc/             # Key Generation Center
+├── examples/            # Example implementations
+│   ├── server_plugin/   # Example server plugin
+│   └── client_sdk/      # SDK usage examples
+├── docs/                # Documentation
+├── docker/              # Docker configurations
+└── release/             # Build outputs
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+make test
+
+# Run tests with race detection
+make test-race
+
+# Run tests with coverage
+make coverage
+```
+
+### Code Style
+
+- Use `gofmt` for code formatting: `make fmt`
+- Follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+- Write clear, descriptive commit messages
+- Add tests for new functionality
+- Document exported functions and types
+
+## Development Workflow
+
+### Making Changes
+
+1. **Fork** the repository on GitHub
+2. **Clone** your fork locally
+3. **Create a branch** for your changes:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+4. **Make your changes** and commit them
+5. **Test** your changes:
+   ```bash
+   make test
+   make fmt
+   ```
+6. **Push** to your fork:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+7. **Open a Pull Request** on GitHub
+
+### Commit Messages
+
+Write clear, concise commit messages that explain the "why" behind your changes:
+
+```
+feat(server): add health check endpoint
+
+Add /health and /ready endpoints for Kubernetes liveness
+and readiness probes.
+```
+
+Use conventional commit prefixes:
+- `feat:` - New features
+- `fix:` - Bug fixes
+- `docs:` - Documentation changes
+- `test:` - Test additions or modifications
+- `refactor:` - Code refactoring
+- `ci:` - CI/CD changes
+- `build:` - Build system changes
+
+### Pull Request Guidelines
+
+- Keep PRs focused on a single change
+- Update documentation if needed
+- Add tests for new functionality
+- Ensure all tests pass
+- Request review from maintainers
+
+## Reporting Issues
+
+### Bug Reports
+
+When reporting bugs, please include:
+
+- Go version (`go version`)
+- Operating system and version
+- Steps to reproduce the issue
+- Expected vs actual behavior
+- Relevant logs or error messages
+
+### Feature Requests
+
+For feature requests, please:
+
+- Check existing issues to avoid duplicates
+- Clearly describe the use case
+- Explain the proposed solution
+
+## Security Issues
+
+For security vulnerabilities, please see our [Security Policy](SECURITY.md) and report issues privately.
+
+## Getting Help
+
+- **GitHub Issues** - For bugs and feature requests
+- **Discussions** - For questions and community support
+- **Documentation** - See the [docs/](docs/) directory
+
+## License
+
+By contributing to OpenNHP, you agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE).

--- a/docs/code.md
+++ b/docs/code.md
@@ -8,9 +8,149 @@ permalink: /code/
 # Understand the Source Code
 {: .fs-9 }
 
-This article explains how to read the source code of OpenNHP.
+This article explains the architecture and structure of the OpenNHP codebase.
 {: .fs-6 .fw-300 }
 
 [中文版](/zh-cn/code/){: .label .fs-4 }
 
 ---
+
+## Repository Structure
+
+OpenNHP uses a multi-module Go architecture:
+
+```
+opennhp/
+├── nhp/                 # Core protocol library (github.com/OpenNHP/opennhp/nhp)
+├── endpoints/           # Network daemons (github.com/OpenNHP/opennhp/endpoints)
+├── examples/            # Example implementations
+├── docs/                # Documentation (Jekyll)
+├── docker/              # Container configurations
+└── release/             # Build outputs
+```
+
+## Core Library (`nhp/`)
+
+The `nhp` module contains the core NHP protocol implementation:
+
+| Directory | Purpose |
+|-----------|---------|
+| `core/` | Protocol implementation: packets, encryption, device management |
+| `common/` | Shared types, message structures, error definitions |
+| `utils/` | Helper functions: IP utilities, iptables, crypto helpers |
+| `plugins/` | Server plugin system interfaces |
+| `log/` | Async logging framework |
+| `etcd/` | etcd integration for distributed configuration |
+| `ebpf/` | eBPF programs for XDP and traffic control |
+| `test/` | Unit tests |
+
+### Key Files in `core/`
+
+- `device.go` - NHP device lifecycle and connection management
+- `packet.go` - Packet structure and header definitions
+- `crypto.go` - Cryptographic primitives (ECDH, AEAD)
+- `initiator.go` - Client-side message encryption
+- `responder.go` - Server-side message decryption
+
+## Network Daemons (`endpoints/`)
+
+The `endpoints` module contains executable daemons:
+
+| Component | Binary | Purpose |
+|-----------|--------|---------|
+| `agent/` | `nhp-agent` | Client that sends knock requests |
+| `server/` | `nhp-server` | Central server handling knock validation |
+| `ac/` | `nhp-ac` | Access Controller managing firewall rules |
+| `db/` | `nhp-db` | Data broker for DHP (Data Hiding Protocol) |
+| `kgc/` | `nhp-kgc` | Key Generation Center for IBC keys |
+
+Each daemon follows a similar structure:
+
+```
+agent/
+├── main/           # Entry point and CLI
+│   ├── main.go     # CLI commands
+│   ├── export.go   # C FFI exports for SDK
+│   └── etc/        # Configuration files
+├── udpagent.go     # UDP transport implementation
+├── config.go       # Configuration handling
+└── msghandler.go   # Message processing
+```
+
+## Cryptographic Schemes
+
+OpenNHP supports two cipher schemes:
+
+| Scheme | Algorithms | Use Case |
+|--------|-----------|----------|
+| `CIPHER_SCHEME_CURVE` | Curve25519 + ChaCha20-Poly1305 + BLAKE2s | International |
+| `CIPHER_SCHEME_GMSM` | SM2 + SM4-GCM + SM3 | Chinese standards |
+
+See [Cryptography](/cryptography/) for detailed protocol documentation.
+
+## Plugin System
+
+Server plugins extend NHP server functionality:
+
+```go
+type PluginHandler interface {
+    Init(helper *NhpServerPluginHelper) error
+    Close() error
+    AuthWithNHP(req *AuthRequest) (*AuthResponse, error)
+    AuthWithHttp(req *HttpAuthRequest) (*HttpAuthResponse, error)
+}
+```
+
+See [Server Plugin Development](/server_plugin/) for implementation guide.
+
+## SDK Architecture
+
+The agent provides SDKs for multiple platforms:
+
+| Platform | Output | Build Target |
+|----------|--------|--------------|
+| Linux | `nhp-agent.so` | `make linuxagentsdk` |
+| macOS | `nhp-agent.dylib` | `make macosagentsdk` |
+| iOS | `nhpagent.xcframework` | `make iosagentsdk` |
+| Android | `libnhpagent.so` | `make androidagentsdk` |
+
+See [Agent SDK](/agent_sdk/) for integration documentation.
+
+## Building from Source
+
+```bash
+# Initialize dependencies
+make init
+
+# Build all binaries
+make
+
+# Build specific components
+make agentd      # nhp-agent
+make serverd     # nhp-server
+make acd         # nhp-ac
+
+# Development commands
+make test        # Run tests
+make fmt         # Format code
+make clean       # Clean build artifacts
+```
+
+## Testing
+
+Tests are located in `nhp/test/` and `endpoints/test/`:
+
+```bash
+# Run all tests
+make test
+
+# Run with race detection
+make test-race
+
+# Run with coverage
+make coverage
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/OpenNHP/opennhp/blob/main/CONTRIBUTING.md) for development guidelines.


### PR DESCRIPTION
## Summary

- Create `CONTRIBUTING.md` with development setup, workflow guidelines, and contribution process
- Expand `docs/code.md` from a stub to comprehensive architecture documentation

## Changes

### CONTRIBUTING.md (new file)
- Code of conduct reference
- Prerequisites and build instructions
- Project structure overview
- Development workflow (fork, branch, test, PR)
- Commit message conventions
- Bug reporting and feature request guidelines

### docs/code.md (expanded)
- Multi-module architecture overview
- Core library (`nhp/`) directory breakdown
- Network daemons (`endpoints/`) documentation
- Cryptographic schemes explanation
- Plugin system interface
- SDK architecture table
- Build and test commands

## Motivation

README.md references `CONTRIBUTING.md` but the file didn't exist. This PR fulfills that reference and provides comprehensive onboarding documentation for new contributors.

## Test Plan

- [x] Verify CONTRIBUTING.md renders correctly on GitHub
- [x] Verify docs/code.md renders correctly in Jekyll site
- [x] Check all internal links work