### PR TITLE
docs(readme): point Release badge at latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 # OpenNHP: Open Source Zero Trust Security Toolkit
 
 [![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
-[![Release](https://img.shields.io/github/v/release/OpenNHP/opennhp)](https://github.com/OpenNHP/opennhp/releases)
+[![Release](https://img.shields.io/github/v/tag/OpenNHP/opennhp?label=release)](https://github.com/OpenNHP/opennhp/tags)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green)
 [![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)


### PR DESCRIPTION
## Summary

The Release badge added in #1497 rendered as **"no releases or repo not found"** because `img.shields.io/github/v/release/...` reads GitHub Releases, which the repo does not currently publish — it ships tags only (`v0.3.6` … `v0.6.0`). Switching to `github/v/tag/...` so the badge shows the most recent tag and links to the tags page.

If GitHub Releases start being published later (e.g., via the existing [release-please workflow](.github/workflows/release-please.yml)), this can be switched back.

## Test plan

- [x] Render README.md on GitHub and verify the Release badge resolves to the latest tag (`v0.6.0` at time of writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)