### PR TITLE
github: add PR template and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Default owners for everything
+* @OpenNHP/maintainers
+
+# Core protocol
+/nhp/core/ @OpenNHP/core-team
+/nhp/common/ @OpenNHP/core-team
+
+# Endpoints
+/endpoints/ @OpenNHP/endpoints-team
+
+# Documentation
+/docs/ @OpenNHP/docs-team
+*.md @OpenNHP/docs-team
+
+# CI/CD
+/.github/ @OpenNHP/devops-team

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+Brief description of changes.
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactoring
+- [ ] CI/CD improvement
+
+## Related Issues
+
+Fixes #
+
+## Testing
+
+- [ ] Unit tests added/updated
+- [ ] Manual testing performed
+- [ ] All existing tests pass
+
+## Checklist
+
+- [ ] Code follows project style guidelines
+- [ ] Self-review completed
+- [ ] Documentation updated (if needed)
+- [ ] No new warnings introduced


### PR DESCRIPTION
## Summary

Add pull request template and CODEOWNERS file to standardize contributions.

## Files Added

- `.github/PULL_REQUEST_TEMPLATE.md` - Standard PR template with checklist
- `.github/CODEOWNERS` - Code ownership definitions for automatic review assignment

## Benefits

- Consistent PR format with type of change, testing info, and checklist
- Automatic reviewer assignment based on code area
- Clear ownership of different parts of the codebase