### PR TITLE
ci: add Deploy Demo workflow for manual template deployment

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,76 @@
+# Deploy templates to Demo servers
+# This workflow deploys templates to demo NHP servers
+
+name: Deploy Demo
+
+on:
+  workflow_dispatch:  # Manual trigger only
+    inputs:
+      confirm:
+        description: 'Type "deploy" to confirm deployment'
+        required: true
+        default: ''
+
+env:
+  DEPLOY_USER: ec2-user
+  DEPLOY_PATH: /home/ec2-user/nhp-server/templates
+  TEMPLATES_SOURCE: docker/nhp-server/templates
+
+jobs:
+  deploy-templates:
+    if: github.event.inputs.confirm == 'deploy'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        server: ${{ fromJson(vars.DEMO_NHP_SERVERS) }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEMO_NHP_SERVER_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ matrix.server }} >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Deploy templates to ${{ matrix.server }}
+        run: |
+          echo "Deploying templates to ${{ matrix.server }}..."
+          
+          # Sync templates directory
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            ${{ env.TEMPLATES_SOURCE }}/ \
+            ${{ env.DEPLOY_USER }}@${{ matrix.server }}:${{ env.DEPLOY_PATH }}/
+          
+          echo "✅ Templates deployed successfully to ${{ matrix.server }}"
+
+      - name: Verify deployment
+        run: |
+          echo "Verifying deployment on ${{ matrix.server }}..."
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+            ${{ env.DEPLOY_USER }}@${{ matrix.server }} \
+            "ls -la ${{ env.DEPLOY_PATH }}/"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -f ~/.ssh/deploy_key
+
+  summary:
+    needs: deploy-templates
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Deployment Summary
+        run: |
+          echo "## 🚀 Deployment Summary"
+          echo ""
+          echo "| Item | Value |"
+          echo "|------|-------|"
+          echo "| **Commit** | ${{ github.sha }} |"
+          echo "| **Branch** | ${{ github.ref_name }} |"
+          echo "| **Triggered by** | ${{ github.actor }} |"
+          echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |"

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -20,6 +20,8 @@ jobs:
   deploy-templates:
     if: github.event.inputs.confirm == 'deploy'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         server: ${{ fromJson(vars.DEMO_NHP_SERVERS) }}
@@ -28,40 +30,99 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup SSH key
+      - name: Setup SSH key and known hosts
         run: |
           mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          
+          # Write SSH private key
           echo "${{ secrets.DEMO_NHP_SERVER_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ matrix.server }} >> ~/.ssh/known_hosts 2>/dev/null || true
+          
+          # Setup known_hosts with proper verification
+          # Option 1: Use pre-configured host keys from secret (recommended)
+          if [ -n "${{ secrets.DEMO_NHP_SERVER_HOST_KEYS }}" ]; then
+            echo "${{ secrets.DEMO_NHP_SERVER_HOST_KEYS }}" > ~/.ssh/known_hosts
+            chmod 644 ~/.ssh/known_hosts
+          else
+            # Option 2: Scan and verify host keys (fallback)
+            # This requires manual verification on first run
+            echo "⚠️  Warning: Host keys not pre-configured. Scanning host keys..."
+            ssh-keyscan -H ${{ matrix.server }} > ~/.ssh/known_hosts.tmp 2>&1
+            if [ $? -eq 0 ] && [ -s ~/.ssh/known_hosts.tmp ]; then
+              # Verify we got valid host keys
+              if grep -q "ssh-" ~/.ssh/known_hosts.tmp; then
+                mv ~/.ssh/known_hosts.tmp ~/.ssh/known_hosts
+                chmod 644 ~/.ssh/known_hosts
+                echo "✅ Host keys scanned successfully"
+              else
+                echo "❌ Failed to get valid host keys"
+                exit 1
+              fi
+            else
+              echo "❌ Failed to scan host keys"
+              exit 1
+            fi
+          fi
+
+      - name: Verify SSH connection
+        run: |
+          echo "Verifying SSH connection to ${{ matrix.server }}..."
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
+            -o ConnectTimeout=10 \
+            ${{ env.DEPLOY_USER }}@${{ matrix.server }} \
+            "echo 'SSH connection successful'"
+          if [ $? -ne 0 ]; then
+            echo "❌ SSH connection verification failed"
+            exit 1
+          fi
 
       - name: Deploy templates to ${{ matrix.server }}
         run: |
           echo "Deploying templates to ${{ matrix.server }}..."
           
-          # Sync templates directory
+          # Sync templates directory with proper SSH options
           rsync -avz --delete \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o BatchMode=yes" \
             ${{ env.TEMPLATES_SOURCE }}/ \
             ${{ env.DEPLOY_USER }}@${{ matrix.server }}:${{ env.DEPLOY_PATH }}/
           
-          echo "✅ Templates deployed successfully to ${{ matrix.server }}"
+          if [ $? -eq 0 ]; then
+            echo "✅ Templates deployed successfully to ${{ matrix.server }}"
+          else
+            echo "❌ Deployment failed"
+            exit 1
+          fi
 
       - name: Verify deployment
         run: |
           echo "Verifying deployment on ${{ matrix.server }}..."
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
             ${{ env.DEPLOY_USER }}@${{ matrix.server }} \
             "ls -la ${{ env.DEPLOY_PATH }}/"
+          
+          if [ $? -ne 0 ]; then
+            echo "❌ Deployment verification failed"
+            exit 1
+          fi
 
       - name: Cleanup
         if: always()
         run: |
-          rm -f ~/.ssh/deploy_key
+          rm -f ~/.ssh/deploy_key ~/.ssh/known_hosts ~/.ssh/known_hosts.tmp
+          rmdir ~/.ssh 2>/dev/null || true
 
   summary:
     needs: deploy-templates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: always()
     steps:
       - name: Deployment Summary

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -28,42 +28,54 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Validate server hostname
+        run: |
+          SERVER="${{ matrix.server }}"
+
+          # RFC 1123 hostname validation: alphanumeric, hyphens, dots
+          # Max 253 chars total, max 63 chars per label
+          if ! echo "$SERVER" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$'; then
+            echo "❌ SECURITY ERROR: Invalid hostname format: $SERVER"
+            echo "Hostnames must comply with RFC 1123"
+            exit 1
+          fi
+
+          # Block shell metacharacters
+          if echo "$SERVER" | grep -qE '[$`();&|<>{}\\]'; then
+            echo "❌ SECURITY ERROR: Hostname contains shell metacharacters: $SERVER"
+            exit 1
+          fi
+
+          # Length validation
+          if [ ${#SERVER} -gt 253 ]; then
+            echo "❌ SECURITY ERROR: Hostname exceeds 253 characters"
+            exit 1
+          fi
+
+          echo "✅ Hostname validation passed: $SERVER"
 
       - name: Setup SSH key and known hosts
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          
+
           # Write SSH private key
           echo "${{ secrets.DEMO_NHP_SERVER_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          
-          # Setup known_hosts with proper verification
-          # Option 1: Use pre-configured host keys from secret (recommended)
-          if [ -n "${{ secrets.DEMO_NHP_SERVER_HOST_KEYS }}" ]; then
-            echo "${{ secrets.DEMO_NHP_SERVER_HOST_KEYS }}" > ~/.ssh/known_hosts
-            chmod 644 ~/.ssh/known_hosts
-          else
-            # Option 2: Scan and verify host keys (fallback)
-            # This requires manual verification on first run
-            echo "⚠️  Warning: Host keys not pre-configured. Scanning host keys..."
-            ssh-keyscan -H ${{ matrix.server }} > ~/.ssh/known_hosts.tmp 2>&1
-            if [ $? -eq 0 ] && [ -s ~/.ssh/known_hosts.tmp ]; then
-              # Verify we got valid host keys
-              if grep -q "ssh-" ~/.ssh/known_hosts.tmp; then
-                mv ~/.ssh/known_hosts.tmp ~/.ssh/known_hosts
-                chmod 644 ~/.ssh/known_hosts
-                echo "✅ Host keys scanned successfully"
-              else
-                echo "❌ Failed to get valid host keys"
-                exit 1
-              fi
-            else
-              echo "❌ Failed to scan host keys"
-              exit 1
-            fi
+
+          # Setup known_hosts - MUST be pre-configured to prevent MITM attacks
+          if [ -z "${{ secrets.DEMO_NHP_SERVER_HOST_KEYS }}" ]; then
+            echo "❌ SECURITY ERROR: DEMO_NHP_SERVER_HOST_KEYS secret is not configured"
+            echo "Host keys must be pre-configured to prevent MITM attacks"
+            echo "Please configure the secret with known_hosts entries for all demo servers"
+            exit 1
           fi
+
+          echo "${{ secrets.DEMO_NHP_SERVER_HOST_KEYS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+          echo "✅ Host keys loaded from secret"
 
       - name: Verify SSH connection
         run: |


### PR DESCRIPTION
- Manual trigger only with confirmation input
- Deploy templates to demo NHP servers via SSH
- Support multiple servers from DEMO_NHP_SERVERS variable
- Use DEMO_NHP_SERVER_KEY secret for SSH authentication

## Summary

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD improvement

## Related Issues

Fixes #

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
