### PR TITLE
fix(ci): remove duplicate permissions block in ubuntu-build workflow

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -12,9 +12,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
-
 jobs:
 
   build:


### PR DESCRIPTION
## Summary
- Remove duplicate `permissions` block that was causing workflow file parsing error

The workflow file had `permissions: contents: read` defined twice (lines 6-7 and 15-16), which caused GitHub Actions to fail with "workflow file issue".

## Test plan
- [ ] Verify CI workflow runs successfully after merge