### PR TITLE
ci: add Release Please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: go
+          changelog-path: CHANGELOG.md


### PR DESCRIPTION
## Summary

Add Release Please GitHub Action to automate CHANGELOG updates, version bumps, and GitHub releases.

## How It Works

1. **Conventional Commits** drive versioning:
   - `fix:` → patch bump (0.6.0 → 0.6.1)
   - `feat:` → minor bump (0.6.0 → 0.7.0)
   - `feat!:` or `BREAKING CHANGE:` → major bump (0.6.0 → 1.0.0)

2. **Release PR**: When conventional commits are merged, Release Please creates/updates a PR with:
   - Updated CHANGELOG.md entries
   - Version bump
   - Summary of changes

3. **GitHub Release**: When the Release PR is merged, it creates a GitHub Release with proper tags

## Benefits

- No manual CHANGELOG editing after initial setup
- Consistent semantic versioning based on commit types
- Release PRs allow review before publishing
- Integrates with existing build-binaries workflow

## File Added

- `.github/workflows/release-please.yml`