### PR TITLE
docs(readme): refresh badges, add Why section and protocol flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 OpenNHP is a Go-based Zero Trust security toolkit implementing two core protocols:
 - **NHP (Network-infrastructure Hiding Protocol)**: Conceals server ports, IPs, and domains from unauthorized access
-- **DHP (Data-object Hiding Protocol)**: Ensures data security via encryption and confidential computing
+- **DHP (Data-content Hiding Protocol)**: Ensures data security via encryption and confidential computing
 
 The system follows NIST Zero Trust Architecture with three core components that communicate via encrypted UDP packets using the Noise Protocol Framework.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ The codebase uses two separate Go modules with a local replace directive:
   - `agent/`: NHP-Agent - client that sends knock requests
   - `server/`: NHP-Server - authenticates and authorizes requests
   - `ac/`: NHP-AC - access controller that manages firewall rules
-  - `db/`: NHP-DB - data object management for DHP
+  - `db/`: NHP-DB - Data Broker for DHP
   - `kgc/`: Key Generation Center for IBC (Identity-Based Cryptography)
   - `relay/`: TCP relay functionality
 
@@ -159,7 +159,7 @@ The codebase uses two separate Go modules with a local replace directive:
 - `NHP_AGENT`: Client initiating access requests
 - `NHP_SERVER`: Central authentication/authorization server
 - `NHP_AC`: Access controller managing network rules
-- `NHP_DB`: Data object backend for DHP
+- `NHP_DB`: Data Broker for DHP
 - `NHP_RELAY`: Packet relay
 
 **Packet Types** (defined in `nhp/core/packet.go`):

--- a/README.md
+++ b/README.md
@@ -9,18 +9,38 @@
 
 # OpenNHP: Open Source Zero Trust Security Toolkit
 
-![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
+[![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
+[![Release](https://img.shields.io/github/v/release/OpenNHP/opennhp)](https://github.com/OpenNHP/opennhp/releases)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green)
 [![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
 
-**OpenNHP** is a lightweight, cryptography-powered, open-source toolkit implementing Zero Trust security for infrastructure, applications, and data. It is the reference implementation of the [**Cloud Security Alliance (CSA) Network-infrastructure Hiding Protocol (NHP) specification**](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure), and features two core protocols:
+**OpenNHP** is a lightweight, cryptography-powered, open-source toolkit implementing Zero Trust security for infrastructure, applications, and data. It is the reference implementation of the [**Cloud Security Alliance (CSA)**](https://cloudsecurityalliance.org/) *Network-infrastructure Hiding Protocol (NHP) specification*, and features two core protocols:
 
-- **Network-infrastructure Hiding Protocol (NHP):** Conceals server ports, IP addresses, and domain names to protect applications and infrastructure from unauthorized access.
-- **Data-object Hiding Protocol (DHP):** Ensures data security and privacy via encryption and confidential computing, making data *"usable but not visible."*
+- [**Network-infrastructure Hiding Protocol (NHP):**](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure) Conceals server ports, IP addresses, and domain names to protect applications and infrastructure from unauthorized access.
+- **Data-content Hiding Protocol (DHP):** Ensures data security and privacy via encryption and confidential computing, making data *"usable but not visible."*
 
 **[Website](https://opennhp.org) · [Documentation](https://docs.opennhp.org) · [Live Demo](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+
+---
+
+## Why OpenNHP
+
+The modern internet is a dark forest. Attackers — increasingly backed by LLMs that scan, fingerprint, and exploit at machine speed — treat every reachable service as a target. Traditional defenses authenticate users *after* the network lets them in, leaving exposed ports, IPs, and domains as a permanent attack surface.
+
+OpenNHP inverts that model: **invisible until trusted.** Every port, IP, and hostname sits behind a default-deny gate. Access is granted only after a cryptographically signed knock is authenticated and authorized out-of-band. Attackers can't exploit what they can't discover.
+
+### The third-generation network hiding protocol
+
+NHP is the next step in a line of "hide the service first" designs:
+
+| Generation | Protocol | Limitations |
+|---|---|---|
+| 1 | Port Knocking | Plaintext, replay-prone |
+| 2 | Single Packet Authorization (SPA) | Shared secrets, one-way, ports only, typically C/C++ |
+| **3** | **NHP** | Modern crypto, bi-directional with status, hides domain + IP + ports, stateless and horizontally scalable, memory-safe Go |
+
+NHP slots in alongside existing IAM, DNS, FIDO, and Zero Trust policy engines rather than replacing them — it extends your stack instead of forking it.
 
 ---
 
@@ -33,8 +53,25 @@ OpenNHP follows a modular design with three core components, inspired by the [NI
 | Component | Role |
 |-----------|------|
 | **NHP-Agent** | Client that sends encrypted knock requests to gain access |
-| **NHP-Server** | Authenticates and authorizes requests; decoupled from protected resources |
+| **NHP-Server** | Authenticates and authorizes requests; runs separately from the protected host |
 | **NHP-AC** | Access controller that manages firewall rules on the protected server |
+
+### Protocol flow
+
+1. Agent sends an encrypted knock (`NHP_KNK`) to the Server.
+2. Server validates the knock and sends an operation request (`NHP_AOP`) to the AC.
+3. AC opens the firewall and replies (`NHP_ART`) to the Server.
+4. Server returns an acknowledgment (`NHP_ACK`) with access info to the Agent.
+5. Agent reaches the protected resource through the AC.
+
+### Cryptography
+
+OpenNHP ships with two interchangeable cipher suites:
+
+- **`CIPHER_SCHEME_CURVE`** — Curve25519 + AES-256-GCM + BLAKE2s
+- **`CIPHER_SCHEME_GMSM`** — SM2 + SM4-GCM + SM3
+
+Both are driven by the [Noise Protocol Framework](https://noiseprotocol.org/). An Identity-Based Cryptography (IBC) mode is available via the Key Generation Center (KGC).
 
 > For protocol details, deployment models, and cryptographic design, see the [documentation](https://docs.opennhp.org).
 
@@ -53,7 +90,7 @@ opennhp/
 │   └── etcd/         # Distributed configuration support
 └── endpoints/        # Daemon implementations (Go module, depends on nhp)
     ├── agent/        # NHP-Agent daemon
-    ├── server/        # NHP-Server daemon
+    ├── server/       # NHP-Server daemon
     ├── ac/           # NHP-AC (access controller) daemon
     ├── db/           # NHP-DB (data object backend for DHP)
     ├── kgc/          # Key Generation Center (IBC)
@@ -110,6 +147,10 @@ We welcome contributions! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before 
 ```bash
 git commit -S -m "your message"
 ```
+
+## Security
+
+Found a vulnerability? Please follow the responsible-disclosure process in [SECURITY.md](SECURITY.md) rather than opening a public issue.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ NHP is the next step in a line of "hide the service first" designs:
 | Generation | Protocol | Limitations |
 |---|---|---|
 | 1 | Port Knocking | Plaintext, replay-prone |
-| 2 | Single Packet Authorization (SPA) | Shared secrets, one-way, ports only, typically C/C++ |
+| 2 | Single Packet Authorization (SPA) | Shared secrets, one-way, typically hides ports only, typically C/C++ |
 | **3** | **NHP** | Modern crypto, bi-directional with status, hides domain + IP + ports, stateless and horizontally scalable, memory-safe Go |
 
 NHP slots in alongside existing IAM, DNS, FIDO, and Zero Trust policy engines rather than replacing them — it extends your stack instead of forking it.
@@ -53,7 +53,7 @@ OpenNHP follows a modular design with three core components, inspired by the [NI
 | Component | Role |
 |-----------|------|
 | **NHP-Agent** | Client that sends encrypted knock requests to gain access |
-| **NHP-Server** | Authenticates and authorizes requests; runs separately from the protected host |
+| **NHP-Server** | Authenticates and authorizes requests; runs separately and is architecturally decoupled from the protected host |
 | **NHP-AC** | Access controller that manages firewall rules on the protected server |
 
 ### Protocol flow
@@ -147,6 +147,8 @@ We welcome contributions! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before 
 ```bash
 git commit -S -m "your message"
 ```
+
+---
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 [![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
 
-**OpenNHP** is a lightweight, cryptography-powered, open-source toolkit implementing Zero Trust security for infrastructure, applications, and data. It is the reference implementation of the [**Cloud Security Alliance (CSA)**](https://cloudsecurityalliance.org/) *Network-infrastructure Hiding Protocol (NHP) specification*, and features two core protocols:
+**OpenNHP** is a lightweight, cryptography-powered, open-source toolkit implementing Zero Trust security for infrastructure, applications, and data. It is the reference implementation of the [**Cloud Security Alliance (CSA)**](https://cloudsecurityalliance.org/) *[Network-infrastructure Hiding Protocol (NHP) specification](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)*, and features two core protocols:
 
-- [**Network-infrastructure Hiding Protocol (NHP):**](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure) Conceals server ports, IP addresses, and domain names to protect applications and infrastructure from unauthorized access.
+- **Network-infrastructure Hiding Protocol (NHP):** Conceals server ports, IP addresses, and domain names to protect applications and infrastructure from unauthorized access.
 - **Data-content Hiding Protocol (DHP):** Ensures data security and privacy via encryption and confidential computing, making data *"usable but not visible."*
 
 **[Website](https://opennhp.org) · [Documentation](https://docs.opennhp.org) · [Live Demo](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
@@ -26,7 +26,7 @@
 
 ## Why OpenNHP
 
-The modern internet is a dark forest. Attackers — increasingly backed by LLMs that scan, fingerprint, and exploit at machine speed — treat every reachable service as a target. Traditional defenses authenticate users *after* the network lets them in, leaving exposed ports, IPs, and domains as a permanent attack surface.
+The modern internet is a [dark forest](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Attackers — increasingly backed by LLMs that scan, fingerprint, and exploit at machine speed via [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) — treat every reachable service as a target. [Gartner projects](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI-driven cyberattacks will rise rapidly. Traditional defenses authenticate users *after* the network lets them in, leaving exposed ports, IPs, and domains as a permanent attack surface.
 
 OpenNHP inverts that model: **invisible until trusted.** Every port, IP, and hostname sits behind a default-deny gate. Access is granted only after a cryptographically signed knock is authenticated and authorized out-of-band. Attackers can't exploit what they can't discover.
 
@@ -92,7 +92,7 @@ opennhp/
     ├── agent/        # NHP-Agent daemon
     ├── server/       # NHP-Server daemon
     ├── ac/           # NHP-AC (access controller) daemon
-    ├── db/           # NHP-DB (data object backend for DHP)
+    ├── db/           # NHP-DB (Data Broker for DHP)
     ├── kgc/          # Key Generation Center (IBC)
     └── relay/        # TCP relay
 ```

--- a/docker/nhp-agent/etc/dhp.toml
+++ b/docker/nhp-agent/etc/dhp.toml
@@ -1,4 +1,4 @@
-# Configuration that is related to data object hiding protocol in agent side.
+# Configuration that is related to data content hiding protocol in agent side.
 
 # TEEPrivateKeyBase64: base64 encoded private key of TEE (Trusted Execution Environment).
 TEEPrivateKeyBase64 = "j20JfF3rjoRtz2m+KP+agYjDBPdQwC9Dwfcasn83yAQ="

--- a/docs/code.md
+++ b/docs/code.md
@@ -60,7 +60,7 @@ The `endpoints` module contains executable daemons:
 | `agent/` | `nhp-agent` | Client that sends knock requests |
 | `server/` | `nhp-server` | Central server handling knock validation |
 | `ac/` | `nhp-ac` | Access Controller managing firewall rules |
-| `db/` | `nhp-db` | Data broker for DHP (Data Hiding Protocol) |
+| `db/` | `nhp-db` | Data Broker for DHP (Data-content Hiding Protocol) |
 | `kgc/` | `nhp-kgc` | Key Generation Center for IBC keys |
 
 Each daemon follows a similar structure:
@@ -82,7 +82,7 @@ OpenNHP supports two cipher schemes:
 
 | Scheme | Algorithms | Use Case |
 |--------|-----------|----------|
-| `CIPHER_SCHEME_CURVE` | Curve25519 + ChaCha20-Poly1305 + BLAKE2s | International |
+| `CIPHER_SCHEME_CURVE` | Curve25519 + AES-256-GCM + BLAKE2s | International |
 | `CIPHER_SCHEME_GMSM` | SM2 + SM4-GCM + SM3 | Chinese standards |
 
 See [Cryptography](/cryptography/) for detailed protocol documentation.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -24,7 +24,7 @@ alternate is listed but the canonical term is what the implementation uses.
 | **NHP-Agent** | agent, client, initiator | Client-side component embedded in a host, SDK, browser, or app. Sends the encrypted knock request and, once access is granted, connects to the Protected Resource. |
 | **NHP-Server** | server, controller (SDP) | Control-plane component that decrypts knocks, authenticates the NHP-Agent, checks policy via the ASP, and instructs the NHP-AC. Maps to the *Policy Engine/Administrator* in NIST SP 800-207. |
 | **NHP-AC** | Access Controller, gateway (SDP) | Data-plane component that enforces default-deny and dynamically opens the firewall on the NHP-Server's instruction. Maps to the *Policy Enforcement Point* in NIST SP 800-207. |
-| **NHP-DB** | — | Data-object backend for the Data-content Hiding Protocol (DHP). Stores encrypted zero-trust data objects. |
+| **NHP-DB** | — | Data Broker for the Data-content Hiding Protocol (DHP). Stores encrypted zero-trust data objects. |
 | **NHP-KGC** | KGC | Key Generation Center used by Identity-Based Cryptography (IBC) to issue agent/server keys. |
 | **NHP-Relay** | relay | Optional forwarder for NHP packets across network segments; preserves source addresses via the NHP-RLY message type. |
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -24,7 +24,7 @@ alternate is listed but the canonical term is what the implementation uses.
 | **NHP-Agent** | agent, client, initiator | Client-side component embedded in a host, SDK, browser, or app. Sends the encrypted knock request and, once access is granted, connects to the Protected Resource. |
 | **NHP-Server** | server, controller (SDP) | Control-plane component that decrypts knocks, authenticates the NHP-Agent, checks policy via the ASP, and instructs the NHP-AC. Maps to the *Policy Engine/Administrator* in NIST SP 800-207. |
 | **NHP-AC** | Access Controller, gateway (SDP) | Data-plane component that enforces default-deny and dynamically opens the firewall on the NHP-Server's instruction. Maps to the *Policy Enforcement Point* in NIST SP 800-207. |
-| **NHP-DB** | — | Data-object backend for the Data-object Hiding Protocol (DHP). Stores encrypted zero-trust data objects. |
+| **NHP-DB** | — | Data-object backend for the Data-content Hiding Protocol (DHP). Stores encrypted zero-trust data objects. |
 | **NHP-KGC** | KGC | Key Generation Center used by Identity-Based Cryptography (IBC) to issue agent/server keys. |
 | **NHP-Relay** | relay | Optional forwarder for NHP packets across network segments; preserves source addresses via the NHP-RLY message type. |
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,7 +28,7 @@ Spec: https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trus
 
 - [Overview](https://docs.opennhp.org/): Project introduction, architecture, workflow.
 - [NHP Quick Start](https://docs.opennhp.org/nhp_quick_start/): End-to-end Docker walkthrough of the knock/auth/open flow.
-- [DHP Quick Start](https://docs.opennhp.org/dhp_quick_start/): Data-object hiding protocol setup.
+- [DHP Quick Start](https://docs.opennhp.org/dhp_quick_start/): Data-content hiding protocol setup.
 - [Features](https://docs.opennhp.org/features/): Supported features and configuration flags.
 - [Cryptography](https://docs.opennhp.org/cryptography/): ECC, Noise Protocol Framework, IBC/CL-PKC.
 - [Comparison](https://docs.opennhp.org/comparison/): NHP vs SPA (CSA SDP's legacy packet-authorization mechanism).
@@ -55,7 +55,7 @@ When generating code or documentation, prefer these exact terms:
 - **NHP-Agent** — the client-side component that initiates knock requests. Not "agent", "client", "initiator".
 - **NHP-Server** — the control-plane component that authenticates knocks and decides access. Not "controller" (which is SDP terminology).
 - **NHP-AC** — the Access Controller (data-plane component that enforces firewall rules). Not "gateway" (that is the SDP role term).
-- **NHP-DB** — the Data-object backend for the Data-object Hiding Protocol (DHP).
+- **NHP-DB** — the Data-object backend for the Data-content Hiding Protocol (DHP).
 - **NHP-KGC** — the Key Generation Center used by Identity-Based Cryptography.
 - **NHP-Relay** — the relay component for NHP packet forwarding.
 - **Knock** — the initial encrypted UDP (or TCP) packet sent by an NHP-Agent to request access.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -55,7 +55,7 @@ When generating code or documentation, prefer these exact terms:
 - **NHP-Agent** — the client-side component that initiates knock requests. Not "agent", "client", "initiator".
 - **NHP-Server** — the control-plane component that authenticates knocks and decides access. Not "controller" (which is SDP terminology).
 - **NHP-AC** — the Access Controller (data-plane component that enforces firewall rules). Not "gateway" (that is the SDP role term).
-- **NHP-DB** — the Data-object backend for the Data-content Hiding Protocol (DHP).
+- **NHP-DB** — the Data Broker for the Data-content Hiding Protocol (DHP).
 - **NHP-KGC** — the Key Generation Center used by Identity-Based Cryptography.
 - **NHP-Relay** — the relay component for NHP packet forwarding.
 - **Knock** — the initial encrypted UDP (or TCP) packet sent by an NHP-Agent to request access.

--- a/docs/protocol/messages.md
+++ b/docs/protocol/messages.md
@@ -15,7 +15,7 @@ routes the packet to a logical handler on the receiver. Twenty-eight IDs
 are defined today: seventeen **NHP** types (IDs 0–16) covering the
 knock/auth/access flow, AC lifecycle, relay, registration, OTP, and
 explicit session exit; plus eleven **DHP** types (IDs 17–27) used by the
-Data-object Hiding Protocol.
+Data-content Hiding Protocol.
 {: .fs-6 .fw-300 }
 
 *Implements CSA Stealth Mode SDP §NHP Message Types (Table 4) and Appendix 2. IDs and string names defined in [`nhp/core/packet.go`](https://github.com/OpenNHP/opennhp/blob/main/nhp/core/packet.go); payload structs in [`nhp/common/nhpmsg.go`](https://github.com/OpenNHP/opennhp/blob/main/nhp/common/nhpmsg.go).*
@@ -48,7 +48,7 @@ NHP — Network-infrastructure Hiding Protocol
 | 15 | [NHP-ACC](#nhp-acc--access) | Agent → AC | Agent presents its temporary access token to the AC's listener. |
 | 16 | [NHP-EXT](#nhp-ext--exit) | Agent → Server | Request early closure of an active session. Empty body. |
 
-DHP — Data-object Hiding Protocol *(documented here for completeness; detailed DHP semantics live with the DHP docs)*
+DHP — Data-content Hiding Protocol *(documented here for completeness; detailed DHP semantics live with the DHP docs)*
 
 {: .note }
 DHP entries are shown under their Go constant names (e.g., `NHP_DRG`) rather
@@ -212,7 +212,7 @@ Agent explicitly requests early teardown of an active session. The Server then s
 
 ## DHP message types {#dhp}
 
-The Data-object Hiding Protocol reuses the NHP wire format for a separate
+The Data-content Hiding Protocol reuses the NHP wire format for a separate
 set of flows around data-object registration, access, attestation, and key
 wrapping. They are listed here so the ID table is complete; their payload
 fields (`DRGMsg`, `DAKMsg`, `DARMsg`, `DAGMsg`, `DSAMsg`, `DAVMsg`, `DWRMsg`,

--- a/endpoints/agent/main/etc/dhp.toml
+++ b/endpoints/agent/main/etc/dhp.toml
@@ -1,4 +1,4 @@
-# Configuration that is related to data object hiding protocol in agent side.
+# Configuration that is related to data content hiding protocol in agent side.
 
 # TEEPrivateKeyBase64: base64 encoded private key of TEE (Trusted Execution Environment).
 TEEPrivateKeyBase64 = "j20JfF3rjoRtz2m+KP+agYjDBPdQwC9Dwfcasn83yAQ="


### PR DESCRIPTION
## Summary

- Replace the static build/version badges with live GitHub Actions and GitHub Releases badges.
- Add a **Why OpenNHP** section that frames the "dark forest / AI-era" threat model and the third-generation evolution from Port Knocking → SPA → NHP, aligned with the messaging on opennhp.org.
- Inline the 5-step protocol flow and document the two cipher suites (`CIPHER_SCHEME_CURVE` and `CIPHER_SCHEME_GMSM`) plus IBC/KGC support.
- Fix the repository-structure tree alignment and add a pointer to [SECURITY.md](SECURITY.md) for responsible disclosure.

## Test plan

- [ ] Render README.md on GitHub and verify the live Build and Release badges resolve.
- [ ] Verify all markdown links (CONTRIBUTING.md, SECURITY.md, LICENSE, docs.opennhp.org) work.
- [ ] Confirm the generation comparison and component tables render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)