### PR TITLE
ci: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  # Go modules - nhp
+  - package-ecosystem: "gomod"
+    directory: "/nhp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+
+  # Go modules - endpoints
+  - package-ecosystem: "gomod"
+    directory: "/endpoints"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+
+  # Go modules - examples
+  - package-ecosystem: "gomod"
+    directory: "/examples/server_plugin"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "go"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary

Add Dependabot configuration to automatically create PRs for dependency updates.

## Configuration

Monitors:
- `/nhp` - Core Go module
- `/endpoints` - Endpoint Go module
- `/examples/server_plugin` - Example plugin Go module
- `/` - GitHub Actions workflows

## Schedule

- Weekly updates on Mondays
- Automatic labels: `dependencies`, `go` or `ci`
- Limited open PRs to avoid noise

## Benefits

- Keeps dependencies up to date automatically
- Security vulnerabilities patched promptly
- Reduces manual maintenance burden