### PR TITLE
fix(utils): use format specifiers in fmt.Errorf calls

### DIFF
--- a/nhp/utils/cmd.go
+++ b/nhp/utils/cmd.go
@@ -30,7 +30,7 @@ func Run(command string, in string, args ...string) (string, string, error) {
 	}
 	if stderr.String() != "" {
 		log.Println(stderr.String())
-		return "", cmd.String(), fmt.Errorf(stderr.String())
+		return "", cmd.String(), fmt.Errorf("%s", stderr.String())
 	}
 
 	res := strings.Replace(stdout.String(), "\n", "", -1)

--- a/nhp/utils/crypto.go
+++ b/nhp/utils/crypto.go
@@ -66,7 +66,7 @@ func GenerateRsaKey(bits int) (string, string) {
 func Md5sum(fullFilePath string) (string, error) {
 	fileInfo, err := os.Stat(fullFilePath)
 	if err != nil {
-		return "", fmt.Errorf("file not found: " + err.Error())
+		return "", fmt.Errorf("file not found: %w", err)
 	}
 
 	if !fileInfo.Mode().IsRegular() {
@@ -75,14 +75,14 @@ func Md5sum(fullFilePath string) (string, error) {
 
 	file, err := os.Open(fullFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to open file: " + err.Error())
+		return "", fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()
 
 	hasher := md5.New()
 
 	if _, err := io.Copy(hasher, file); err != nil {
-		return "", fmt.Errorf("failed to read file content: " + err.Error())
+		return "", fmt.Errorf("failed to read file content: %w", err)
 	}
 
 	// Convert hash to hex string

--- a/nhp/utils/iptables.go
+++ b/nhp/utils/iptables.go
@@ -430,7 +430,7 @@ func (ipset *IPSet) Run(ctx context.Context, args ...string) (string, error) {
 		return "", err
 	}
 	if stderr.String() != "" {
-		return "", fmt.Errorf(stderr.String())
+		return "", fmt.Errorf("%s", stderr.String())
 	}
 	return stdout.String(), nil
 }

--- a/nhp/utils/utils.go
+++ b/nhp/utils/utils.go
@@ -115,12 +115,12 @@ func SaveStructAsJsonFile(filePath string, data any) error {
 
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal data to JSON: " + err.Error())
+		return fmt.Errorf("failed to marshal data to JSON: %w", err)
 	}
 
 	err = os.WriteFile(filePath, jsonData, 0644)
 	if err != nil {
-		return fmt.Errorf("failed to write JSON to file: " + err.Error())
+		return fmt.Errorf("failed to write JSON to file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
Fix Go vet errors for non-constant format strings in `fmt.Errorf` calls.

## Problem
Go vet flags non-constant format strings as a potential security concern (format string attacks).

## Changes
- `utils/cmd.go` - use `%s` format specifier
- `utils/crypto.go` - use `%w` for proper error wrapping
- `utils/iptables.go` - use `%s` format specifier
- `utils/utils.go` - use `%w` for proper error wrapping

## Test plan
- [x] `go vet ./...` passes