### PR TITLE
fix: add bounds checking to prevent panics from malformed input

### DIFF
--- a/nhp/core/crypto.go
+++ b/nhp/core/crypto.go
@@ -339,6 +339,9 @@ func AESDecrypt(cipherText []byte, key []byte) ([]byte, error) {
 }
 func unpad(padded []byte, blockSize int) []byte {
 	length := len(padded)
+	if length == 0 {
+		return nil
+	}
 	unpadLen := int(padded[length-1])
 	if unpadLen > blockSize || unpadLen > length {
 		return nil

--- a/nhp/core/packet.go
+++ b/nhp/core/packet.go
@@ -76,7 +76,7 @@ var nhpHeaderTypeStrings []string = []string{
 }
 
 func HeaderTypeToString(t int) string {
-	if t < len(nhpHeaderTypeStrings) {
+	if t >= 0 && t < len(nhpHeaderTypeStrings) {
 		return nhpHeaderTypeStrings[t]
 	}
 	return "UNKNOWN"

--- a/nhp/core/scheme/curve/curve.go
+++ b/nhp/core/scheme/curve/curve.go
@@ -22,6 +22,9 @@ type Curve25519ECDH struct {
 }
 
 func (c *Curve25519ECDH) SetPrivateKey(prk []byte) (err error) {
+	if len(prk) < PrivateKeySize {
+		return fmt.Errorf("private key too short: got %d bytes, need %d", len(prk), PrivateKeySize)
+	}
 	copy(c.PrivKey[:], prk[:PrivateKeySize])
 	pbk, err := curve25519.X25519(c.PrivKey[:], curve25519.Basepoint)
 	if err != nil {

--- a/nhp/core/scheme/gmsm/gmsm.go
+++ b/nhp/core/scheme/gmsm/gmsm.go
@@ -26,6 +26,9 @@ type SM2ECDH struct {
 }
 
 func (s *SM2ECDH) SetPrivateKey(prk []byte) (err error) {
+	if len(prk) < PrivateKeySize {
+		return fmt.Errorf("private key too short: got %d bytes, need %d", len(prk), PrivateKeySize)
+	}
 	copy(s.PrivKey[:], prk[:PrivateKeySize])
 	s.prvK, err = ecdh.P256().NewPrivateKey(prk)
 	if err != nil {

--- a/nhp/log/logger.go
+++ b/nhp/log/logger.go
@@ -127,11 +127,11 @@ func (lw *AsyncLogWriter) writeRoutine() {
 				filename := fmt.Sprintf("%s-%s.log", lw.Name, date)
 				if len(lw.DirPath) > 0 {
 					filename = filepath.Join(lw.DirPath, filename)
-					file, err = os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
-					if err != nil {
-						fmt.Printf("Error: AsyncLogWriter cannot open file %s (%v)\n", filename, err)
-						continue
-					}
+				}
+				file, err = os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+				if err != nil {
+					fmt.Printf("Error: AsyncLogWriter cannot open file %s (%v)\n", filename, err)
+					continue
 				}
 			}
 


### PR DESCRIPTION
## Summary

- Fix nil pointer dereference in `AsyncLogWriter.writeRoutine` when `DirPath` is empty but `Name` is set
- Add input validation to `SetPrivateKey` in both Curve25519 and SM2 implementations to prevent slice bounds panic
- Handle empty slice in `unpad` function to prevent index out of range panic
- Check for negative values in `HeaderTypeToString` to prevent array index out of bounds

## Test plan

- [x] Verified all fuzz tests pass locally
- [x] Verified `make test` passes
- [x] All existing unit tests continue to pass

These fixes address panics discovered by fuzz testing (PR #1350) and ensure graceful error handling for malformed or edge-case inputs.