### PR TITLE
ci: add GPG signing for release-please commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,19 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
         with:
           release-type: go
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary

Fix merge blocking on release-please PRs by adding GPG commit signing.

## Problem

PR #1385 is blocked because release-please commits aren't GPG signed, but the repo requires signed commits.

## Solution

Use [crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg) to import a GPG key and configure git to sign commits before release-please runs.

## Setup Required

Add these secrets to the repo:

| Secret | Description |
|--------|-------------|
| `GPG_PRIVATE_KEY` | ASCII-armored GPG private key (`gpg --armor --export-secret-key EMAIL`) |
| `GPG_PASSPHRASE` | Passphrase for the key |

### Generate a bot GPG key (recommended)

```bash
# Generate key (use a bot email like bot@opennhp.org)
gpg --full-generate-key

# Export private key
gpg --armor --export-secret-key bot@opennhp.org | pbcopy

# Add as secret
gh secret set GPG_PRIVATE_KEY --repo OpenNHP/opennhp
gh secret set GPG_PASSPHRASE --repo OpenNHP/opennhp
```

## After Merge

Once this is merged and secrets are configured, close and reopen PR #1385 (or push a new commit) to trigger a new release-please run with signed commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)