### PR TITLE
fix: add startup grace period to prevent AC fail-open during container init

### DIFF
--- a/endpoints/ac/constants.go
+++ b/endpoints/ac/constants.go
@@ -12,6 +12,11 @@ const (
 	ServerKeepaliveInterval        = common.ServerKeepaliveInterval
 	ServerDiscoveryRetryBeforeFail = common.ServerDiscoveryRetryBeforeFail
 
+	// StartupGracePeriod is the time after AC startup during which it stays
+	// in deny-all mode even if all server discoveries fail. This prevents
+	// fail-open during container orchestration when the server hasn't started yet.
+	StartupGracePeriod = 60 // seconds
+
 	TokenStoreRefreshInterval = common.TokenStoreRefreshInterval
 	TempPortOpenTime          = 30
 

--- a/endpoints/ac/udpac.go
+++ b/endpoints/ac/udpac.go
@@ -515,6 +515,8 @@ func (a *UdpAC) maintainServerConnectionRoutine() {
 	var discoveryRoutineWg sync.WaitGroup
 	defer discoveryRoutineWg.Wait()
 
+	startupTime := time.Now()
+
 	for {
 		// make a local copy of servers then iterate because next operations are time consuming (too long to use locked iteration)
 		a.serverPeerMutex.Lock()
@@ -535,7 +537,7 @@ func (a *UdpAC) maintainServerConnectionRoutine() {
 		a.serverPeerMutex.Unlock()
 
 		// check whether all server discovery failed.
-		// If so, open all blocked input
+		// If so, open all blocked input (but not during startup grace period)
 		quitCheck := make(chan struct{})
 		discoveryQuitArr = append(discoveryQuitArr, quitCheck)
 		discoveryRoutineWg.Add(1)
@@ -559,8 +561,14 @@ func (a *UdpAC) maintainServerConnectionRoutine() {
 							a.iptables.ResetAllInput()
 						}
 					} else {
-						if a.config.FilterMode == FilterMode_IPTABLES {
-							a.iptables.AcceptAllInput()
+						// During startup grace period, stay in deny-all mode
+						// to avoid fail-open when server hasn't started yet
+						if time.Since(startupTime) < StartupGracePeriod*time.Second {
+							log.Info("all server discoveries failed, but within startup grace period (%ds) - staying in deny-all mode", StartupGracePeriod)
+						} else {
+							if a.config.FilterMode == FilterMode_IPTABLES {
+								a.iptables.AcceptAllInput()
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

- Add a 60-second startup grace period to the AC's server discovery routine
- During the grace period, the AC stays in deny-all mode even if all server discoveries fail
- Prevents `AcceptAllInput()` from being triggered when Docker containers start simultaneously and the server isn't ready yet
- After the grace period, normal fail-open behavior resumes for operational continuity

## Context

Follow-up to #1450. Even with proper iptables flushing, the AC goes fail-open during container startup because:
1. All containers start simultaneously in docker-compose
2. AC attempts server discovery before the server is ready
3. After 3 failed retries (~15s), `AcceptAllInput()` inserts unconditional ACCEPT rules
4. Protected services become reachable without NHP authorization

## Test plan

- [ ] Start docker-compose from clean state
- [ ] Verify AC stays in deny-all mode during initial 60s
- [ ] Verify AC connects to server once it's ready (within grace period)
- [ ] Verify fail-open still works after grace period if server is truly unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)