### PR TITLE
ci: use PAT for release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: go
-          changelog-path: CHANGELOG.md
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch release-please workflow to use `RELEASE_PLEASE_TOKEN` PAT instead of default `GITHUB_TOKEN`
- Fixes CI failure where org policy prevents GitHub Actions from creating PRs with the default token
- Removes invalid `changelog-path` parameter that was causing warnings

## Context
The organization has disabled write permissions for workflows at the org level, causing the release-please action to fail with:
> GitHub Actions is not permitted to create or approve pull requests

## Test plan
- [x] Verify `RELEASE_PLEASE_TOKEN` secret is configured in repository settings
- [ ] Merge PR and confirm release-please workflow succeeds on next push to main

🤖 Generated with [Claude Code](https://claude.ai/code)