### PR TITLE
docs: use LayerV wordmark variant that renders on light backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ git commit -S -m "your message"
 ## Sponsors
 
 <a href="https://layerv.ai">
-  <img src="https://layerv.ai/layerv-wordmark.svg" height="40" alt="LayerV.ai">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://layerv.ai/layerv-wordmark.svg">
+    <img src="https://layerv.ai/layerv-wordmark-dark.svg" height="40" alt="LayerV.ai">
+  </picture>
 </a>
 
 ---


### PR DESCRIPTION
Follow-up to #1487 — the `layerv-wordmark.svg` landed in that PR uses near-white fills (meant for dark backgrounds like opennhp.org's footer), so it rendered as near-invisible text on GitHub's default white README canvas.

### Fix

Use GitHub's theme-aware `<picture>` pattern:

```html
<a href="https://layerv.ai">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://layerv.ai/layerv-wordmark.svg">
    <img src="https://layerv.ai/layerv-wordmark-dark.svg" height="40" alt="LayerV.ai">
  </picture>
</a>
```

- GitHub **light mode** → `layerv-wordmark-dark.svg` (dark text, legible on white)
- GitHub **dark mode** → `layerv-wordmark.svg` (light text, legible on dark)

Confirmed that `-dark.svg` on layerv.ai is a distinct file from the base with dark fills (`#030712`, `#111827`, etc.) instead of the near-white fills of the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)