### PR TITLE
Enable gosec linter after fixing security issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,10 +7,10 @@ linters:
     - govet
     - misspell
     - unconvert
+    - gosec
   disable:
     - depguard
     - errcheck  # TODO: Enable after fixing existing issues
-    - gosec     # TODO: Enable after fixing existing issues
   settings:
     govet:
       # Not using enable-all to avoid shadow analyzer
@@ -22,6 +22,16 @@ linters:
       locale: US
       ignore-rules:
         - tempset  # intentional name for temporary ipset
+    gosec:
+      excludes:
+        - G101  # Hardcoded credentials - false positives on variable names
+        - G115  # Integer overflow - most are safe conversions with masks/bounds
+        - G204  # Command injection - uses exec.CommandContext with separate args
+        - G304  # File path traversal - paths are application-controlled
+        - G306  # Poor WriteFile permissions - most are config files
+        - G401  # MD5 weak crypto - used for checksums, not security
+        - G501  # Import blocklist md5 - used for checksums, not security
+        - G505  # Import blocklist sha1 - used for checksums, not security
   exclusions:
     generated: lax
     presets:
@@ -37,6 +47,20 @@ linters:
       - linters:
           - govet
         text: "shadow: declaration of .* shadows declaration"
+      # Suppress G103 (unsafe) for crypto/packet code - intentional for performance
+      - linters:
+          - gosec
+        text: "G103:"
+        path: "(core/packet|core/scheme|core/verifier|core/wasm)"
+      # Suppress G104 (unhandled errors) for logging operations
+      - linters:
+          - gosec
+        text: "G104:"
+        path: "(log/|etcd/)"
+      # Suppress G407 (hardcoded IV) - IV is randomly generated before use
+      - linters:
+          - gosec
+        text: "G407:"
     paths:
       - core/wasm/policy
       - third_party$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,7 +62,7 @@ linters:
           - gosec
         text: "G407:"
     paths:
-      - "nhp/core/wasm/policy"
+      - "nhp/core/wasm/policy/"  # Exclude generated WASM policy code
       - "third_party/"
       - "builtin/"
       - "examples/"
@@ -80,7 +80,7 @@ formatters:
   exclusions:
     generated: lax
     paths:
-      - "nhp/core/wasm/policy"
+      - "nhp/core/wasm/policy/"
       - "third_party/"
       - "builtin/"
       - "examples/"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,14 +24,14 @@ linters:
         - tempset  # intentional name for temporary ipset
     gosec:
       excludes:
-        - G101  # Hardcoded credentials - false positives on variable names
-        - G115  # Integer overflow - most are safe conversions with masks/bounds
-        - G204  # Command injection - uses exec.CommandContext with separate args
-        - G304  # File path traversal - paths are application-controlled
-        - G306  # Poor WriteFile permissions - most are config files
-        - G401  # MD5 weak crypto - used for checksums, not security
+        - G101  # Hardcoded credentials - false positives on variable names like "PrivateKey"
+        - G115  # Integer overflow - safe conversions: WASM bit extraction, timestamps, bounded lengths
+        - G204  # Command injection - uses exec.CommandContext with args array, not shell strings
+        - G304  # File path traversal - all paths are admin-controlled (config files, CLI args)
+        - G401  # MD5 weak crypto - used for checksums/deduplication, not cryptographic security
         - G501  # Import blocklist md5 - used for checksums, not security
         - G505  # Import blocklist sha1 - used for checksums, not security
+        # NOTE: G306 (file permissions) NOT excluded - must be handled case-by-case
   exclusions:
     generated: lax
     presets:
@@ -47,25 +47,25 @@ linters:
       - linters:
           - govet
         text: "shadow: declaration of .* shadows declaration"
-      # Suppress G103 (unsafe) for crypto/packet code - intentional for performance
+      # Suppress G103 (unsafe) for crypto/packet code - intentional for zero-copy performance
       - linters:
           - gosec
         text: "G103:"
-        path: "(core/packet|core/scheme|core/verifier|core/wasm)"
-      # Suppress G104 (unhandled errors) for logging operations
+        path: "nhp/core/(packet|scheme|verifier|wasm)"
+      # Suppress G104 (unhandled errors) for logging operations where errors are non-fatal
       - linters:
           - gosec
         text: "G104:"
-        path: "(log/|etcd/)"
-      # Suppress G407 (hardcoded IV) - IV is randomly generated before use
+        path: "nhp/(log|etcd)/"
+      # Suppress G407 (hardcoded IV) - IV is randomly generated at runtime before use
       - linters:
           - gosec
         text: "G407:"
     paths:
-      - core/wasm/policy
-      - third_party$
-      - builtin$
-      - examples$
+      - "nhp/core/wasm/policy"
+      - "third_party/"
+      - "builtin/"
+      - "examples/"
 issues:
   max-issues-per-linter: 50
   max-same-issues: 10
@@ -80,7 +80,7 @@ formatters:
   exclusions:
     generated: lax
     paths:
-      - core/wasm/policy
-      - third_party$
-      - builtin$
-      - examples$
+      - "nhp/core/wasm/policy"
+      - "third_party/"
+      - "builtin/"
+      - "examples/"

--- a/endpoints/db/utils.go
+++ b/endpoints/db/utils.go
@@ -193,7 +193,7 @@ func (a *AppParams) LoadMetadataAsStruct() (map[string]any, error) {
 
 func (a *UdpDevice) UploadFileToNHPServer(filePath string) (string, error) {
 	httpHost := fmt.Sprintf("http://%s/", a.GetServerPeer().Host())
-	testReq, err := http.Get(httpHost)
+	testReq, err := http.Get(httpHost) //nolint:gosec // G107: URL constructed from configured server peer
 	if err != nil {
 		return "", err
 	}

--- a/endpoints/kgc/kgc.go
+++ b/endpoints/kgc/kgc.go
@@ -100,7 +100,7 @@ func (k *KGCImpl) GenerateMasterKey() error {
 	pubKeyBytes = append(pubKeyBytes, masterKey.PpubY.Bytes()...)
 	content = []byte(updateValueWithKey(string(content), "MasterPublicKeyBase64", base64.StdEncoding.EncodeToString(pubKeyBytes)))
 
-	err = os.WriteFile(configFilePath, content, 0644)
+	err = os.WriteFile(configFilePath, content, 0600) // Contains master private key
 	if err != nil {
 		return err
 	}

--- a/endpoints/kgc/kgc.go
+++ b/endpoints/kgc/kgc.go
@@ -100,8 +100,13 @@ func (k *KGCImpl) GenerateMasterKey() error {
 	pubKeyBytes = append(pubKeyBytes, masterKey.PpubY.Bytes()...)
 	content = []byte(updateValueWithKey(string(content), "MasterPublicKeyBase64", base64.StdEncoding.EncodeToString(pubKeyBytes)))
 
-	err = os.WriteFile(configFilePath, content, 0600) // Contains master private key
+	err = os.WriteFile(configFilePath, content, 0600)
 	if err != nil {
+		return err
+	}
+	// Ensure restrictive permissions even if file already existed
+	// (WriteFile only sets permissions on new files, not existing ones)
+	if err := os.Chmod(configFilePath, 0600); err != nil {
 		return err
 	}
 

--- a/endpoints/server/kbs/resource/resource.go
+++ b/endpoints/server/kbs/resource/resource.go
@@ -65,7 +65,7 @@ func generateCosignKeyPair(privateKeyPath, publicKeyPath string) error {
 		return fmt.Errorf("fail to write private key file: %w", err)
 	}
 
-	if err := os.WriteFile(publicKeyPath, keys.PublicBytes, 0644); err != nil {
+	if err := os.WriteFile(publicKeyPath, keys.PublicBytes, 0644); err != nil { //nolint:gosec // G306: Public keys are intentionally world-readable
 		return fmt.Errorf("fail to write public key file: %w", err)
 	}
 

--- a/endpoints/server/webrtcserver.go
+++ b/endpoints/server/webrtcserver.go
@@ -65,7 +65,7 @@ func (w *WebRTCServer) Start() error {
 						if err = w.pc.SetLocalDescription(answer); err == nil {
 							if w.conf.AnswerFile != "" {
 								if data, err := json.Marshal(answer); err == nil {
-									_ = os.WriteFile(w.conf.AnswerFile, data, 0644)
+									_ = os.WriteFile(w.conf.AnswerFile, data, 0644) //nolint:gosec // G306: SDP signaling data is not sensitive
 								}
 							}
 						}

--- a/nhp/core/packet.go
+++ b/nhp/core/packet.go
@@ -158,12 +158,14 @@ func (pkt *Packet) Flag() uint16 {
 
 func (pkt *Packet) Header() Header {
 	if pkt.Flag()&common.NHP_FLAG_EXTENDEDLENGTH == 0 {
+		//nolint:gosec // G103: Intentional unsafe pointer for zero-copy packet header access
 		return (*curve.HeaderCurve)(unsafe.Pointer(&pkt.Content[0]))
 	} else {
 		switch pkt.Flag() & (0xF << 12) {
 		case common.NHP_FLAG_SCHEME_GMSM:
 			fallthrough
 		default:
+			//nolint:gosec // G103: Intentional unsafe pointer for zero-copy packet header access
 			return (*gmsm.HeaderGmsm)(unsafe.Pointer(&pkt.Content[0]))
 		}
 	}
@@ -172,10 +174,12 @@ func (pkt *Packet) Header() Header {
 func (pkt *Packet) HeaderWithCipherScheme(cipherScheme int) Header {
 	switch cipherScheme {
 	case common.CIPHER_SCHEME_GMSM:
+		//nolint:gosec // G103: Intentional unsafe pointer for zero-copy packet header access
 		return (*gmsm.HeaderGmsm)(unsafe.Pointer(&pkt.Content[0]))
 	case common.CIPHER_SCHEME_CURVE:
 		fallthrough
 	default:
+		//nolint:gosec // G103: Intentional unsafe pointer for zero-copy packet header access
 		return (*curve.HeaderCurve)(unsafe.Pointer(&pkt.Content[0]))
 	}
 }

--- a/nhp/core/responder.go
+++ b/nhp/core/responder.go
@@ -455,18 +455,27 @@ func (ppd *PacketParserData) decryptBody() (err error) {
 		// decompress with size limit to prevent decompression bombs
 		var buf bytes.Buffer
 		br := bytes.NewReader(body)
-		r, _ := zlib.NewReader(br)
+		r, err := zlib.NewReader(br)
+		if err != nil {
+			log.Critical("invalid compressed data: %v", err)
+			ErrDataDecompressionFailed.SetExtraError(err)
+			return ErrDataDecompressionFailed
+		}
 		defer r.Close()
 
 		// Limit decompressed size to 10MB to prevent DoS via decompression bomb
 		const maxDecompressedSize = 10 * 1024 * 1024
-		limitedReader := io.LimitReader(r, maxDecompressedSize)
-		_, err = io.Copy(&buf, limitedReader)
+		limitedReader := io.LimitReader(r, maxDecompressedSize+1) // +1 to detect overflow
+		n, err := io.Copy(&buf, limitedReader)
 		if err != nil {
 			log.Critical("message decompression failed: %v", err)
 			ErrDataDecompressionFailed.SetExtraError(err)
-			err = ErrDataDecompressionFailed
-			return err
+			return ErrDataDecompressionFailed
+		}
+		if n > maxDecompressedSize {
+			log.Critical("decompressed data exceeds maximum size limit (%d bytes)", maxDecompressedSize)
+			ErrDataDecompressionFailed.SetExtraError(fmt.Errorf("decompressed size %d exceeds limit %d", n, maxDecompressedSize))
+			return ErrDataDecompressionFailed
 		}
 
 		ppd.BodyMessage = buf.Bytes() // separately allocated memory

--- a/nhp/core/scheme/curve/header.go
+++ b/nhp/core/scheme/curve/header.go
@@ -38,7 +38,9 @@ func (h *HeaderCurve) TypeAndPayloadSize() (t int, s int) {
 
 func (h *HeaderCurve) SetTypeAndPayloadSize(t int, s int) {
 	preamble := utils.GetRandomUint32()
+	//nolint:gosec // G115: Values are masked to 16 bits before conversion, preventing overflow
 	t32 := uint32((t & 0x0000FFFF) << 16)
+	//nolint:gosec // G115: Values are masked to 16 bits before conversion, preventing overflow
 	s32 := uint32(s & 0x0000FFFF)
 	tns := preamble ^ (s32 | t32)
 	binary.BigEndian.PutUint32(h.HeaderCommon[0:4], preamble)
@@ -56,8 +58,10 @@ func (h *HeaderCurve) Version() (int, int) {
 }
 
 func (h *HeaderCurve) SetVersion(major int, minor int) {
-	h.HeaderCommon[8] = uint8(major)
-	h.HeaderCommon[9] = uint8(minor)
+	//nolint:gosec // G115: Protocol version values are always 0-255 by design
+	h.HeaderCommon[8] = uint8(major & 0xFF)
+	//nolint:gosec // G115: Protocol version values are always 0-255 by design
+	h.HeaderCommon[9] = uint8(minor & 0xFF)
 }
 
 func (h *HeaderCurve) Flag() uint16 {
@@ -85,6 +89,7 @@ func (h *HeaderCurve) Counter() uint64 {
 }
 
 func (h *HeaderCurve) Bytes() []byte {
+	//nolint:gosec // G103: Intentional unsafe pointer for zero-copy header serialization
 	pHeader := (*[HeaderSize]byte)(unsafe.Pointer(&h.HeaderCommon))
 	return pHeader[:]
 }

--- a/nhp/core/scheme/gmsm/header.go
+++ b/nhp/core/scheme/gmsm/header.go
@@ -38,7 +38,9 @@ func (h *HeaderGmsm) TypeAndPayloadSize() (t int, s int) {
 
 func (h *HeaderGmsm) SetTypeAndPayloadSize(t int, s int) {
 	preamble := utils.GetRandomUint32()
+	//nolint:gosec // G115: Values are masked to 16 bits before conversion, preventing overflow
 	t32 := uint32((t & 0x0000FFFF) << 16)
+	//nolint:gosec // G115: Values are masked to 16 bits before conversion, preventing overflow
 	s32 := uint32(s & 0x0000FFFF)
 	tns := preamble ^ (s32 | t32)
 	binary.BigEndian.PutUint32(h.HeaderCommon[0:4], preamble)
@@ -56,8 +58,10 @@ func (h *HeaderGmsm) Version() (int, int) {
 }
 
 func (h *HeaderGmsm) SetVersion(major int, minor int) {
-	h.HeaderCommon[8] = uint8(major)
-	h.HeaderCommon[9] = uint8(minor)
+	//nolint:gosec // G115: Protocol version values are always 0-255 by design
+	h.HeaderCommon[8] = uint8(major & 0xFF)
+	//nolint:gosec // G115: Protocol version values are always 0-255 by design
+	h.HeaderCommon[9] = uint8(minor & 0xFF)
 }
 
 func (h *HeaderGmsm) Flag() uint16 {
@@ -86,6 +90,7 @@ func (h *HeaderGmsm) Counter() uint64 {
 }
 
 func (h *HeaderGmsm) Bytes() []byte {
+	//nolint:gosec // G103: Intentional unsafe pointer for zero-copy header serialization
 	pHeader := (*[HeaderSize]byte)(unsafe.Pointer(&h.HeaderCommon))
 	return pHeader[:]
 }

--- a/nhp/core/wasm/policy/memory/memory.go
+++ b/nhp/core/wasm/policy/memory/memory.go
@@ -8,6 +8,7 @@ import (
 func ReadBufferFromMemory(bufferPosition *uint32, length uint32) []byte {
 	subjectBuffer := make([]byte, length)
 	// Convert the pointer to a byte slice pointer first
+	//nolint:gosec // G103: Required for WASM memory access - pointer comes from WASM runtime
 	data := unsafe.Slice((*byte)(unsafe.Pointer(bufferPosition)), length)
 	for i := range subjectBuffer {
 		subjectBuffer[i] = data[i]
@@ -19,15 +20,20 @@ func ReadBufferFromMemory(bufferPosition *uint32, length uint32) []byte {
 // (a kind of pair with position and length)
 func CopyBufferToMemory(buffer []byte) uint64 {
 	bufferPtr := &buffer[0]
+	//nolint:gosec // G103: Required for WASM memory access - returns pointer to Go memory for WASM
 	unsafePtr := uintptr(unsafe.Pointer(bufferPtr))
 
+	//nolint:gosec // G115: Pointer truncation is intentional for 32-bit WASM address space
 	ptr := uint32(unsafePtr)
+	//nolint:gosec // G115: Buffer length is always within uint32 range for WASM
 	size := uint32(len(buffer))
 
 	return (uint64(ptr) << uint64(32)) | uint64(size)
 }
 
 func StringToPtr(s string) (uint32, uint32) {
+	//nolint:gosec // G103: Required for WASM string passing - pointer to string data for WASM
 	ptr := unsafe.Pointer(unsafe.StringData(s))
+	//nolint:gosec // G115: Pointer truncation is intentional for 32-bit WASM address space
 	return uint32(uintptr(ptr)), uint32(len(s))
 }

--- a/nhp/core/ztdo/noise.go
+++ b/nhp/core/ztdo/noise.go
@@ -408,9 +408,11 @@ type DataPrivateKeyWrapping struct {
 func NewDataPrivateKeyWrapping(providerPublicKeyBase64 string, dataPrivateKeyBase64 string, key, ad []byte) *DataPrivateKeyWrapping {
 	symmetricCipherMode := AES256GCM128Tag
 	var Iv [core.GCMNonceSize]byte
-	rand.Read(Iv[:])
+	if _, err := rand.Read(Iv[:]); err != nil {
+		panic("crypto/rand.Read failed: " + err.Error())
+	}
 
-	cipherText, _ := symmetricCipherMode.Encrypt(key, Iv[:], []byte(dataPrivateKeyBase64), ad)
+	cipherText, _ := symmetricCipherMode.Encrypt(key, Iv[:], []byte(dataPrivateKeyBase64), ad) //nolint:gosec // G104: Encrypt with valid key/IV doesn't fail
 
 	return &DataPrivateKeyWrapping{
 		ProviderPublicKeyBase64: providerPublicKeyBase64,

--- a/nhp/core/ztdo/ztdo.go
+++ b/nhp/core/ztdo/ztdo.go
@@ -190,7 +190,9 @@ func (header *ZtdoHeader) GetECCMode() DataKeyPairECCMode {
 }
 
 func (payload *ZtdoPayload) SetIV() {
-	_, _ = rand.Read(payload.Content.Iv[:]) //nolint:gosec // G104: crypto/rand.Read returns nil error on success
+	if _, err := rand.Read(payload.Content.Iv[:]); err != nil {
+		panic("crypto/rand.Read failed: " + err.Error())
+	}
 }
 
 func (payload *ZtdoPayload) SetCipherText(mode SymmetricCipherMode, key, plaintext []byte, ad []byte) error {

--- a/nhp/core/ztdo/ztdo.go
+++ b/nhp/core/ztdo/ztdo.go
@@ -190,7 +190,7 @@ func (header *ZtdoHeader) GetECCMode() DataKeyPairECCMode {
 }
 
 func (payload *ZtdoPayload) SetIV() {
-	rand.Read(payload.Content.Iv[:])
+	_, _ = rand.Read(payload.Content.Iv[:]) //nolint:gosec // G104: crypto/rand.Read returns nil error on success
 }
 
 func (payload *ZtdoPayload) SetCipherText(mode SymmetricCipherMode, key, plaintext []byte, ad []byte) error {
@@ -643,6 +643,7 @@ func encodeMetadataLength(length int, continuation bool) ([2]byte, error) {
 		return result, fmt.Errorf("length %d is negative", length)
 	}
 
+	//nolint:gosec // G602: result is [2]byte array, indices 0 and 1 are always valid
 	result[0] = byte((length >> 8) & 0x7F)
 	if continuation {
 		result[0] |= 0x80

--- a/nhp/log/logger.go
+++ b/nhp/log/logger.go
@@ -128,7 +128,7 @@ func (lw *AsyncLogWriter) writeRoutine() {
 				if len(lw.DirPath) > 0 {
 					filename = filepath.Join(lw.DirPath, filename)
 				}
-				file, err = os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+				file, err = os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 				if err != nil {
 					fmt.Printf("Error: AsyncLogWriter cannot open file %s (%v)\n", filename, err)
 					continue
@@ -149,8 +149,8 @@ func (lw *AsyncLogWriter) writeRoutine() {
 
 			// close after all writes
 			if !useStdout {
-				file.Sync()
-				file.Close()
+				_ = file.Sync()  //nolint:gosec // G104: Sync errors on log files are non-critical
+				_ = file.Close() //nolint:gosec // G104: Close errors on log files are non-critical
 			}
 		}
 
@@ -254,6 +254,7 @@ func NewLogger(prepend string, level int, dir string, filename string) *Logger {
 	return l
 }
 
+//nolint:gosec // G104: Logger.Output errors are non-critical and handled by async writer
 func (l *Logger) initActions(prepend string) {
 	flag := log.Ldate | log.Ltime | log.Lmsgprefix
 	if ShowCallerFileLine {
@@ -263,42 +264,42 @@ func (l *Logger) initActions(prepend string) {
 	l.lgWrn = log.New(l.lw, prepend+" [Warning] ", flag)
 	l.Warning = func(format string, args ...any) {
 		if l.logLevel >= LogLevelError {
-			l.lgWrn.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgWrn.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgErr = log.New(l.lw, prepend+" [Error] ", flag)
 	l.Error = func(format string, args ...any) {
 		if l.logLevel >= LogLevelError {
-			l.lgErr.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgErr.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgCrt = log.New(l.lw, prepend+" [Critical] ", flag)
 	l.Critical = func(format string, args ...any) {
 		if l.logLevel >= LogLevelError {
-			l.lgCrt.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgCrt.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgEva = log.New(l.lwEvaluate, prepend+" [Evaluate] ", flag|log.Lmicroseconds)
 	l.Evaluate = func(format string, args ...any) {
 		if l.logLevel >= LogLevelError {
-			l.lgEva.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgEva.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgInf = log.New(l.lw, prepend+" [Info] ", flag)
 	l.Info = func(format string, args ...any) {
 		if l.logLevel >= LogLevelInfo {
-			l.lgInf.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgInf.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgSts = log.New(l.lw, prepend+" [Stats] ", flag)
 	l.Stats = func(format string, args ...any) {
 		if l.logLevel >= LogLevelInfo {
-			l.lgSts.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgSts.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
@@ -306,35 +307,35 @@ func (l *Logger) initActions(prepend string) {
 	l.lgAdt = log.New(l.lwAudit, prepend+" [Audit] ", flag)
 	l.Audit = func(format string, args ...any) {
 		if l.logLevel >= LogLevelAudit {
-			l.lgAdt.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgAdt.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgTrx = log.New(l.lwAudit, prepend+" [Transaction] ", flag)
 	l.Transaction = func(format string, args ...any) {
 		if l.logLevel >= LogLevelAudit {
-			l.lgTrx.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgTrx.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgDbg = log.New(l.lw, prepend+" [Debug] ", flag)
 	l.Debug = func(format string, args ...any) {
 		if l.logLevel >= LogLevelDebug {
-			l.lgDbg.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgDbg.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgVbs = log.New(l.lw, prepend+" [Verbose] ", flag)
 	l.Verbose = func(format string, args ...any) {
 		if l.logLevel >= LogLevelTrace {
-			l.lgVbs.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgVbs.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 
 	l.lgTrc = log.New(l.lw, prepend+" [Trace] ", flag)
 	l.Trace = func(format string, args ...any) {
 		if l.logLevel >= LogLevelTrace {
-			l.lgTrc.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgTrc.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 	l.isRunning = true
@@ -510,6 +511,7 @@ func NewLoggerDefine(prepend string, level int, dir string, filename string) *Lo
 	return l
 }
 
+//nolint:gosec // G104: Logger.Output errors are non-critical and handled by async writer
 func (l *Logger) initActionsNoInfoPrepend(prepend string) {
 	flag := log.Ldate | log.Ltime | log.Lmsgprefix
 	if ShowCallerFileLine {
@@ -519,7 +521,7 @@ func (l *Logger) initActionsNoInfoPrepend(prepend string) {
 	l.lgInf = log.New(l.lw, prepend, flag)
 	l.Info = func(format string, args ...any) {
 		if l.logLevel >= LogLevelInfo {
-			l.lgInf.Output(l.callDepth, fmt.Sprintf(format, args...))
+			_ = l.lgInf.Output(l.callDepth, fmt.Sprintf(format, args...))
 		}
 	}
 

--- a/nhp/utils/cmd.go
+++ b/nhp/utils/cmd.go
@@ -18,7 +18,7 @@ func Run(command string, in string, args ...string) (string, string, error) {
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
 
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := exec.CommandContext(ctx, command, args...) //nolint:gosec // G204: Command args passed as separate parameters, not shell string
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	if len(in) > 0 {

--- a/nhp/utils/crypto.go
+++ b/nhp/utils/crypto.go
@@ -42,6 +42,7 @@ func HMACSha256(key, value string) []byte {
 	return hash
 }
 
+//nolint:gosec // G401: MD5 used for non-cryptographic checksums, not for security
 func MD5(value string) string {
 	_16bytes := md5.Sum([]byte(value))
 	return hex.EncodeToString(_16bytes[:])
@@ -63,6 +64,9 @@ func GenerateRsaKey(bits int) (string, string) {
 	return base64.StdEncoding.EncodeToString(pivKey), base64.StdEncoding.EncodeToString(pubKey)
 }
 
+// Md5sum computes MD5 checksum for file integrity verification (not cryptographic security)
+//
+//nolint:gosec // G401: MD5 used for file integrity checksums, not for cryptographic security
 func Md5sum(fullFilePath string) (string, error) {
 	fileInfo, err := os.Stat(fullFilePath)
 	if err != nil {
@@ -73,7 +77,7 @@ func Md5sum(fullFilePath string) (string, error) {
 		return "", fmt.Errorf("path is not a regular file")
 	}
 
-	file, err := os.Open(fullFilePath)
+	file, err := os.Open(fullFilePath) //nolint:gosec // G304: Path validated by os.Stat above
 	if err != nil {
 		return "", fmt.Errorf("failed to open file: %w", err)
 	}

--- a/nhp/utils/file.go
+++ b/nhp/utils/file.go
@@ -23,7 +23,7 @@ func ReadWholeFile(fileName string) (string, error) {
 		return "", err
 	}
 
-	buf, err := os.ReadFile(fileName)
+	buf, err := os.ReadFile(fileName) //nolint:gosec // G304: fileName is application-controlled config path
 	if err != nil {
 		return "", err
 	}
@@ -31,8 +31,11 @@ func ReadWholeFile(fileName string) (string, error) {
 	return string(buf), nil
 }
 
+// HashFile computes hash for file integrity verification (not cryptographic security)
+//
+//nolint:gosec // G401,G501: MD5/SHA1 used for file integrity checksums, not for cryptographic security
 func HashFile(method string, fileName string) (string, error) {
-	file, err := os.Open(fileName) // Open the file for reading
+	file, err := os.Open(fileName) //nolint:gosec // G304: fileName is application-controlled path
 	if err != nil {
 		return "", err
 	}

--- a/nhp/utils/utils.go
+++ b/nhp/utils/utils.go
@@ -16,6 +16,10 @@ import (
 	"github.com/OpenNHP/opennhp/nhp/log"
 )
 
+// GetRandomUint32 returns a non-zero random uint32 for packet preamble obfuscation.
+// Uses math/rand which is sufficient for this non-cryptographic use case.
+//
+//nolint:gosec // G404: math/rand is intentional - used for packet obfuscation, not security
 func GetRandomUint32() (r uint32) {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for {
@@ -72,7 +76,7 @@ func DownloadFileToTemp(fileUrl string, pattern string) (string, error) {
 	}
 	defer outFile.Close()
 
-	resp, err := http.Get(fileUrl)
+	resp, err := http.Get(fileUrl) //nolint:gosec // G107: URL comes from trusted configuration
 	if err != nil {
 		return "", err
 	}

--- a/nhp/utils/utils.go
+++ b/nhp/utils/utils.go
@@ -122,7 +122,7 @@ func SaveStructAsJsonFile(filePath string, data any) error {
 		return fmt.Errorf("failed to marshal data to JSON: %w", err)
 	}
 
-	err = os.WriteFile(filePath, jsonData, 0644)
+	err = os.WriteFile(filePath, jsonData, 0644) //nolint:gosec // G306: Generic utility - callers determine sensitivity
 	if err != nil {
 		return fmt.Errorf("failed to write JSON to file: %w", err)
 	}
@@ -165,7 +165,7 @@ func UpdateTomlConfig(filePath string, key string, value any) error {
 		return fmt.Errorf("unsupported type: %T", value)
 	}
 
-	err = os.WriteFile(filePath, []byte(newContent), 0644)
+	err = os.WriteFile(filePath, []byte(newContent), 0644) //nolint:gosec // G306: Config files are typically world-readable
 	if err != nil {
 		return err
 	}

--- a/nhp/utils/uuid.go
+++ b/nhp/utils/uuid.go
@@ -9,6 +9,10 @@ import (
 	"github.com/google/uuid"
 )
 
+// NewUUID generates a UUID using math/rand. For cryptographically secure UUIDs,
+// use GenerateUUIDv4() instead which uses crypto/rand.
+//
+//nolint:gosec // G404: math/rand is acceptable for non-security UUID generation
 func NewUUID() (string, error) {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	uuid := make([]byte, 16)
@@ -25,6 +29,9 @@ func NewUUID() (string, error) {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
 }
 
+// RandNumber returns a random 4-digit number (1000-10999) for non-security purposes.
+//
+//nolint:gosec // G404: math/rand is acceptable for non-security random numbers
 func RandNumber() int {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	randomNumber := rng.Intn(10000)


### PR DESCRIPTION
## Summary

- Enables the `gosec` security linter in `.golangci.yml` (closes #1373)
- Configures appropriate exclusions for intentional patterns
- Fixes real security issues found during the process

## Changes

### Configuration Updates
- Added `gosec` to enabled linters
- Configured rule exclusions for false positives and intentional patterns:
  - G101 (hardcoded credentials): Variable naming false positives
  - G115 (integer overflow): Safe conversions (WASM bit extraction, timestamps, bounded lengths)
  - G204 (command injection): Uses `exec.CommandContext` with args array, not shell strings
  - G304 (file path traversal): All paths are admin-controlled (config files, CLI args)
  - G401/G501/G505 (weak crypto): MD5/SHA1 used for checksums, not security
  - G103 (unsafe pointer): Intentional for crypto/packet operations (path-based exclusion)
  - G104 (unhandled errors): Logging operations (path-based exclusion)
  - G407 (hardcoded IV): IV randomly generated at runtime before use
- Fixed path regex patterns to be properly anchored (e.g., `nhp/core/(packet|scheme|...)`)
- **G306 (file permissions) is NOT globally excluded** - handled case-by-case

### Security Fixes
- **G110 (decompression bomb)**: Added 10MB size limit in `responder.go` with proper overflow detection (rejects oversized data instead of silently truncating)
- **G306 (file permissions)**: Fixed `kgc.go` to use 0600 for config containing master private key, with `os.Chmod` to enforce permissions on existing files
- **G104 (error handling)**: Fixed `rand.Read` error handling in `ztdo.go` and `noise.go` - now panics on failure (security-critical IV generation)
- **G104 (error handling)**: Fixed `zlib.NewReader` error handling in `responder.go`
- **G302 (file permissions)**: Changed log file permissions to 0600

### Nolint Comments
Added explanatory `//nolint:gosec` comments for remaining edge cases:
- Crypto/packet unsafe pointer operations (performance-critical)
- Math/rand usage for non-security purposes (packet obfuscation)
- HTTP requests with configured URLs
- G306 for intentionally world-readable files (public keys, config updates, SDP signaling)

## Test Plan
- [x] Verify CI passes with gosec enabled
- [x] Confirm no new security warnings
- [x] Run existing tests to ensure no regressions