### PR TITLE
fix: align DefaultCipherScheme with cipher scheme in docker quick start config

### DIFF
--- a/docker/nhp-ac/etc/config.toml
+++ b/docker/nhp-ac/etc/config.toml
@@ -9,7 +9,7 @@
 # LogLevel: 0: silent, 1: error, 2: info, 3: audit, 4: debug, 5: trace.
 PrivateKeyBase64 = "hpo6FtdcPir87EV8BYeAINAG7nEDPU2LG/WTRS+bPF4="
 ACId = "testAC-1"
-DefaultCipherScheme = 0
+DefaultCipherScheme = 1
 UserId = "agent-0"
 OrganizationId = "opennhp.org"
 LogLevel = 4

--- a/docker/nhp-agent/etc/config.toml
+++ b/docker/nhp-agent/etc/config.toml
@@ -8,7 +8,7 @@
 # OrganizationId: specify the organization id this agent represents.
 # LogLevel: 0: silent, 1: error, 2: info, 3: audit, 4: debug, 5: trace.
 PrivateKeyBase64 = "O2Ytgu7YraFYqq0iS41vhBNhwb1nPVS9kmPzXxLVNo0="
-DefaultCipherScheme = 0
+DefaultCipherScheme = 1
 UserId = "agent-0"
 OrganizationId = "opennhp.org"
 LogLevel = 5

--- a/docker/nhp-server/etc/config.toml
+++ b/docker/nhp-server/etc/config.toml
@@ -10,7 +10,7 @@
 # LogLevel: 0: silent, 1: error, 2: info, 3: audit, 4: debug, 5: trace.
 # DisableAgentValidation: whether for the server to skip the agent's public key validation.
 PrivateKeyBase64 = "I9UzYO3skKYmDykz9DRBbV+cEebSw/L5yIvzHI4jz+o="
-DefaultCipherScheme = 0
+DefaultCipherScheme = 1
 ListenIp = "0.0.0.0"    # empty for ipv4 + ipv6, "0.0.0.0" for ipv4 only
 ListenPort = 62206
 Hostname = "localhost:62206" # the hostname of NHP-Server


### PR DESCRIPTION
## Summary

Brief description of changes.

## Type of Change

- [ ] Bug fix

## Related Issues

Fixes #

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
