### PR TITLE
docs: self-host LayerV logo (remote SVG was 404 behind 200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,9 @@ git commit -S -m "your message"
 ## Sponsors
 
 <a href="https://layerv.ai">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://layerv.ai/layerv-wordmark.svg">
-    <img src="https://layerv.ai/layerv-wordmark-dark.svg" height="40" alt="LayerV.ai">
-  </picture>
+  <img src="docs/images/layerv_logo.png" height="40" alt="LayerV.ai logo">
+  &nbsp;
+  <img src="docs/images/layerv_text.svg" height="24" alt="LayerV.ai">
 </a>
 
 ---


### PR DESCRIPTION
Fixes the broken-image icon in the Sponsors section after #1488 merged.

### Root cause

`https://layerv.ai/layerv-wordmark-dark.svg` returns HTTP 200 but with `Content-Type: text/html` — layerv.ai is a Next.js-style SPA that serves its HTML shell for any path it doesn't recognise. GitHub's camo proxy sees "200 OK, text/html" and renders a broken image.

My earlier verification that the URL "existed" was misleading: I compared MD5 hashes of the responses and got different hashes across variants, but the responses were all just *different HTML pages* from the SPA, not actual SVGs.

### Fix

Point the sponsor block back at the locally-hosted pair that was in the repo all along:

```
docs/images/layerv_logo.png
docs/images/layerv_text.svg
```

These are the assets the README used before #1487 and they render correctly on GitHub's white canvas. No remote dependency, no camo surprises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)