### PR TITLE
docs: update NHP spec link and live demo URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 
 **OpenNHP** is a lightweight, cryptography-powered, open-source toolkit implementing Zero Trust security for infrastructure, applications, and data. It features two core protocols:
 
-- **Network-infrastructure Hiding Protocol (NHP):** Conceals server ports, IP addresses, and domain names to protect applications and infrastructure from unauthorized access.
+- **[Network-infrastructure Hiding Protocol (NHP)](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure):** Conceals server ports, IP addresses, and domain names to protect applications and infrastructure from unauthorized access.
 - **Data-object Hiding Protocol (DHP):** Ensures data security and privacy via encryption and confidential computing, making data *"usable but not visible."*
 
-**[Website](https://opennhp.org) · [Documentation](https://docs.opennhp.org) · [Live Demo](https://acdemo.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[Website](https://opennhp.org) · [Documentation](https://docs.opennhp.org) · [Live Demo](https://opennhp.org/demo.html) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 


### PR DESCRIPTION
## Summary

- Link NHP protocol name to the [CSA specification](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)
- Update live demo URL from `acdemo.opennhp.org` to `opennhp.org/demo.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)