### PR TITLE
test: add fuzz testing infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,26 @@ test:
 	@echo "[OpenNHP] Runing Tests for the Output Binaries ..."
 	@echo "$(COLOUR_GREEN)[OpenNHP] All Tests Are Done!$(END_COLOUR)"
 
+# Run fuzz tests (60 seconds each by default)
+fuzz:
+	@echo "$(COLOUR_BLUE)[OpenNHP] Running fuzz tests...$(END_COLOUR)"
+	cd nhp && go test -fuzz=FuzzECDHFromKey -fuzztime=60s ./test/
+	cd nhp && go test -fuzz=FuzzAESDecrypt -fuzztime=60s ./test/
+	cd nhp && go test -fuzz=FuzzHeaderTypeToDeviceType -fuzztime=60s ./test/
+	cd nhp && go test -fuzz=FuzzAgentKnockMsg -fuzztime=60s ./test/
+	@echo "$(COLOUR_GREEN)[OpenNHP] Fuzz tests completed$(END_COLOUR)"
+
+# Run fuzz tests briefly (for CI)
+fuzz-quick:
+	@echo "$(COLOUR_BLUE)[OpenNHP] Running quick fuzz tests...$(END_COLOUR)"
+	cd nhp && go test -fuzz=FuzzECDHFromKey -fuzztime=10s ./test/
+	cd nhp && go test -fuzz=FuzzAESDecrypt -fuzztime=10s ./test/
+	cd nhp && go test -fuzz=FuzzAgentKnockMsg -fuzztime=10s ./test/
+	@echo "$(COLOUR_GREEN)[OpenNHP] Quick fuzz tests completed$(END_COLOUR)"
+
 archive:
 	@echo "$(COLOUR_BLUE)[OpenNHP] Start archiving... $(END_COLOUR)"
 	@cd release && mkdir -p archive && tar -czvf ./archive/$(PACKAGE_FILE) nhp-agent nhp-ac nhp-db nhp-server
 	@echo "$(COLOUR_GREEN)[OpenNHP] Package ${PACKAGE_FILE} archived!$(END_COLOUR)"
 
-.PHONY: all generate-version-and-build init agentd acd serverd db linuxagentsdk androidagentsdk macosagentsdk iosagentsdk devicesdk plugins test archive ebpf clean_ebpf
+.PHONY: all generate-version-and-build init agentd acd serverd db linuxagentsdk androidagentsdk macosagentsdk iosagentsdk devicesdk plugins test fuzz fuzz-quick archive ebpf clean_ebpf

--- a/nhp/test/fuzz_json_test.go
+++ b/nhp/test/fuzz_json_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/OpenNHP/opennhp/nhp/common"
+)
+
+// FuzzAgentKnockMsg tests JSON parsing of AgentKnockMsg.
+// This is a security-critical message type used for authentication.
+func FuzzAgentKnockMsg(f *testing.F) {
+	// Seed corpus with valid JSON structures
+	f.Add([]byte(`{"userId":"test","deviceId":"dev1"}`))
+	f.Add([]byte(`{"userId":"","deviceId":""}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"nested":{"deep":"value"}}`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var msg common.AgentKnockMsg
+		// Should not panic on any JSON input
+		_ = json.Unmarshal(data, &msg)
+	})
+}
+
+// FuzzServerKnockAckMsg tests JSON parsing of server acknowledgment messages.
+func FuzzServerKnockAckMsg(f *testing.F) {
+	f.Add([]byte(`{"errCode":0,"errMsg":"success"}`))
+	f.Add([]byte(`{"errCode":-1,"errMsg":"error"}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var msg common.ServerKnockAckMsg
+		_ = json.Unmarshal(data, &msg)
+	})
+}
+
+// FuzzACOpsResultMsg tests JSON parsing of AC operation result messages.
+func FuzzACOpsResultMsg(f *testing.F) {
+	f.Add([]byte(`{"errCode":0,"preAccessAction":{}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var msg common.ACOpsResultMsg
+		_ = json.Unmarshal(data, &msg)
+	})
+}
+
+// FuzzDARMsg tests JSON parsing of Data Access Request messages.
+// Security-critical for DHP (Data Hiding Protocol).
+func FuzzDARMsg(f *testing.F) {
+	f.Add([]byte(`{"doId":"test-id","dbId":"db1"}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var msg common.DARMsg
+		_ = json.Unmarshal(data, &msg)
+	})
+}

--- a/nhp/test/fuzz_test.go
+++ b/nhp/test/fuzz_test.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/OpenNHP/opennhp/nhp/core"
+)
+
+// FuzzECDHFromKey tests ECDH key creation with random inputs.
+// This is important for security as malformed keys should be handled gracefully.
+func FuzzECDHFromKey(f *testing.F) {
+	// Seed corpus with valid key sizes
+	f.Add([]byte{}, int(core.ECC_CURVE25519))
+	f.Add(make([]byte, 32), int(core.ECC_CURVE25519))
+	f.Add(make([]byte, 64), int(core.ECC_SM2))
+	f.Add(make([]byte, 16), int(core.ECC_CURVE25519))
+	f.Add(make([]byte, 48), int(core.ECC_SM2))
+
+	f.Fuzz(func(t *testing.T, data []byte, eccType int) {
+		// Normalize eccType to valid range
+		var eType core.EccTypeEnum
+		switch eccType % 2 {
+		case 0:
+			eType = core.ECC_CURVE25519
+		case 1:
+			eType = core.ECC_SM2
+		}
+
+		// ECDHFromKey should not panic on any input
+		// It should return nil for invalid keys
+		e := core.ECDHFromKey(eType, data)
+		if e != nil {
+			// If key was accepted, verify basic operations don't panic
+			_ = e.PublicKey()
+			_ = e.PublicKeyBase64()
+		}
+	})
+}
+
+// FuzzAESDecrypt tests AES decryption with random inputs.
+// Ensures malformed ciphertext is handled without panics.
+func FuzzAESDecrypt(f *testing.F) {
+	// Seed corpus with various sizes
+	f.Add(make([]byte, 16), make([]byte, 32)) // minimum block size
+	f.Add(make([]byte, 32), make([]byte, 32)) // two blocks
+	f.Add(make([]byte, 48), make([]byte, 32)) // three blocks
+	f.Add([]byte{}, make([]byte, 32))         // empty ciphertext
+
+	f.Fuzz(func(t *testing.T, ciphertext []byte, key []byte) {
+		// Normalize key to 32 bytes (AES-256)
+		if len(key) < 32 {
+			paddedKey := make([]byte, 32)
+			copy(paddedKey, key)
+			key = paddedKey
+		} else if len(key) > 32 {
+			key = key[:32]
+		}
+
+		// AESDecrypt should not panic on any input
+		_, _ = core.AESDecrypt(ciphertext, key)
+	})
+}
+
+// FuzzHeaderTypeToDeviceType tests header type to device type mapping.
+func FuzzHeaderTypeToDeviceType(f *testing.F) {
+	// Seed with known valid types
+	f.Add(0)  // NHP_KPL
+	f.Add(1)  // NHP_KNK
+	f.Add(10) // NHP_AOL
+	f.Add(100)
+	f.Add(-1)
+	f.Add(1000000)
+
+	f.Fuzz(func(t *testing.T, headerType int) {
+		// Should not panic on any input
+		_ = core.HeaderTypeToDeviceType(headerType)
+		_ = core.HeaderTypeToString(headerType)
+	})
+}


### PR DESCRIPTION
## Summary
- Add Go native fuzz tests (Go 1.18+) for security-critical functions
- Add Makefile targets for running fuzz tests locally

## New Fuzz Tests

### Crypto Fuzzing (`nhp/test/fuzz_test.go`)

| Test | Target | Purpose |
|------|--------|---------|
| `FuzzECDHFromKey` | `core.ECDHFromKey` | Test ECDH key creation with malformed inputs |
| `FuzzAESDecrypt` | `core.AESDecrypt` | Test AES decryption with random ciphertext |
| `FuzzHeaderTypeToDeviceType` | `core.HeaderTypeToDeviceType` | Test packet header type mapping |

### JSON Message Fuzzing (`nhp/test/fuzz_json_test.go`)

| Test | Target | Purpose |
|------|--------|---------|
| `FuzzAgentKnockMsg` | `common.AgentKnockMsg` | Test authentication message parsing |
| `FuzzServerKnockAckMsg` | `common.ServerKnockAckMsg` | Test server acknowledgment parsing |
| `FuzzACOpsResultMsg` | `common.ACOpsResultMsg` | Test AC operation result parsing |
| `FuzzDARMsg` | `common.DARMsg` | Test DHP data access request parsing |

## New Makefile Targets

| Target | Description |
|--------|-------------|
| `make fuzz` | Run full fuzz tests (60 seconds each) |
| `make fuzz-quick` | Run brief fuzz tests (10 seconds each, suitable for CI) |

## Usage

```bash
# Run all fuzz tests (takes ~4 minutes)
make fuzz

# Run quick fuzz tests (takes ~30 seconds)
make fuzz-quick

# Run a specific fuzz test manually
cd nhp && go test -fuzz=FuzzECDHFromKey -fuzztime=120s ./test/
```

## Why Fuzz Testing?

Fuzz testing is particularly valuable for:
- **Crypto code**: Ensures malformed keys/ciphertext don't cause panics
- **Message parsing**: Validates JSON parsing handles all edge cases
- **Security boundaries**: Identifies potential denial-of-service vectors

## Test plan
- [x] Verify fuzz tests compile
- [ ] Run `make fuzz-quick` to verify tests execute
- [ ] Review any crashes found in fuzz corpus