### PR TITLE
fix(ipv6): fix critical bugs in IPv6 support implementation

### DIFF
--- a/nhp/test/ipv6_support_test.go
+++ b/nhp/test/ipv6_support_test.go
@@ -265,7 +265,8 @@ func TestIPHashStringFormats(t *testing.T) {
 		// IPv6 formats
 		{"IPv6 TCP", "2001:db8::1,80,2001:db8::2", "2001:db8::1,80,2001:db8::2"},
 		{"IPv6 UDP", "2001:db8::1,udp:53,2001:db8::2", "2001:db8::1,udp:53,2001:db8::2"},
-		{"IPv6 ICMP", "2001:db8::1,icmp:8/0,2001:db8::2", "2001:db8::1,icmp:8/0,2001:db8::2"},
+		// Note: ICMPv6 uses type 128 for Echo Request (not type 8 like ICMPv4)
+		{"IPv6 ICMP", "2001:db8::1,icmpv6:128/0,2001:db8::2", "2001:db8::1,icmpv6:128/0,2001:db8::2"},
 
 		// Net/port format for tempset
 		{"IPv4 net,port", "192.168.1.0/25,80", "192.168.1.0/25,80"},
@@ -294,12 +295,33 @@ func TestIPTablesStructFields(t *testing.T) {
 	_ = ipt.AcceptInputMode  // IPv4 accept mode
 	_ = ipt.AcceptInput6Mode // IPv6 accept mode
 
+	// IPv4 policy fields
+	_ = ipt.InputPolicy   // IPv4 INPUT chain policy
+	_ = ipt.ForwardPolicy // IPv4 FORWARD chain policy
+	_ = ipt.OutputPolicy  // IPv4 OUTPUT chain policy
+
+	// IPv6 policy fields (new)
+	_ = ipt.Input6Policy   // IPv6 INPUT chain policy
+	_ = ipt.Forward6Policy // IPv6 FORWARD chain policy
+	_ = ipt.Output6Policy  // IPv6 OUTPUT chain policy
+
 	// Verify default values
 	if ipt.IPv6Available != false {
 		t.Error("IPv6Available should default to false")
 	}
 	if ipt.Binary6 != "" {
 		t.Error("Binary6 should default to empty string")
+	}
+
+	// Verify IPv6 policy defaults (should be 0 = POLICY_ACCEPT by default)
+	if ipt.Input6Policy != 0 {
+		t.Errorf("Input6Policy should default to 0, got %d", ipt.Input6Policy)
+	}
+	if ipt.Forward6Policy != 0 {
+		t.Errorf("Forward6Policy should default to 0, got %d", ipt.Forward6Policy)
+	}
+	if ipt.Output6Policy != 0 {
+		t.Errorf("Output6Policy should default to 0, got %d", ipt.Output6Policy)
 	}
 }
 

--- a/nhp/utils/iputils.go
+++ b/nhp/utils/iputils.go
@@ -27,7 +27,8 @@ func DetectIPType(ipStr string) (IPTYPE, error) {
 }
 
 // IsIPv6 returns true if the string is a valid IPv6 address.
-// Note: IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) return true.
+// Note: IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) return false because
+// Go's net.IP.To4() returns a non-nil value for these addresses.
 func IsIPv6(ipStr string) bool {
 	ip := net.ParseIP(ipStr)
 	return ip != nil && ip.To4() == nil


### PR DESCRIPTION
## Summary

This PR fixes several bugs discovered in the IPv6 support PR #1329.

### Critical Fixes

1. **Fix PASS_PRE_ACCESS_IP mode for IPv6** (`msghandler.go:463-470, 532-543`)
   - `netStr1` was empty for IPv6, causing invalid ipset entries like `",12345"` to be created
   - Added check `if netStr1 != ""` before adding the second IP range (only needed for IPv4)

2. **Fix ICMPv6 type codes** (`msghandler.go:257, 312, 875`)
   - Was incorrectly using `icmp:8/0` for IPv6 addresses
   - ICMPv4 Echo Request = type 8, but ICMPv6 Echo Request = type **128**
   - Now correctly uses `icmpv6:128/0` for IPv6 addresses

### Moderate Fixes

3. **Fix incorrect IsIPv6 documentation** (`iputils.go:29-31`)
   - Comment incorrectly stated IPv4-mapped addresses (::ffff:x.x.x.x) return true
   - They actually return false because Go's `net.IP.To4()` returns non-nil for them

4. **Add error handling for tempset operations** (`msghandler.go:300-327`)
   - Previously silently ignored errors from ipset.Add for tempset entries
   - Now logs warnings when tempset additions fail

5. **Add IPv6 policy detection** (`iptables.go:78-128`)
   - `NewIPTables()` now also detects ip6tables INPUT/FORWARD/OUTPUT chain policies
   - Added new struct fields: `Input6Policy`, `Forward6Policy`, `Output6Policy`

## Test Plan

- [x] All existing IPv6 tests pass
- [x] Updated test file to expect correct `icmpv6:128/0` format for IPv6 ICMP
- [x] Added tests for new IPv6 policy struct fields
- [x] Both modules build successfully