### PR TITLE
github: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- OS: [e.g., Ubuntu 22.04, macOS 14]
+- Go version: [e.g., 1.24]
+- OpenNHP version: [e.g., 0.6.0]
+- Component: [agent/server/ac/db]
+
+## Logs
+
+```
+Paste relevant logs here
+```
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://opennhp.org/docs
+    about: Check the documentation before opening an issue
+  - name: Discussions
+    url: https://github.com/OpenNHP/opennhp/discussions
+    about: Ask questions and discuss ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+Describe the problem this feature would solve.
+
+## Proposed Solution
+
+Describe your proposed solution.
+
+## Alternatives Considered
+
+Any alternative solutions you've considered.
+
+## Additional Context
+
+Any other context or screenshots.


### PR DESCRIPTION
## Summary

Add GitHub issue templates to improve the quality of bug reports and feature requests.

## Files Added

- `.github/ISSUE_TEMPLATE/bug_report.md` - Structured template for bug reports
- `.github/ISSUE_TEMPLATE/feature_request.md` - Template for feature requests
- `.github/ISSUE_TEMPLATE/config.yml` - Links to docs and discussions

## Benefits

- Ensures bug reports include environment info, reproduction steps, and logs
- Guides feature requests to describe problem, solution, and alternatives
- Reduces back-and-forth clarification on issues