### PR TITLE
ci: count coverage from external test packages via -coverpkg

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -46,8 +46,12 @@ jobs:
 
     - name: Run tests with coverage
       run: |
-        cd nhp && go test -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v 'wasm/policy')
-        cd ../endpoints && go test -coverprofile=coverage.out -covermode=atomic ./...
+        cd nhp
+        PKGS=$(go list ./... | grep -v 'wasm/policy')
+        COVERPKG=$(echo "$PKGS" | paste -sd,)
+        go test -coverpkg="$COVERPKG" -coverprofile=coverage.out -covermode=atomic $PKGS
+        cd ../endpoints
+        go test -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v6


### PR DESCRIPTION
## Summary

Fixes Codecov reporting ~1% coverage despite the repo having 21 test files.

**Root cause.** Most unit tests live in external packages (`nhp/test`, `endpoints/test`) that import the production code via `package test` rather than sitting inline with the production packages. Without `-coverpkg`, `go test` only records coverage for the package *being tested* — so the `./test/` packages report near-0% and the `core/`, `common/`, `agent/`, `server/`, and `ac/` code they actually exercise is invisible to the coverage tool.

**Fix.** Add `-coverpkg` to instrument every package in the module. The existing `wasm/policy` exclusion is preserved (its tests are not run in this workflow — it targets `js/wasm`).

**Expected effect.** A one-time jump in reported coverage on the next run to reflect actual coverage. This only changes measurement; no test code is touched. The `threshold: 1%` in [codecov.yml](../blob/main/codecov.yml) may flag the first delta as a large positive change — that is cosmetic and the new baseline will be the accurate one.

## Test plan

- [ ] CI runs successfully on this PR.
- [ ] Codecov report on this PR shows a substantially higher coverage number than `main`.
- [ ] No new test failures introduced by instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)