### PR TITLE
docs: translate READMEs for zh-cn/de/ja/fr/es and add zh-tw

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,216 +1,176 @@
 [![en](https://img.shields.io/badge/lang-en-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.md)
 [![zh-cn](https://img.shields.io/badge/lang-zh--cn-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-cn.md)
+[![zh-tw](https://img.shields.io/badge/lang-zh--tw-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-tw.md)
 [![de](https://img.shields.io/badge/lang-de-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.de.md)
 [![ja](https://img.shields.io/badge/lang-ja-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.ja.md)
 [![fr](https://img.shields.io/badge/lang-fr-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.fr.md)
 [![es](https://img.shields.io/badge/lang-es-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.es.md)
 
 ![OpenNHP Logo](docs/images/logo11.png)
-# OpenNHP: Zero Trust Netzwerk-Infrastruktur-Verbergungsprotokoll
-Ein leichtgewichtiges, kryptographisch getriebenes Zero Trust Netzwerkprotokoll auf der OSI-Schicht 5, um Ihren Server und Ihre Daten vor Angreifern zu verbergen.
 
-![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
-![Lizenz](https://img.shields.io/badge/license-Apache%202.0-green)
+# OpenNHP: Open-Source-Werkzeugkasten für Zero-Trust-Sicherheit
 
----
+[![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
+[![Release](https://img.shields.io/github/v/tag/OpenNHP/opennhp?label=release)](https://github.com/OpenNHP/opennhp/tags)
+![License](https://img.shields.io/badge/license-Apache%202.0-green)
+[![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
 
-## Herausforderung: KI verwandelt das Internet in einen "Dunklen Wald"
+**OpenNHP** ist ein schlankes, kryptographiegetriebenes, quelloffenes Toolkit, das Zero-Trust-Sicherheit für Infrastruktur, Anwendungen und Daten umsetzt. Es ist die Referenzimplementierung der [**Cloud Security Alliance (CSA)**](https://cloudsecurityalliance.org/) *[Network-infrastructure Hiding Protocol (NHP) Spezifikation](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)* und umfasst zwei Kernprotokolle:
 
-Der schnelle Fortschritt der **KI**-Technologien, insbesondere großer Sprachmodelle (LLMs), verändert die Cybersicherheitslandschaft erheblich. Das Aufkommen der **autonomen Ausnutzung von Schwachstellen (AVE)** stellt einen großen Fortschritt im KI-Zeitalter dar, indem es die Ausnutzung von Schwachstellen automatisiert, wie in [diesem Forschungspapier](https://arxiv.org/abs/2404.08144) gezeigt wird. Diese Entwicklung erhöht das Risiko für alle exponierten Netzwerkdienste erheblich und erinnert an die [Dunkle Wald-Hypothese](https://de.wikipedia.org/wiki/Dunkler_Wald) des Internets. KI-gesteuerte Tools scannen kontinuierlich die digitale Umgebung, identifizieren schnell Schwachstellen und nutzen sie aus. Folglich entwickelt sich das Internet zu einem **"dunklen Wald"**, in dem **Sichtbarkeit Verwundbarkeit bedeutet**.
+- **Network-infrastructure Hiding Protocol (NHP):** Verbirgt Server-Ports, IP-Adressen und Domainnamen, um Anwendungen und Infrastruktur vor unbefugtem Zugriff zu schützen.
+- **Data-content Hiding Protocol (DHP):** Sorgt für Datensicherheit und -vertraulichkeit durch Verschlüsselung und Confidential Computing, sodass Daten *„nutzbar, aber nicht sichtbar"* werden.
 
-![Verwundbarkeitsrisiken](docs/images/Vul_Risks.png)
-
-Gartner prognostiziert einen [schnellen Anstieg von KI-gesteuerten Cyberangriffen](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025). Dieser Wandel erfordert eine Neubewertung traditioneller Cybersicherheitsstrategien mit einem Fokus auf proaktive Verteidigungsmaßnahmen, schnelle Reaktionsmechanismen und die Einführung von Netzwerkverbergungstechnologien zum Schutz kritischer Infrastrukturen.
-
----
-
-## Schnelle Demo: OpenNHP in Aktion sehen
-
-Bevor wir in die Details von OpenNHP eintauchen, beginnen wir mit einer kurzen Demonstration, wie OpenNHP einen Server vor unbefugtem Zugriff schützt. Sie können dies in Aktion sehen, indem Sie den geschützten Server unter https://acdemo.opennhp.org aufrufen.
-
-### 1) Der geschützte Server ist für nicht authentifizierte Benutzer "unsichtbar"
-
-Standardmäßig führt jeder Versuch, eine Verbindung zum geschützten Server herzustellen, zu einem TIME OUT-Fehler, da alle Ports geschlossen sind, wodurch der Server *"unsichtbar"* und scheinbar offline wird.
-
-![OpenNHP Demo](docs/images/OpenNHP_ACDemo0.png)
-
-Das Scannen der Ports des Servers führt ebenfalls zu einem TIME OUT-Fehler.
-
-![OpenNHP Demo](docs/images/OpenNHP_ScanDemo.png)
-
-### 2) Nach der Authentifizierung wird der geschützte Server zugänglich
-
-OpenNHP unterstützt eine Vielzahl von Authentifizierungsmethoden, wie OAuth, SAML, QR-Codes und mehr. Für diese Demonstration verwenden wir einen einfachen Benutzernamen/Passwort-Authentifizierungsdienst unter https://demologin.opennhp.org.
-
-![OpenNHP Demo](docs/images/OpenNHP_DemoLogin.png)
-
-Sobald Sie auf die Schaltfläche "Login" klicken, ist die Authentifizierung erfolgreich und Sie werden zum geschützten Server weitergeleitet. Zu diesem Zeitpunkt wird der Server *"sichtbar"* und auf Ihrem Gerät zugänglich.
-
-![OpenNHP Demo](docs/images/OpenNHP_ACDemo1.png)
+**[Website](https://opennhp.org) · [Dokumentation](https://docs.opennhp.org) · [Live-Demo](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 
-## Vision: Das Internet vertrauenswürdig machen
+## Warum OpenNHP
 
-Die Offenheit der TCP/IP-Protokolle hat das explosive Wachstum von Internetanwendungen vorangetrieben, aber auch Schwachstellen offengelegt, die es böswilligen Akteuren ermöglichen, unbefugten Zugriff zu erhalten und jede exponierte IP-Adresse auszunutzen. Obwohl das [OSI-Netzwerkmodell](https://de.wikipedia.org/wiki/OSI-Modell) die *5. Schicht (Sitzungsschicht)* zur Verwaltung von Verbindungen definiert, wurden bisher nur wenige effektive Lösungen hierfür implementiert.
+Das moderne Internet ist ein [dunkler Wald](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Angreifer – zunehmend unterstützt durch LLMs, die mittels [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) in Maschinengeschwindigkeit scannen, Fingerprinting betreiben und ausnutzen – behandeln jeden erreichbaren Dienst als Ziel. [Gartner prognostiziert](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025), dass KI-gestützte Cyberangriffe rasant zunehmen werden. Herkömmliche Verteidigungsmaßnahmen authentifizieren Nutzer erst *nachdem* das Netzwerk sie hereingelassen hat, sodass offene Ports, IPs und Domains zur dauerhaften Angriffsfläche werden.
 
-**NHP**, oder das **"Netzwerk-Infrastruktur-Verbergungsprotokoll"**, ist ein leichtgewichtiges, kryptographisch getriebenes Zero Trust Netzwerkprotokoll, das auf der *OSI-Sitzungsschicht* arbeitet und sich ideal zur Verwaltung der Netzwerkvisibilität und Verbindungen eignet. Das Hauptziel von NHP ist es, geschützte Ressourcen vor unbefugten Entitäten zu verbergen und den Zugriff nur verifizierten, autorisierten Benutzern durch kontinuierliche Überprüfung zu gewähren, um so zu einem vertrauenswürdigeren Internet beizutragen.
+OpenNHP dreht dieses Modell um: **unsichtbar bis vertrauenswürdig.** Jeder Port, jede IP und jeder Hostname liegt hinter einem Default-Deny-Gate. Zugriff wird erst nach einem kryptographisch signierten Knock gewährt, der außerhalb des Datenkanals authentifiziert und autorisiert wurde. Angreifer können nicht ausnutzen, was sie nicht entdecken können.
 
-![Vertrauenswürdiges Internet](docs/images/TrustworthyCyberspace.png)
+### Das Netzwerkverstecker-Protokoll der dritten Generation
+
+NHP ist der nächste Schritt in einer Linie von „Dienst zuerst verstecken"-Entwürfen:
+
+| Generation | Protokoll | Einschränkungen |
+|---|---|---|
+| 1 | Port Knocking | Klartext, anfällig für Replay-Angriffe |
+| 2 | Single Packet Authorization (SPA) | Geteilte Geheimnisse, Einwegkommunikation, verbirgt typischerweise nur Ports, meist in C/C++ |
+| **3** | **NHP** | Moderne Kryptographie, bidirektional mit Statusrückmeldung, verbirgt Domain + IP + Ports, zustandslos und horizontal skalierbar, speichersicheres Go |
+
+NHP fügt sich neben bestehenden IAM-, DNS-, FIDO- und Zero-Trust-Policy-Engines ein, statt sie zu ersetzen – es erweitert Ihren Stack, statt ihn zu forken.
 
 ---
-
-## Lösung: OpenNHP stellt die Kontrolle über die Netzwerkvisibilität wieder her
-
-**OpenNHP** ist die Open-Source-Implementierung des NHP-Protokolls. Es basiert auf der Kryptographie und wurde mit Sicherheitsprinzipien im Vordergrund entwickelt, um eine echte Zero Trust-Architektur auf der *OSI-Sitzungsschicht* zu implementieren.
-
-![OpenNHP als OSI 5. Schicht](docs/images/OSI_OpenNHP.png)
-
-OpenNHP baut auf früheren Forschungen zur Netzwerkverbergungstechnologie auf und nutzt moderne kryptographische Rahmenwerke und Architektur, um Sicherheit und hohe Leistung zu gewährleisten und die Einschränkungen früherer Technologien zu überwinden.
-
-| Netzwerk-Infrastruktur-Verbergungsprotokoll | 1. Generation | 2. Generation | 3. Generation |
-|:---|:---|:---|:---|
-| **Kerntechnologie** | [Port Knocking](https://de.wikipedia.org/wiki/Port_knocking) | [Single Packet Authorization (SPA)](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) | Netzwerk-Infrastruktur-Verbergungsprotokoll (NHP) |
-| **Authentifizierung** | Port-Sequenzen | Geteilte Geheimnisse | Modernes Kryptographie-Rahmenwerk |
-| **Architektur** | Kein Kontrollplan | Kein Kontrollplan | Skalierbarer Kontrollplan |
-| **Fähigkeit** | Ports verbergen | Ports verbergen | Ports, IPs und Domains verbergen |
-| **Zugriffskontrolle** | IP-Ebene | Port-Ebene | Anwendungsebene |
-| **Open-Source-Projekte** | [knock](https://github.com/jvinet/knock) *(C)* | [fwknop](https://github.com/mrash/fwknop) *(C++)* | [OpenNHP](https://github.com/OpenNHP/opennhp) *(Go)* |
-
-> Es ist entscheidend, eine **speichersichere** Sprache wie *Go* für die Entwicklung von OpenNHP zu wählen, wie im [technischen Bericht der US-Regierung](https://www.whitehouse.gov/wp-content/uploads/2024/02/Final-ONCD-Technical-Report.pdf) betont wird. Für einen detaillierten Vergleich zwischen **SPA und NHP** lesen Sie bitte die [Abschnitt unten](#comparison-between-spa-and-nhp).
-
-## Sicherheitsvorteile
-
-Da OpenNHP Zero Trust-Prinzipien auf der *OSI-Sitzungsschicht* implementiert, bietet es erhebliche Vorteile:
-
-- Reduziert die Angriffsfläche durch Verbergen der Infrastruktur
-- Verhindert unbefugte Netzwerkaufklärung
-- Mildert die Ausnutzung von Schwachstellen
-- Verhindert Phishing durch verschlüsseltes DNS
-- Schützt vor DDoS-Angriffen
-- Ermöglicht granulare Zugriffskontrolle
-- Bietet verbindungsbasierte Identitätsverfolgung
-- Angriffszurechnung
 
 ## Architektur
 
-Die Architektur von OpenNHP orientiert sich an der [NIST Zero Trust-Architektur](https://www.nist.gov/publications/zero-trust-architecture). Sie folgt einem modularen Design mit drei Hauptkomponenten: **NHP-Server**, **NHP-AC** und **NHP-Agent**, wie in der folgenden Abbildung dargestellt.
+OpenNHP folgt einem modularen Design mit drei Kernkomponenten, inspiriert von der [NIST Zero Trust Architecture](https://www.nist.gov/publications/zero-trust-architecture):
 
-![OpenNHP Architektur](docs/images/OpenNHP_Arch.gif)
+![OpenNHP architecture](docs/images/OpenNHP_Arch.gif)
 
-> Weitere Informationen zur Architektur und zum Workflow finden Sie in der [OpenNHP-Dokumentation](https://docs.opennhp.org/).
+| Komponente | Rolle |
+|-----------|------|
+| **NHP-Agent** | Client, der verschlüsselte Knock-Anfragen sendet, um Zugriff zu erhalten |
+| **NHP-Server** | Authentifiziert und autorisiert Anfragen; läuft separat und ist architektonisch vom geschützten Host entkoppelt |
+| **NHP-AC** | Zugriffs-Controller, der die Firewall-Regeln auf dem geschützten Server verwaltet |
 
-## Kern: Kryptographische Algorithmen
+### Protokollablauf
 
-Kryptographie steht im Mittelpunkt von OpenNHP und bietet robuste Sicherheit, hervorragende Leistung und Skalierbarkeit durch den Einsatz modernster kryptographischer Algorithmen. Nachfolgend sind die wichtigsten kryptographischen Algorithmen und Frameworks aufgeführt, die von OpenNHP verwendet werden:
+1. Agent sendet einen verschlüsselten Knock (`NHP_KNK`) an den Server.
+2. Server validiert den Knock und schickt eine Operations-Anfrage (`NHP_AOP`) an den AC.
+3. AC öffnet die Firewall und antwortet (`NHP_ART`) dem Server.
+4. Server schickt eine Bestätigung (`NHP_ACK`) mit Zugriffsinformationen an den Agent.
+5. Agent erreicht die geschützte Ressource über den AC.
 
-- **[Elliptische Kurvenkryptographie (ECC)](https://de.wikipedia.org/wiki/Elliptische-Kurven-Kryptographie)**: Wird für effiziente asymmetrische Kryptographie verwendet.
+### Kryptographie
 
-> Im Vergleich zu RSA bietet ECC eine höhere Effizienz mit stärkerer Verschlüsselung bei kürzeren Schlüssellängen, was sowohl die Netzwerkübertragung als auch die Rechenleistung verbessert. Die folgende Tabelle zeigt die Unterschiede in der Sicherheitsstärke, den Schlüssellängen und dem Verhältnis zwischen RSA und ECC sowie die jeweiligen Gültigkeitszeiträume.
+OpenNHP liefert zwei austauschbare Cipher-Suiten mit:
 
-| Sicherheitsstärke (Bits) | DSA/RSA-Schlüssellänge (Bits) | ECC-Schlüssellänge (Bits) | Verhältnis: ECC zu DSA/RSA | Gültigkeit |
-|:------------------------:|:-----------------------------:|:------------------------:|:--------------------------:|:---------:|
-| 80                       | 1024                          | 160-223                  | 1:6                        | Bis 2010  |
-| 112                      | 2048                          | 224-255                  | 1:9                        | Bis 2030  |
-| 128                      | 3072                          | 256-383                  | 1:12                       | Nach 2031 |
-| 192                      | 7680                          | 384-511                  | 1:20                       |           |
-| 256                      | 15360                         | 512+                     | 1:30                       |           |
+- **`CIPHER_SCHEME_CURVE`** – Curve25519 + AES-256-GCM + BLAKE2s
+- **`CIPHER_SCHEME_GMSM`** – SM2 + SM4-GCM + SM3
 
-- **[Noise Protocol Framework](https://noiseprotocol.org/)**: Ermöglicht sicheren Schlüsselaustausch, Nachrichtenverschlüsselung/-entschlüsselung und gegenseitige Authentifizierung.
+Beide bauen auf dem [Noise Protocol Framework](https://noiseprotocol.org/) auf. Ein Identity-Based Cryptography (IBC)-Modus ist über das Key Generation Center (KGC) verfügbar.
 
-> Das Noise-Protokoll basiert auf dem [Diffie-Hellman-Schlüsselaustausch](https://de.wikipedia.org/wiki/Diffie-Hellman-Schl%C3%BCsselaustausch) und bietet moderne kryptographische Lösungen wie gegenseitige und optionale Authentifizierung, Identitätsverbergung, Vorwärtsgeheimnis und null Round-Trip-Verschlüsselung. Es hat sich bereits durch seine Sicherheit und Leistung bewährt und wird von beliebten Anwendungen wie [WhatsApp](https://www.whatsapp.com/security/WhatsApp-Security-Whitepaper.pdf), [Slack](https://github.com/slackhq/nebula) und [WireGuard](https://www.wireguard.com/) verwendet.
-
-- **[Identitätsbasierte Kryptographie (IBC)](https://de.wikipedia.org/wiki/Identit%C3%A4tsbasierte_Kryptographie)**: Vereinfacht die Schlüsselverteilung im großen Maßstab.
-
-> Eine effiziente Schlüsselverteilung ist entscheidend für die Umsetzung von Zero Trust. OpenNHP unterstützt sowohl PKI als auch IBC. Während PKI seit Jahrzehnten weit verbreitet ist, hängt es von zentralisierten Zertifizierungsstellen (CA) zur Identitätsprüfung und Schlüsselverwaltung ab, was zeitaufwändig und kostspielig sein kann. Im Gegensatz dazu ermöglicht IBC einen dezentralisierten und selbstverwalteten Ansatz für die Identitätsprüfung und Schlüsselverwaltung, was es kostengünstiger für die Zero Trust-Umgebung von OpenNHP macht, in der Milliarden von Geräten oder Servern in Echtzeit geschützt und eingebunden werden müssen.
-
-- **[Zertifikatslose Kryptographie (CL-PKC)](https://de.wikipedia.org/wiki/Zertifikatslose_Kryptographie)**: Empfohlener IBC-Algorithmus
-
-> CL-PKC ist ein Schema, das die Sicherheit verbessert, indem es die Schlüsselverwaltung vermeidet und die Einschränkungen der identitätsbasierten Kryptographie (IBC) angeht. In den meisten IBC-Systemen wird der private Schlüssel eines Benutzers von einer Schlüsselgenerierungsstelle (KGC) erstellt, was erhebliche Risiken birgt. Ein kompromittierter KGC kann zur Offenlegung der privaten Schlüssel aller Benutzer führen, wodurch volles Vertrauen in den KGC erforderlich ist. CL-PKC mindert dieses Problem, indem der Schlüsselerstellungsprozess aufgeteilt wird, sodass der KGC nur einen Teil des privaten Schlüssels kennt. Dadurch kombiniert CL-PKC die Stärken von PKI und IBC und bietet eine stärkere Sicherheit ohne die Nachteile der zentralisierten Schlüsselverwaltung.
-
-Weiterführende Informationen:
-
-> Weitere Details zu den in OpenNHP verwendeten kryptographischen Algorithmen finden Sie in der [OpenNHP-Dokumentation](https://docs.opennhp.org/cryptography/).
-
-## Hauptfunktionen
-
-- Mildert die Ausnutzung von Schwachstellen, indem standardmäßig "deny-all"-Regeln angewendet werden
-- Verhindert Phishing-Angriffe durch verschlüsselte DNS-Auflösung
-- Schützt vor DDoS-Angriffen, indem die Infrastruktur verborgen wird
-- Ermöglicht Angriffszurechnung durch identitätsbasierte Verbindungen
-- Standardmäßig verweigerter Zugriff auf alle geschützten Ressourcen
-- Authentifizierung basierend auf Identität und Geräten vor dem Netzwerkzugang
-- Verschlüsselte DNS-Auflösung, um DNS-Hijacking zu verhindern
-- Verteilte Infrastruktur zur Minderung von DDoS-Angriffen
-- Skalierbare Architektur mit entkoppelten Komponenten
-- Integration mit bestehenden Systemen zur Verwaltung von Identitäten und Zugriffen
-- Unterstützung für verschiedene Bereitstellungsmodelle (Client-zu-Gateway, Client-zu-Server usw.)
-- Kryptographisch sicher unter Verwendung moderner Algorithmen (ECC, Noise Protocol, IBC)
-
-<details>
-<summary>Klicken Sie hier, um die Funktionsdetails zu erweitern</summary>
-
-- **Standardmäßig verweigerter Zugriff**: Alle Ressourcen sind standardmäßig verborgen und werden nur nach Authentifizierung und Autorisierung zugänglich.
-- **Authentifizierung basierend auf Identität und Geräten**: Stellt sicher, dass nur bekannte Benutzer auf zugelassenen Geräten Zugriff erhalten.
-- **Verschlüsselte DNS-Auflösung**: Verhindert DNS-Hijacking und damit verbundene Phishing-Angriffe.
-- **DDoS-Minderung**: Das verteilte Infrastruktursystem hilft beim Schutz vor DDoS-Angriffen.
-- **Skalierbare Architektur**: Entkoppelte Komponenten ermöglichen flexiblen Einsatz und Skalierung.
-- **IAM-Integration**: Funktioniert mit Ihren bestehenden Systemen zur Verwaltung von Identitäten und Zugriffen.
-- **Flexibler Einsatz**: Unterstützt verschiedene Modelle, einschließlich Client-zu-Gateway, Client-zu-Server und mehr.
-- **Starke Kryptographie**: Nutzt moderne Algorithmen wie ECC, Noise Protocol und IBC für robuste Sicherheit.
-</details>
-
-## Bereitstellung
-
-OpenNHP unterstützt mehrere Bereitstellungsmodelle für unterschiedliche Anwendungsfälle:
-
-- Client-zu-Gateway: Sichert den Zugriff auf mehrere Server hinter einem Gateway
-- Client-zu-Server: Sichert direkt einzelne Server/Anwendungen
-- Server-zu-Server: Sichert die Kommunikation zwischen Backend-Diensten
-- Gateway-zu-Gateway: Sichert Standort-zu-Standort-Verbindungen
-
-> Weitere Details zur Bereitstellung finden Sie in der [OpenNHP-Dokumentation](https://docs.opennhp.org/deploy/).
-
-## Vergleich zwischen SPA und NHP
-Das Single Packet Authorization (SPA)-Protokoll ist in der vom [Cloud Security Alliance (CSA)](https://cloudsecurityalliance.org/) veröffentlichten [Software Defined Perimeter (SDP)-Spezifikation](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) enthalten. NHP verbessert die Sicherheit, Zuverlässigkeit, Skalierbarkeit und Erweiterbarkeit durch ein modernes kryptographisches Framework und eine moderne Architektur, wie im [AHAC-Forschungspapier](https://www.mdpi.com/2076-3417/14/13/5593) gezeigt.
-
-| - | SPA | NHP | Vorteile von NHP |
-|:---|:---|:---|:---|
-| **Architektur** | Das SPA-Paketentschlüsselungs- und Benutzer-/Geräteauthentifizierungskomponente ist mit der Netzwerkzugriffskontrollkomponente im SPA-Server gekoppelt. | NHP-Server (die Paketentschlüsselungs- und Benutzer-/Geräteauthentifizierungskomponente) und NHP-AC (die Zugriffskontrollkomponente) sind entkoppelt. Der NHP-Server kann auf separaten Hosts bereitgestellt werden und unterstützt horizontale Skalierung. | <ul><li>Performance: Die ressourcenintensive Komponente NHP-Server ist vom geschützten Server getrennt.</li><li>Skalierbarkeit: Der NHP-Server kann im verteilten oder Cluster-Modus bereitgestellt werden.</li><li>Sicherheit: Die IP-Adresse des geschützten Servers ist für den Client nicht sichtbar, solange die Authentifizierung nicht erfolgreich war.</li></ul>|
-| **Kommunikation** | Einfache Richtung | Bidirektional | Bessere Zuverlässigkeit durch Statusbenachrichtigung der Zugriffskontrolle |
-| **Kryptographisches Framework** | Geteilte Geheimnisse | PKI oder IBC, Noise Framework | <ul><li>Sicherheit: Bewährter Schlüsselvereinbarungsmechanismus zur Abschwächung von MITM-Bedrohungen</li><li>Niedrige Kosten: Effiziente Schlüsselverteilung für das Zero Trust-Modell</li><li>Performance: Hochleistungs-Verschlüsselung/Entschlüsselung</li></ul>|
-| **Fähigkeit zur Verbergung der Netzwerkinfrastruktur** | Nur Serverports | Domains, IPs und Ports | Stärker gegen verschiedene Angriffe (z.B. Schwachstellen, DNS-Hijacking und DDoS-Angriffe) |
-| **Erweiterbarkeit** | Keine, nur für SDP | Universell | Unterstützt jedes Szenario, das eine Dienstverschleierung erfordert |
-| **Interoperabilität** | Nicht verfügbar | Anpassbar | NHP kann nahtlos mit bestehenden Protokollen (z.B. DNS, FIDO usw.) integriert werden |
-
-## Beitrag leisten
-
-Wir begrüßen Beiträge zu OpenNHP! Bitte lesen Sie unsere [Beitragsrichtlinien](CONTRIBUTING.md), um mehr darüber zu erfahren, wie Sie sich beteiligen können.
-
-## Lizenz
-
-OpenNHP wird unter der [Apache 2.0-Lizenz](LICENSE) veröffentlicht.
-
-## Kontakt
-
-- Projekt-Website: [https://github.com/OpenNHP/opennhp](https://github.com/OpenNHP/opennhp)
-- E-Mail: [opennhp@gmail.com](mailto:opennhp@gmail.com)
-- Discord: [Treten Sie unserem Discord bei](https://discord.gg/CpyVmspx5x)
-
-Für eine detaillierte Dokumentation besuchen Sie bitte unsere [Offizielle Dokumentation](https://opennhp.org).
-
-## Referenzen
-
-- [Software-Defined Perimeter (SDP) Specification v2.0](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2). Jason Garbis, Juanita Koilpillai, Junaid lslam, Bob Flores, Daniel Bailey, Benfeng Chen, Eitan Bremler, Michael Roza, Ahmed Refaey Hussein. [*Cloud Security Alliance (CSA)*](https://cloudsecurityalliance.org/). März 2022.
-- [AHAC: Fortschrittliches Netzwerk-Verbergung-Zugriffskontroll-Framework](https://www.mdpi.com/2076-3417/14/13/5593). Mudi Xu, Benfeng Chen, Zhizhong Tan, Shan Chen, Lei Wang, Yan Liu, Tai Io San, Sou Wang Fong, Wenyong Wang und Jing Feng. *Zeitschrift für Angewandte Wissenschaften*. Juni 2024.
-- [STALE: Ein skalierbares und sicheres grenzüberschreitendes Authentifizierungssystem, das E-Mail und ECDH-Schlüsselaustausch nutzt](https://www.mdpi.com/2079-9292/14/12/2399) Jiexin Zheng, Mudi Xu, Jianqing Li, Benfeng Chen, Zhizhong Tan, Anyu Wang, Shuo Zhang, Yan Liu, Kevin Qi Zhang, Lirong Zheng, Wenyong Wang. *Elektronik*. Juni 2025
-- [DRL-AMIR: Intelligent Flow Scheduling für Software-Defined Zero Trust Networks](https://www.techscience.com/cmc/v84n2/62920). Wenlong Ke, Zilong Li, Peiyu Chen, Benfeng Chen, Jinglin Lv, Qiang Wang, Ziyi Jia und Shigen Shen. *CMC*. Juli 2025.
-- [auf tiefe zu lernen NHP netzwerke den kontrolle zu](https://www.nature.com/articles/s41598-025-31556-3). Qinglin Huang, Zhizhong Tan, Qiang Wang, Ziyi Jia und Benfeng Chen. *Wissenschaftliche Berichte der Zeitschrift Nature* dezember 2025.
-- Noise Protocol Framework. https://noiseprotocol.org/
-- Vulnerability Management Framework-Projekt. https://phoenix.security/web-vuln-management/
+> Für Protokolldetails, Bereitstellungsmodelle und kryptographisches Design siehe die [Dokumentation](https://docs.opennhp.org).
 
 ---
 
-🌟 Vielen Dank für Ihr Interesse an OpenNHP! Wir freuen uns auf Ihre Beiträge und Ihr Feedback.
+## Repository-Struktur
 
+```
+opennhp/
+├── nhp/              # Kernprotokoll-Bibliothek (Go-Modul)
+│   ├── core/         # Paketverarbeitung, Kryptographie, Noise-Protokoll, Geräteverwaltung
+│   ├── common/       # Gemeinsame Typen und Nachrichtendefinitionen
+│   ├── utils/        # Hilfsfunktionen
+│   ├── plugins/      # Plugin-Handler-Schnittstellen
+│   ├── log/          # Logging-Infrastruktur
+│   └── etcd/         # Unterstützung für verteilte Konfiguration
+└── endpoints/        # Daemon-Implementierungen (Go-Modul, abhängig von nhp)
+    ├── agent/        # NHP-Agent-Daemon
+    ├── server/       # NHP-Server-Daemon
+    ├── ac/           # NHP-AC-(Zugriffs-Controller)-Daemon
+    ├── db/           # NHP-DB (Data Broker für DHP)
+    ├── kgc/          # Key Generation Center (IBC)
+    └── relay/        # TCP-Relay
+```
+
+---
+
+## Schnellstart
+
+### Voraussetzungen
+
+- Go 1.25.6+
+- `make`
+- Docker und Docker Compose (für die Full-Stack-Demo)
+
+### Bauen
+
+```bash
+# Alle Komponenten bauen
+make
+
+# Einzelne Daemons bauen
+make agentd    # NHP-Agent
+make serverd   # NHP-Server
+make acd       # NHP-AC
+make db        # NHP-DB
+make kgc       # Key Generation Center
+```
+
+### Testen
+
+```bash
+cd nhp && go test ./...
+cd endpoints && go test ./...
+```
+
+### Mit Docker starten
+
+```bash
+cd docker && docker-compose up --build
+```
+
+Folgen Sie dem [Schnellstart-Tutorial](https://docs.opennhp.org/nhp_quick_start/), um den vollständigen Authentifizierungs-Workflow in einer Docker-Umgebung zu simulieren.
+
+---
+
+## Mitwirken
+
+Beiträge sind willkommen! Bitte lesen Sie [CONTRIBUTING.md](CONTRIBUTING.md), bevor Sie Pull Requests einreichen.
+
+**Hinweis:** Alle Commits müssen mit einem verifizierten GPG- oder SSH-Schlüssel signiert sein.
+
+```bash
+git commit -S -m "your message"
+```
+
+---
+
+## Sicherheit
+
+Eine Schwachstelle gefunden? Bitte folgen Sie dem Responsible-Disclosure-Prozess in [SECURITY.md](SECURITY.md), statt ein öffentliches Issue zu eröffnen.
+
+---
+
+## Sponsoren
+
+<a href="https://layerv.ai">
+  <img src="docs/images/layerv_logo.png" height="40" alt="LayerV.ai logo">
+</a>
+
+---
+
+## Lizenz
+
+Veröffentlicht unter der [Apache 2.0 Lizenz](LICENSE).
+
+## Kontakt
+
+- E-Mail: [support@opennhp.org](mailto:support@opennhp.org)
+- Discord: [Discord beitreten](https://discord.gg/CpyVmspx5x)
+- Website: [https://opennhp.org](https://opennhp.org)

--- a/README.es.md
+++ b/README.es.md
@@ -1,216 +1,176 @@
 [![en](https://img.shields.io/badge/lang-en-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.md)
 [![zh-cn](https://img.shields.io/badge/lang-zh--cn-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-cn.md)
+[![zh-tw](https://img.shields.io/badge/lang-zh--tw-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-tw.md)
 [![de](https://img.shields.io/badge/lang-de-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.de.md)
 [![ja](https://img.shields.io/badge/lang-ja-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.ja.md)
 [![fr](https://img.shields.io/badge/lang-fr-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.fr.md)
 [![es](https://img.shields.io/badge/lang-es-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.es.md)
 
-![Logo OpenNHP](docs/images/logo11.png)
-# OpenNHP: Protocolo de Ocultación de Infraestructura de Red Zero Trust
-Un protocolo de red de confianza cero impulsado por criptografía en la capa 5 del modelo OSI para ocultar su servidor y sus datos de los atacantes.
+![OpenNHP Logo](docs/images/logo11.png)
 
-![Estado de Construcción](https://img.shields.io/badge/build-passing-brightgreen)
-![Versión](https://img.shields.io/badge/version-1.0.0-blue)
-![Licencia](https://img.shields.io/badge/license-Apache%202.0-green)
+# OpenNHP: Kit de herramientas de seguridad Zero Trust de código abierto
 
----
+[![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
+[![Release](https://img.shields.io/github/v/tag/OpenNHP/opennhp?label=release)](https://github.com/OpenNHP/opennhp/tags)
+![License](https://img.shields.io/badge/license-Apache%202.0-green)
+[![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
 
-## Desafío: La IA transforma Internet en un "Bosque Oscuro"
+**OpenNHP** es un kit de herramientas ligero, de código abierto e impulsado por criptografía, que implementa seguridad Zero Trust para infraestructuras, aplicaciones y datos. Es la implementación de referencia de la *[especificación Network-infrastructure Hiding Protocol (NHP)](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)* de la [**Cloud Security Alliance (CSA)**](https://cloudsecurityalliance.org/) e incluye dos protocolos principales:
 
-El rápido avance de las tecnologías de **IA**, especialmente los grandes modelos de lenguaje (LLM), está transformando significativamente el panorama de la ciberseguridad. El surgimiento de la **Explotación Autónoma de Vulnerabilidades (AVE)** representa un gran avance en la era de la IA, al automatizar la explotación de vulnerabilidades, como se muestra en [este artículo de investigación](https://arxiv.org/abs/2404.08144). Este desarrollo aumenta significativamente el riesgo para todos los servicios de red expuestos, evocando la [Hipótesis del Bosque Oscuro](https://es.wikipedia.org/wiki/Hip%C3%B3tesis_del_bosque_oscuro) en Internet. Las herramientas impulsadas por IA escanean continuamente el entorno digital, identifican rápidamente las debilidades y las explotan. Como resultado, Internet está evolucionando hacia un **"bosque oscuro"** donde **la visibilidad equivale a vulnerabilidad**.
+- **Network-infrastructure Hiding Protocol (NHP):** oculta puertos del servidor, direcciones IP y nombres de dominio para proteger aplicaciones e infraestructura frente a accesos no autorizados.
+- **Data-content Hiding Protocol (DHP):** garantiza la seguridad y la privacidad de los datos mediante cifrado y confidential computing, haciendo que los datos sean *«utilizables pero no visibles»*.
 
-![Riesgos de Vulnerabilidad](docs/images/Vul_Risks.png)
-
-La investigación de Gartner pronostica un [rápido aumento de los ciberataques impulsados por IA](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025). Este cambio de paradigma requiere una reevaluación de las estrategias tradicionales de ciberseguridad, con un enfoque en defensas proactivas, mecanismos de respuesta rápida y la adopción de tecnologías de ocultación de red para proteger la infraestructura crítica.
-
----
-
-## Demostración rápida: Ver OpenNHP en acción
-
-Antes de profundizar en los detalles de OpenNHP, comencemos con una breve demostración de cómo OpenNHP protege un servidor del acceso no autorizado. Puede verlo en acción accediendo al servidor protegido en https://acdemo.opennhp.org.
-
-### 1) El servidor protegido es "invisible" para los usuarios no autenticados
-
-Por defecto, cualquier intento de conectar con el servidor protegido resultará en un error TIME OUT, ya que todos los puertos están cerrados, haciendo que el servidor parezca *"invisible"* y efectivamente fuera de línea.
-
-![Demostración de OpenNHP](docs/images/OpenNHP_ACDemo0.png)
-
-El escaneo de puertos del servidor también devolverá un error TIME OUT.
-
-![Demostración de OpenNHP](docs/images/OpenNHP_ScanDemo.png)
-
-### 2) Después de la autenticación, el servidor protegido se vuelve accesible
-
-OpenNHP admite una variedad de métodos de autenticación, como OAuth, SAML, códigos QR, y más. Para esta demostración, utilizamos un servicio de autenticación básica de nombre de usuario/contraseña en https://demologin.opennhp.org.
-
-![Demostración de OpenNHP](docs/images/OpenNHP_DemoLogin.png)
-
-Una vez que haga clic en el botón "Login", la autenticación se completará con éxito y será redirigido al servidor protegido. En ese momento, el servidor se vuelve *"visible"* y accesible en su dispositivo.
-
-![Demostración de OpenNHP](docs/images/OpenNHP_ACDemo1.png)
+**[Sitio web](https://opennhp.org) · [Documentación](https://docs.opennhp.org) · [Demo en vivo](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 
-## Visín: Hacer de Internet un lugar confiable
+## Por qué OpenNHP
 
-La apertura de los protocolos TCP/IP ha impulsado el crecimiento explosivo de las aplicaciones de Internet, pero también ha expuesto vulnerabilidades, permitiendo que actores malintencionados obtengan acceso no autorizado y exploten cualquier dirección IP expuesta. Aunque el [modelo de red OSI](https://es.wikipedia.org/wiki/Modelo_OSI) define la *capa 5 (capa de sesión)* para la gestión de conexiones, pocas soluciones efectivas se han implementado para abordar este problema.
+La internet moderna es un [bosque oscuro](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Los atacantes —respaldados cada vez más por LLMs que escanean, toman huellas y explotan a velocidad de máquina mediante [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144)— tratan todo servicio alcanzable como un objetivo. [Gartner prevé](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) un rápido aumento de los ciberataques impulsados por IA. Las defensas tradicionales autentican a los usuarios *después* de que la red los deja entrar, dejando los puertos, IPs y dominios expuestos como una superficie de ataque permanente.
 
-**NHP**, o el **"Protocolo de Ocultación de la Infraestructura de Red"**, es un protocolo de red ligero y basado en criptografía Zero Trust, diseñado para funcionar en la *capa de sesión OSI*, óptimo para gestionar la visibilidad y las conexiones de la red. El objetivo principal de NHP es ocultar los recursos protegidos de entidades no autorizadas, otorgando acceso solo a los usuarios verificados y autorizados mediante una verificación continua, contribuyendo así a un Internet más confiable.
+OpenNHP invierte ese modelo: **invisible hasta la confianza**. Cada puerto, IP y nombre de host se sitúa detrás de una puerta de denegación por defecto. El acceso se concede solo después de que un «golpe en la puerta» firmado criptográficamente haya sido autenticado y autorizado fuera de banda. Los atacantes no pueden explotar lo que no pueden descubrir.
 
-![Internet confiable](docs/images/TrustworthyCyberspace.png)
+### El protocolo de ocultación de red de tercera generación
+
+NHP es el siguiente paso en la línea de diseños «ocultar el servicio primero»:
+
+| Generación | Protocolo | Limitaciones |
+|---|---|---|
+| 1 | Port Knocking | Texto plano, vulnerable a repetición |
+| 2 | Single Packet Authorization (SPA) | Secretos compartidos, unidireccional, normalmente oculta solo puertos, típicamente en C/C++ |
+| **3** | **NHP** | Criptografía moderna, bidireccional con estado, oculta dominio + IP + puertos, sin estado y escalable horizontalmente, Go con seguridad de memoria |
+
+NHP se integra junto a los motores IAM, DNS, FIDO y de política Zero Trust existentes, en lugar de reemplazarlos: extiende tu stack en vez de bifurcarlo.
 
 ---
-
-## Solución: OpenNHP restablece el control de la visibilidad de la red
-
-**OpenNHP** es la implementación de código abierto del protocolo NHP. Está impulsado por criptografía y diseñado con principios de seguridad en primer lugar, implementando una verdadera arquitectura de confianza cero en la *capa de sesión OSI*.
-
-![OpenNHP como la capa 5 del OSI](docs/images/OSI_OpenNHP.png)
-
-OpenNHP se basa en investigaciones anteriores sobre tecnología de ocultación de redes, utilizando un marco criptográfico moderno y una arquitectura que garantiza seguridad y alto rendimiento, superando las limitaciones de tecnologías anteriores.
-
-| Protocolo de Ocultación de Infraestructura de Red | 1ª Generación | 2ª Generación | 3ª Generación |
-|:---|:---|:---|:---|
-| **Tecnología Clave** | [Port Knocking](https://es.wikipedia.org/wiki/Port_knocking) | [Single Packet Authorization (SPA)](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) | Protocolo de Ocultación de Infraestructura de Red (NHP) |
-| **Autenticación** | Secuencias de puertos | Secretos compartidos | Marco Criptográfico Moderno |
-| **Arquitectura** | Sin plano de control | Sin plano de control | Plano de control escalable |
-| **Capacidad** | Ocultar puertos | Ocultar puertos | Ocultar puertos, IPs y dominios |
-| **Control de Acceso** | Nivel IP | Nivel de Puertos | Nivel de Aplicación |
-| **Proyectos de Código Abierto** | [knock](https://github.com/jvinet/knock) *(C)* | [fwknop](https://github.com/mrash/fwknop) *(C++)* | [OpenNHP](https://github.com/OpenNHP/opennhp) *(Go)* |
-
-> Es crucial elegir un lenguaje **seguro para la memoria** como *Go* para el desarrollo de OpenNHP, como se destaca en el [informe técnico del gobierno de los EE.UU.](https://www.whitehouse.gov/wp-content/uploads/2024/02/Final-ONCD-Technical-Report.pdf). Para una comparación detallada entre **SPA y NHP**, consulte la [sección a continuación](#comparison-between-spa-and-nhp).
-
-## Beneficios de Seguridad
-
-Dado que OpenNHP implementa los principios de confianza cero en la *capa de sesión OSI*, ofrece beneficios significativos:
-
-- Reduce la superficie de ataque ocultando la infraestructura
-- Evita el reconocimiento no autorizado de la red
-- Mitiga la explotación de vulnerabilidades
-- Previene ataques de phishing mediante DNS cifrado
-- Protege contra ataques DDoS
-- Permite el control de acceso granular
-- Proporciona seguimiento de conexiones basado en identidad
-- Atribución de ataques
 
 ## Arquitectura
 
-La arquitectura de OpenNHP se inspira en el [estándar de Arquitectura de Confianza Cero del NIST](https://www.nist.gov/publications/zero-trust-architecture). Sigue un diseño modular con los tres componentes principales: **NHP-Server**, **NHP-AC** y **NHP-Agent**, como se ilustra en el siguiente diagrama.
+OpenNHP sigue un diseño modular con tres componentes principales, inspirado en la [Arquitectura Zero Trust del NIST](https://www.nist.gov/publications/zero-trust-architecture):
 
-![Arquitectura de OpenNHP](docs/images/OpenNHP_Arch.gif)
+![OpenNHP architecture](docs/images/OpenNHP_Arch.gif)
 
-> Consulte la [documentación de OpenNHP](https://docs.opennhp.org/) para obtener información detallada sobre la arquitectura y el flujo de trabajo.
+| Componente | Rol |
+|-----------|------|
+| **NHP-Agent** | Cliente que envía solicitudes «knock» cifradas para obtener acceso |
+| **NHP-Server** | Autentica y autoriza las solicitudes; se ejecuta por separado y está arquitectónicamente desacoplado del host protegido |
+| **NHP-AC** | Controlador de acceso que gestiona las reglas del cortafuegos en el servidor protegido |
 
-## Centro: Algoritmos Criptográficos
+### Flujo del protocolo
 
-La criptografía es el centro de OpenNHP, proporcionando seguridad robusta, un excelente rendimiento y escalabilidad mediante el uso de algoritmos criptográficos de vanguardia. A continuación se muestran los principales algoritmos y marcos criptográficos utilizados por OpenNHP:
+1. El Agent envía un knock cifrado (`NHP_KNK`) al Server.
+2. El Server valida el knock y envía una solicitud de operación (`NHP_AOP`) al AC.
+3. El AC abre el cortafuegos y responde (`NHP_ART`) al Server.
+4. El Server devuelve un reconocimiento (`NHP_ACK`) con la información de acceso al Agent.
+5. El Agent alcanza el recurso protegido a través del AC.
 
-- **[Criptografía de Curva Elíptica (ECC)](https://es.wikipedia.org/wiki/Criptograf%C3%ADa_de_curva_el%C3%ADptica)**: Utilizada para criptografía asimétrica eficiente.
+### Criptografía
 
-> En comparación con RSA, ECC ofrece una mayor eficiencia con una encriptación más fuerte en longitudes de clave más cortas, mejorando tanto la transmisión en la red como el rendimiento computacional. La tabla a continuación muestra las diferencias en la fortaleza de la seguridad, las longitudes de clave y la proporción de longitud de clave entre RSA y ECC, junto con sus respectivos períodos de validez.
+OpenNHP incluye dos suites criptográficas intercambiables:
 
-| Fortaleza de Seguridad (bits) | Longitud de Clave DSA/RSA (bits) | Longitud de Clave ECC (bits) | Relación: ECC vs. DSA/RSA | Validez |
-|:----------------------------:|:-------------------------------:|:---------------------------:|:--------------------------:|:-------:|
-| 80                           | 1024                            | 160-223                     | 1:6                        | Hasta 2010 |
-| 112                          | 2048                            | 224-255                     | 1:9                        | Hasta 2030 |
-| 128                          | 3072                            | 256-383                     | 1:12                       | Después de 2031 |
-| 192                          | 7680                            | 384-511                     | 1:20                       | |
-| 256                          | 15360                           | 512+                        | 1:30                       | |
+- **`CIPHER_SCHEME_CURVE`** — Curve25519 + AES-256-GCM + BLAKE2s
+- **`CIPHER_SCHEME_GMSM`** — SM2 + SM4-GCM + SM3
 
-- **[Marco de Protocolo Noise](https://noiseprotocol.org/)**: Permite el intercambio seguro de claves, el cifrado/descifrado de mensajes y la autenticación mutua.
+Ambas se basan en el [Noise Protocol Framework](https://noiseprotocol.org/). Un modo de criptografía basada en identidad (IBC) está disponible a través del Key Generation Center (KGC).
 
-> El Protocolo Noise se basa en el [acuerdo de clave Diffie-Hellman](https://es.wikipedia.org/wiki/Intercambio_de_claves_Diffie-Hellman) y proporciona soluciones criptográficas modernas como la autenticación mutua y opcional, el ocultamiento de identidad, la confidencialidad directa y el cifrado de ida y vuelta. Probado por su seguridad y rendimiento, ya es utilizado por aplicaciones populares como [WhatsApp](https://www.whatsapp.com/security/WhatsApp-Security-Whitepaper.pdf), [Slack](https://github.com/slackhq/nebula) y [WireGuard](https://www.wireguard.com/).
-
-- **[Criptografía Basada en Identidad (IBC)](https://es.wikipedia.org/wiki/Criptograf%C3%ADa_basada_en_la_identidad)**: Simplifica la distribución de claves a escala.
-
-> Una distribución eficiente de claves es esencial para implementar Zero Trust. OpenNHP admite tanto PKI como IBC. Mientras que PKI se ha utilizado ampliamente durante décadas, depende de Autoridades Certificadoras (CA) centralizadas para la verificación de identidad y la gestión de claves, lo que puede ser costoso y llevar tiempo. En contraste, IBC permite un enfoque descentralizado y autogestionado para la verificación de identidad y la gestión de claves, haciéndolo más rentable para el entorno Zero Trust de OpenNHP, donde miles de millones de dispositivos o servidores pueden necesitar protección e integración en tiempo real.
-
-- **[Criptografía sin Certificados (CL-PKC)](https://es.wikipedia.org/wiki/Criptograf%C3%ADa_sin_certificado)**: Algoritmo IBC recomendado
-
-> CL-PKC es un esquema que mejora la seguridad al evitar la custodia de claves y abordar las limitaciones de la Criptografía Basada en Identidad (IBC). En la mayoría de los sistemas IBC, la clave privada de un usuario es generada por un Centro de Generación de Claves (KGC), lo cual conlleva riesgos significativos. Un KGC comprometido puede llevar a la exposición de todas las claves privadas de los usuarios, requiriendo plena confianza en el KGC. CL-PKC mitiga este problema dividiendo el proceso de generación de claves, de modo que el KGC solo tiene conocimiento de una clave privada parcial. Como resultado, CL-PKC combina las fortalezas de PKI e IBC, ofreciendo una mayor seguridad sin los inconvenientes de la gestión centralizada de claves.
-
-Lectura adicional:
-
-> Consulte la [documentación de OpenNHP](https://docs.opennhp.org/cryptography/) para una explicación detallada de los algoritmos criptográficos utilizados en OpenNHP.
-
-## Características Clave
-
-- Mitiga la explotación de vulnerabilidades mediante la aplicación de reglas "denegar todo" por defecto
-- Previene ataques de phishing mediante la resolución DNS cifrada
-- Protege contra ataques DDoS ocultando la infraestructura
-- Permite la atribución de ataques mediante conexiones basadas en identidad
-- Control de acceso predeterminado para todos los recursos protegidos
-- Autenticación basada en identidad y dispositivos antes del acceso a la red
-- Resolución DNS cifrada para prevenir secuestro de DNS
-- Infraestructura distribuida para mitigar ataques DDoS
-- Arquitectura escalable con componentes desacoplados
-- Integración con sistemas de gestión de identidades y accesos existentes
-- Compatible con varios modelos de despliegue (cliente a puerta de enlace, cliente a servidor, etc.)
-- Seguridad criptográfica con algoritmos modernos (ECC, Noise Protocol, IBC)
-
-<details>
-<summary>Haga clic para expandir los detalles de las características</summary>
-
-- **Control de acceso predeterminado**: Todos los recursos están ocultos por defecto, solo siendo accesibles tras la autenticación y autorización.
-- **Autenticación basada en identidad y dispositivos**: Garantiza que solo los usuarios conocidos en dispositivos aprobados puedan acceder.
-- **Resolución DNS cifrada**: Evita el secuestro de DNS y los ataques de phishing asociados.
-- **Mitigación de DDoS**: El diseño de infraestructura distribuida ayuda a proteger contra los ataques de denegación de servicio distribuidos.
-- **Arquitectura escalable**: Los componentes desacoplados permiten un despliegue y escalado flexibles.
-- **Integración IAM**: Funciona con sus sistemas de gestión de identidades y accesos existentes.
-- **Despliegue flexible**: Compatible con varios modelos, incluido cliente a puerta de enlace, cliente a servidor y más.
-- **Criptografía robusta**: Utiliza algoritmos modernos como ECC, Noise Protocol e IBC para una seguridad robusta.
-</details>
-
-## Despliegue
-
-OpenNHP admite varios modelos de despliegue para adaptarse a diferentes casos de uso:
-
-- Cliente a puerta de enlace: Asegura el acceso a varios servidores detrás de una puerta de enlace
-- Cliente a servidor: Asegura directamente servidores/aplicaciones individuales
-- Servidor a servidor: Asegura la comunicación entre servicios backend
-- Puerta de enlace a puerta de enlace: Asegura conexiones entre sitios
-
-> Consulte la [documentación de OpenNHP](https://docs.opennhp.org/deploy/) para obtener instrucciones detalladas de despliegue.
-
-## Comparación entre SPA y NHP
-El protocolo Single Packet Authorization (SPA) está incluido en la [especificación del Perímetro Definido por Software (SDP)](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) publicada por la [Cloud Security Alliance (CSA)](https://cloudsecurityalliance.org/). NHP mejora la seguridad, la fiabilidad, la escalabilidad y la extensibilidad mediante un marco criptográfico moderno y una arquitectura moderna, como se demuestra en el [artículo de investigación AHAC](https://www.mdpi.com/2076-3417/14/13/5593).
-
-| - | SPA | NHP | Ventajas de NHP |
-|:---|:---|:---|:---|
-| **Arquitectura** | El componente de descifrado de paquetes SPA y autenticación de usuario/dispositivo está acoplado con el componente de control de acceso a la red en el servidor SPA. | NHP-Server (el componente de descifrado de paquetes y autenticación de usuario/dispositivo) y NHP-AC (el componente de control de acceso) están desacoplados. NHP-Server se puede desplegar en hosts separados y admite la escalabilidad horizontal. | <ul><li>Rendimiento: el componente que consume muchos recursos, NHP-server, está separado del servidor protegido.</li><li>Escalabilidad: NHP-server se puede desplegar en modo distribuido o clúster.</li><li>Seguridad: la dirección IP del servidor protegido no es visible para el cliente a menos que la autenticación sea exitosa.</li></ul>|
-| **Comunicación** | Dirección única | Bidireccional | Mejor fiabilidad con la notificación de estado del control de acceso |
-| **Marco criptográfico** | Secretos compartidos | PKI o IBC, Marco Noise | <ul><li>Seguridad: mecanismo comprobado de intercambio de claves para mitigar las amenazas MITM</li><li>Bajo costo: distribución de claves eficiente para el modelo de confianza cero</li><li>Rendimiento: cifrado/descifrado de alto rendimiento</li></ul>|
-| **Capacidad de Ocultación de Infraestructura de Red** | Solo puertos de servidor | Dominios, IPs y puertos | Más poderoso contra varios ataques (p. ej., vulnerabilidades, secuestro de DNS y ataques DDoS) |
-| **Extensibilidad** | Ninguna, solo para SDP | Todo uso | Compatible con cualquier escenario que necesite oscurecimiento del servicio |
-| **Interoperabilidad** | No disponible | Personalizable | NHP puede integrarse sin problemas con protocolos existentes (p. ej., DNS, FIDO, etc.) |
-
-## Contribuir
-
-¡Damos la bienvenida a las contribuciones a OpenNHP! Consulte nuestras [Directrices de Contribución](CONTRIBUTING.md) para obtener más información sobre cómo participar.
-
-## Licencia
-
-OpenNHP se publica bajo la [Licencia Apache 2.0](LICENSE).
-
-## Contacto
-
-- Sitio web del proyecto: [https://github.com/OpenNHP/opennhp](https://github.com/OpenNHP/opennhp)
-- Correo electrónico: [opennhp@gmail.com](mailto:opennhp@gmail.com)
-- Discord: [Únase a nuestro Discord](https://discord.gg/CpyVmspx5x)
-
-Para obtener una documentación más detallada, visite nuestra [Documentación Oficial](https://opennhp.org).
-
-## Referencias
-
-- [Especificación del Perímetro Definido por Software (SDP) v2.0](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2). Jason Garbis, Juanita Koilpillai, Junaid lslam, Bob Flores, Daniel Bailey, Benfeng Chen, Eitan Bremler, Michael Roza, Ahmed Refaey Hussein. [*Cloud Security Alliance (CSA)*](https://cloudsecurityalliance.org/). Marzo 2022.
-- [AHAC: Marco Avanzado de Control de Acceso Oculto en Red](https://www.mdpi.com/2076-3417/14/13/5593). Mudi Xu, Benfeng Chen, Zhizhong Tan, Shan Chen, Lei Wang, Yan Liu, Tai Io San, Sou Wang Fong, Wenyong Wang y Jing Feng. *Revista de Ciencias Aplicadas*. Junio 2024.
-- [STALE: Un esquema de autenticación transfronteriza escalable y seguro aprovechando el correo electrónico y el intercambio de claves ECDH](https://www.mdpi.com/2079-9292/14/12/2399) Jiexin Zheng, Mudi Xu, Jianqing Li, Benfeng Chen, Zhizhong Tan, Anyu Wang, Shuo Zhang, Yan Liu, Kevin Qi Zhang, Lirong Zheng, Wenyong Wang. *electrónica*. Junio 2025.
-- [DRL-AMIR: Programación de flujo inteligente para redes de confianza cero definidas por software](https://www.techscience.com/cmc/v84n2/62920). WenLong Ke, Zilong Li, Peiyu Chen, Benfeng Chen, Jinglin Lv, Qiang Wang, Ziyi Jia y Shigen Shen. *CMC* julio de 2025.
-- [método de control de tráfico de red de NHP basado en aprendizaje de refuerzo profundo](https://www.nature.com/articles/s41598-025-31556-3). Qinglin Huang, Zhizhong Tan, Qiang Wang, Ziyi Jia y Benfeng Chen.*Informes científicos de la revista Nature* diciembre de 2025.
-- Noise Protocol Framework. https://noiseprotocol.org/
-- Proyecto de Marco de Gestión de Vulnerabilidades. https://phoenix.security/web-vuln-management/
+> Para detalles del protocolo, modelos de despliegue y diseño criptográfico, consulta la [documentación](https://docs.opennhp.org).
 
 ---
 
-🌟 ¡Gracias por su interés en OpenNHP! Esperamos sus contribuciones y comentarios.
+## Estructura del repositorio
 
+```
+opennhp/
+├── nhp/              # Biblioteca principal del protocolo (módulo Go)
+│   ├── core/         # Manejo de paquetes, criptografía, protocolo Noise, gestión de dispositivos
+│   ├── common/       # Tipos compartidos y definiciones de mensajes
+│   ├── utils/        # Funciones utilitarias
+│   ├── plugins/      # Interfaces de manejadores de plugins
+│   ├── log/          # Infraestructura de logging
+│   └── etcd/         # Soporte de configuración distribuida
+└── endpoints/        # Implementaciones de daemons (módulo Go, depende de nhp)
+    ├── agent/        # Daemon NHP-Agent
+    ├── server/       # Daemon NHP-Server
+    ├── ac/           # Daemon NHP-AC (controlador de acceso)
+    ├── db/           # NHP-DB (Data Broker para DHP)
+    ├── kgc/          # Key Generation Center (IBC)
+    └── relay/        # Relay TCP
+```
+
+---
+
+## Inicio rápido
+
+### Requisitos previos
+
+- Go 1.25.6+
+- `make`
+- Docker y Docker Compose (para la demo completa)
+
+### Compilación
+
+```bash
+# Compilar todos los componentes
+make
+
+# Compilar daemons individuales
+make agentd    # NHP-Agent
+make serverd   # NHP-Server
+make acd       # NHP-AC
+make db        # NHP-DB
+make kgc       # Key Generation Center
+```
+
+### Pruebas
+
+```bash
+cd nhp && go test ./...
+cd endpoints && go test ./...
+```
+
+### Ejecución con Docker
+
+```bash
+cd docker && docker-compose up --build
+```
+
+Sigue el [tutorial de inicio rápido](https://docs.opennhp.org/nhp_quick_start/) para simular el flujo completo de autenticación en un entorno Docker.
+
+---
+
+## Contribuir
+
+¡Las contribuciones son bienvenidas! Por favor, lee [CONTRIBUTING.md](CONTRIBUTING.md) antes de enviar un Pull Request.
+
+**Nota:** todos los commits deben estar firmados con una clave GPG o SSH verificada.
+
+```bash
+git commit -S -m "your message"
+```
+
+---
+
+## Seguridad
+
+¿Has encontrado una vulnerabilidad? Sigue el proceso de divulgación responsable descrito en [SECURITY.md](SECURITY.md) en lugar de abrir un issue público.
+
+---
+
+## Patrocinadores
+
+<a href="https://layerv.ai">
+  <img src="docs/images/layerv_logo.png" height="40" alt="LayerV.ai logo">
+</a>
+
+---
+
+## Licencia
+
+Publicado bajo la [Licencia Apache 2.0](LICENSE).
+
+## Contacto
+
+- Correo: [support@opennhp.org](mailto:support@opennhp.org)
+- Discord: [Únete a nuestro Discord](https://discord.gg/CpyVmspx5x)
+- Sitio web: [https://opennhp.org](https://opennhp.org)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,216 +1,176 @@
 [![en](https://img.shields.io/badge/lang-en-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.md)
 [![zh-cn](https://img.shields.io/badge/lang-zh--cn-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-cn.md)
+[![zh-tw](https://img.shields.io/badge/lang-zh--tw-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-tw.md)
 [![de](https://img.shields.io/badge/lang-de-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.de.md)
 [![ja](https://img.shields.io/badge/lang-ja-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.ja.md)
 [![fr](https://img.shields.io/badge/lang-fr-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.fr.md)
 [![es](https://img.shields.io/badge/lang-es-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.es.md)
 
-![Logo OpenNHP](docs/images/logo11.png)
-# OpenNHP : Protocole de Masquage de l'Infrastructure Réseau en Zéro Confiance
-Un protocole réseau de zéro confiance, basé sur la cryptographie, au niveau 5 du modèle OSI, permettant de cacher votre serveur et vos données des attaquants.
+![OpenNHP Logo](docs/images/logo11.png)
 
-![Statut de Construction](https://img.shields.io/badge/build-passing-brightgreen)
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
-![Licence](https://img.shields.io/badge/license-Apache%202.0-green)
+# OpenNHP : Boîte à outils open source de sécurité Zero Trust
 
----
+[![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
+[![Release](https://img.shields.io/github/v/tag/OpenNHP/opennhp?label=release)](https://github.com/OpenNHP/opennhp/tags)
+![License](https://img.shields.io/badge/license-Apache%202.0-green)
+[![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
 
-## Défi : L'IA transforme Internet en une "Forêt Sombre"
+**OpenNHP** est une boîte à outils open source légère et basée sur la cryptographie, qui met en œuvre la sécurité Zero Trust pour les infrastructures, les applications et les données. C'est l'implémentation de référence de la *[spécification Network-infrastructure Hiding Protocol (NHP)](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)* de la [**Cloud Security Alliance (CSA)**](https://cloudsecurityalliance.org/), et elle comprend deux protocoles principaux :
 
-L'avancement rapide des technologies d'**IA**, en particulier les grands modèles de langage (LLM), transforme de manière significative le paysage de la cybersécurité. L'émergence de l'**exploitation autonome des vulnérabilités (AVE)** représente un bond majeur dans l'ère de l'IA, automatisant l'exploitation des vulnérabilités, comme le montre [cet article de recherche](https://arxiv.org/abs/2404.08144). Ce développement augmente de manière significative le risque pour tous les services réseau exposés, évoquant l'hypothèse de la [forêt sombre](https://fr.wikipedia.org/wiki/For%C3%AAt_sombre) sur Internet. Les outils pilotés par l'IA scannent continuellement l'environnement numérique, identifiant rapidement les faiblesses et les exploitant. Ainsi, Internet devient une **"forêt sombre"** où **la visibilité équivaut à la vulnérabilité**.
+- **Network-infrastructure Hiding Protocol (NHP) :** dissimule les ports serveur, les adresses IP et les noms de domaine pour protéger les applications et l'infrastructure contre les accès non autorisés.
+- **Data-content Hiding Protocol (DHP) :** assure la sécurité et la confidentialité des données grâce au chiffrement et au confidential computing, rendant les données *« utilisables mais invisibles »*.
 
-![Risques de Vulnérabilité](docs/images/Vul_Risks.png)
-
-Selon les recherches de Gartner, les [cyberattaques pilotées par l'IA vont augmenter rapidement](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025). Ce paradigme en évolution impose une réévaluation des stratégies de cybersécurité traditionnelles, avec un accent sur les défenses proactives, des mécanismes de réponse rapide, et l'adoption de technologies de masquage réseau pour protéger les infrastructures critiques.
-
----
-
-## Démo rapide : Voir OpenNHP en action
-
-Avant de plonger dans les détails d'OpenNHP, commençons par une démonstration rapide de la façon dont OpenNHP protège un serveur contre les accès non autorisés. Vous pouvez le voir en action en accédant au serveur protégé à l'adresse suivante : https://acdemo.opennhp.org.
-
-### 1) Le serveur protégé est "invisible" aux utilisateurs non authentifiés
-
-Par défaut, toute tentative de connexion au serveur protégé résultera en une erreur de TYPE OUT, car tous les ports sont fermés, rendant le serveur *"invisible"* et apparemment hors ligne.
-
-![Démo OpenNHP](docs/images/OpenNHP_ACDemo0.png)
-
-Le scan des ports du serveur retournera également une erreur de TYPE OUT.
-
-![Démo OpenNHP](docs/images/OpenNHP_ScanDemo.png)
-
-### 2) Après authentification, le serveur protégé devient accessible
-
-OpenNHP supporte une variété de méthodes d'authentification, telles que OAuth, SAML, QR codes, et plus encore. Pour cette démonstration, nous utilisons un service d'authentification basé sur un nom d'utilisateur/mot de passe simple à l'adresse https://demologin.opennhp.org.
-
-![Démo OpenNHP](docs/images/OpenNHP_DemoLogin.png)
-
-Une fois que vous cliquez sur le bouton "Login", l'authentification est réussie, et vous êtes redirigé vers le serveur protégé. Le serveur devient alors *"visible"* et accessible sur votre appareil.
-
-![Démo OpenNHP](docs/images/OpenNHP_ACDemo1.png)
+**[Site web](https://opennhp.org) · [Documentation](https://docs.opennhp.org) · [Démo en direct](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 
-## Vision : Faire d'Internet un espace de confiance
+## Pourquoi OpenNHP
 
-L'ouverture des protocoles TCP/IP a stimulé la croissance des applications Internet, mais a aussi exposé des vulnérabilités, permettant aux acteurs malveillants d'accéder de manière non autorisée à toute adresse IP exposée. Bien que le [modèle réseau OSI](https://fr.wikipedia.org/wiki/Mod%C3%A8le_OSI) définisse la *couche 5 (couche session)* pour la gestion des connexions, peu de solutions efficaces ont été mises en place à cet égard.
+L'internet moderne est une [forêt sombre](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Les attaquants — de plus en plus soutenus par des LLM qui scannent, identifient et exploitent à la vitesse de la machine via l'[Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) — considèrent chaque service accessible comme une cible. [Gartner prévoit](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) une hausse rapide des cyberattaques pilotées par l'IA. Les défenses traditionnelles authentifient les utilisateurs *après* que le réseau les ait laissés entrer, laissant les ports, IP et domaines exposés comme une surface d'attaque permanente.
 
-**NHP**, ou **"Protocole de Masquage de l'Infrastructure Réseau"**, est un protocole réseau de zéro confiance, basé sur la cryptographie, conçu pour fonctionner au *niveau de la couche session OSI*, idéal pour gérer la visibilité réseau et les connexions. L'objectif principal de NHP est de dissimuler les ressources protégées des entités non autorisées, accordant l'accès uniquement aux utilisateurs vérifiés et autorisés par une vérification continue, contribuant ainsi à un Internet plus digne de confiance.
+OpenNHP inverse ce modèle : **invisible jusqu'à la confiance**. Chaque port, IP et nom d'hôte est placé derrière une porte refusant tout par défaut. L'accès n'est accordé qu'après qu'un « toc-toc » cryptographiquement signé a été authentifié et autorisé hors bande. Les attaquants ne peuvent pas exploiter ce qu'ils ne peuvent pas découvrir.
 
-![Internet de Confiance](docs/images/TrustworthyCyberspace.png)
+### Le protocole de masquage réseau de troisième génération
+
+NHP est la prochaine étape dans la lignée des conceptions « cacher le service d'abord » :
+
+| Génération | Protocole | Limitations |
+|---|---|---|
+| 1 | Port Knocking | Texte clair, vulnérable au rejeu |
+| 2 | Single Packet Authorization (SPA) | Secrets partagés, unidirectionnel, cache généralement uniquement les ports, souvent en C/C++ |
+| **3** | **NHP** | Cryptographie moderne, bidirectionnel avec statut, cache domaine + IP + ports, sans état et scalable horizontalement, Go memory-safe |
+
+NHP s'intègre aux moteurs IAM, DNS, FIDO et aux policy engines Zero Trust existants au lieu de les remplacer — il étend votre stack sans la forker.
 
 ---
-
-## Solution : OpenNHP rétablit le contrôle de la visibilité réseau
-
-**OpenNHP** est l'implémentation open source du protocole NHP. Il est basé sur la cryptographie et conçu avec des principes de sécurité en priorité, implémentant une véritable architecture de zéro confiance au *niveau de la couche session OSI*.
-
-![OpenNHP en tant que couche 5 OSI](docs/images/OSI_OpenNHP.png)
-
-OpenNHP s'appuie sur des recherches antérieures sur la technologie de masquage réseau, en utilisant des cadres et une architecture modernes de cryptographie pour garantir la sécurité et des performances élevées, surmontant ainsi les limitations des technologies précédentes.
-
-| Protocole de Masquage de l'Infrastructure | 1ère Génération | 2ème Génération | 3ème Génération |
-|:---|:---|:---|:---|
-| **Technologie Clé** | [Port Knocking](https://fr.wikipedia.org/wiki/Port_knocking) | [Autorisation par Paquet Unique (SPA)](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) | Protocole de Masquage de l'Infrastructure Réseau (NHP) |
-| **Authentification** | Séquences de ports | Secrets partagés | Cadre cryptographique moderne |
-| **Architecture** | Pas de plan de contrôle | Pas de plan de contrôle | Plan de contrôle scalable |
-| **Capacité** | Masquer les ports | Masquer les ports | Masquer les ports, IPs et domaines |
-| **Contrôle d'Accès** | Niveau IP | Niveau Port | Niveau Application |
-| **Projets Open Source** | [knock](https://github.com/jvinet/knock) *(C)* | [fwknop](https://github.com/mrash/fwknop) *(C++)* | [OpenNHP](https://github.com/OpenNHP/opennhp) *(Go)* |
-
-> Il est crucial de choisir un langage **sûr pour la mémoire** comme *Go* pour le développement d'OpenNHP, comme le souligne le [rapport technique du gouvernement des États-Unis](https://www.whitehouse.gov/wp-content/uploads/2024/02/Final-ONCD-Technical-Report.pdf). Pour une comparaison détaillée entre **SPA et NHP**, référez-vous à la [section ci-dessous](#comparison-between-spa-and-nhp).
-
-## Bénéfices en matière de sécurité
-
-Puisqu'OpenNHP implémente les principes de zéro confiance au *niveau de la couche session OSI*, il offre des avantages significatifs :
-
-- Réduit la surface d'attaque en cachant l'infrastructure
-- Empêche la reconnaissance réseau non autorisée
-- Atténue l'exploitation des vulnérabilités
-- Empêche le phishing via DNS chiffré
-- Protège contre les attaques DDoS
-- Permet un contrôle d'accès granulaire
-- Fournit un suivi des connexions basé sur l'identité
-- Attribution des attaques
 
 ## Architecture
 
-L'architecture d'OpenNHP s'inspire de la [norme d'architecture Zero Trust du NIST](https://www.nist.gov/publications/zero-trust-architecture). Elle suit une conception modulaire avec trois composants principaux : **NHP-Server**, **NHP-AC** et **NHP-Agent**, comme illustré dans le diagramme ci-dessous.
+OpenNHP adopte une conception modulaire avec trois composants principaux, inspirée de l'[architecture Zero Trust du NIST](https://www.nist.gov/publications/zero-trust-architecture) :
 
-![Architecture OpenNHP](docs/images/OpenNHP_Arch.gif)
+![OpenNHP architecture](docs/images/OpenNHP_Arch.gif)
 
-> Veuillez consulter la [documentation d'OpenNHP](https://docs.opennhp.org/) pour des informations détaillées sur l'architecture et le flux de travail.
+| Composant | Rôle |
+|-----------|------|
+| **NHP-Agent** | Client qui envoie des requêtes « toc-toc » chiffrées pour obtenir l'accès |
+| **NHP-Server** | Authentifie et autorise les requêtes ; s'exécute séparément et est architecturalement découplé de l'hôte protégé |
+| **NHP-AC** | Contrôleur d'accès qui gère les règles de pare-feu sur le serveur protégé |
 
-## Cœur : Algorithmes Cryptographiques
+### Flux protocolaire
 
-La cryptographie est au cœur d'OpenNHP, fournissant une sécurité robuste, d'excellentes performances et une bonne évolutivité en utilisant des algorithmes cryptographiques de pointe. Voici les principaux algorithmes et cadres cryptographiques employés par OpenNHP :
+1. L'Agent envoie un knock chiffré (`NHP_KNK`) au Server.
+2. Le Server valide le knock et envoie une requête d'opération (`NHP_AOP`) à l'AC.
+3. L'AC ouvre le pare-feu et répond (`NHP_ART`) au Server.
+4. Le Server renvoie un acquittement (`NHP_ACK`) avec les informations d'accès à l'Agent.
+5. L'Agent atteint la ressource protégée via l'AC.
 
-- **[Cryptographie à Courbes Elliptiques (ECC)](https://fr.wikipedia.org/wiki/Cryptographie_sur_courbe_elliptique)** : Utilisée pour la cryptographie asymétrique efficace.
+### Cryptographie
 
-> Comparée à RSA, l'ECC offre une efficacité supérieure avec un chiffrement plus fort à des longueurs de clé plus courtes, améliorant la transmission réseau et les performances de calcul. Le tableau ci-dessous montre les différences de force de sécurité, de longueurs de clé et du ratio entre RSA et ECC, ainsi que leurs périodes de validité respectives.
+OpenNHP fournit deux suites cryptographiques interchangeables :
 
-| Force de Sécurité (bits) | Longueur de Clé DSA/RSA (bits) | Longueur de Clé ECC (bits) | Ratio : ECC vs DSA/RSA | Validité |
-|:--------------------------:|:------------------------------:|:--------------------------:|:-----------------------:|:---------:|
-| 80                         | 1024                           | 160-223                    | 1:6                     | Jusqu'en 2010 |
-| 112                        | 2048                           | 224-255                    | 1:9                     | Jusqu'en 2030 |
-| 128                        | 3072                           | 256-383                    | 1:12                    | Après 2031 |
-| 192                        | 7680                           | 384-511                    | 1:20                    | |
-| 256                        | 15360                          | 512+                       | 1:30                    | |
+- **`CIPHER_SCHEME_CURVE`** — Curve25519 + AES-256-GCM + BLAKE2s
+- **`CIPHER_SCHEME_GMSM`** — SM2 + SM4-GCM + SM3
 
-- **[Cadre de Protocole Noise](https://noiseprotocol.org/)** : Permet l'échange de clés sécurisé, le chiffrement/déchiffrement des messages, et l'authentification mutuelle.
+Toutes deux reposent sur le [Noise Protocol Framework](https://noiseprotocol.org/). Un mode Identity-Based Cryptography (IBC) est disponible via le Key Generation Center (KGC).
 
-> Le protocole Noise est basé sur l'[accord de clé Diffie-Hellman](https://fr.wikipedia.org/wiki/%C3%89change_de_cl%C3%A9_Diffie-Hellman) et offre des solutions cryptographiques modernes telles que l'authentification mutuelle et optionnelle, le masquage de l'identité, la sécurité persistante, et le chiffrement à tour de passezà-tour de zéro. Déjà prouvé pour sa sécurité et ses performances, il est utilisé par des applications populaires comme [WhatsApp](https://www.whatsapp.com/security/WhatsApp-Security-Whitepaper.pdf), [Slack](https://github.com/slackhq/nebula), et [WireGuard](https://www.wireguard.com/).
-
-- **[Cryptographie basée sur l'Identité (IBC)](https://fr.wikipedia.org/wiki/Cryptographie_bas%C3%A9e_sur_l%27identit%C3%A9)** : Simplifie la distribution des clés à grande échelle.
-
-> Une distribution efficace des clés est essentielle pour implémenter le Zéro Confiance. OpenNHP prend en charge à la fois PKI et IBC. Alors que PKI est utilisée depuis des décennies, elle dépend de Certificats d'Autorité centralisés (CA) pour la vérification de l'identité et la gestion des clés, ce qui peut être long et coûteux. En revanche, l'IBC permet une approche décentralisée et autonome de la vérification de l'identité et de la gestion des clés, la rendant plus rentable pour l'environnement Zero Trust d'OpenNHP, où des milliards d'appareils ou de serveurs peuvent avoir besoin de protection et d'intégration en temps réel.
-
-- **[Cryptographie à Clé Publique sans Certificat (CL-PKC)](https://fr.wikipedia.org/wiki/Cryptographie_sans_certificat)** : Algorithme IBC recommandé
-
-> CL-PKC est un schéma qui améliore la sécurité en évitant la garde des clés et en répondant aux limites de la cryptographie basée sur l'identité (IBC). Dans la plupart des systèmes IBC, la clé privée d'un utilisateur est générée par un Centre de Génération de Clés (KGC), ce qui introduit des risques importants. Un KGC compromis peut entraîner l'exposition des clés privées de tous les utilisateurs, nécessitant une confiance totale dans le KGC. CL-PKC atténue ce problème en divisant le processus de génération de clés, de sorte que le KGC n'a connaissance que d'une clé privée partielle. En conséquence, CL-PKC combine les forces du PKI et de l'IBC, offrant une sécurité renforcée sans les inconvénients de la gestion centralisée des clés.
-
-Pour en savoir plus :
-
-> Veuillez consulter la [documentation OpenNHP](https://docs.opennhp.org/cryptography/) pour une explication détaillée des algorithmes cryptographiques utilisés dans OpenNHP.
-
-## Principales Fonctionnalités
-
-- Atténue l'exploitation des vulnérabilités en appliquant par défaut des règles "deny-all"
-- Empêche les attaques de phishing via la résolution DNS chiffrée
-- Protège contre les attaques DDoS en cachant l'infrastructure
-- Permet l'attribution des attaques via des connexions basées sur l'identité
-- Contrôle d'accès par défaut pour toutes les ressources protégées
-- Authentification basée sur l'identité et les appareils avant l'accès au réseau
-- Résolution DNS chiffrée pour empêcher le piratage DNS
-- Infrastructure distribuée pour atténuer les attaques DDoS
-- Architecture évolutive avec des composants découplés
-- Intégration avec les systèmes existants de gestion des identités et des accès
-- Prend en charge divers modèles de déploiement (client-à-passerelle, client-à-serveur, etc.)
-- Sécurité cryptographique avec des algorithmes modernes (ECC, Noise Protocol, IBC)
-
-<details>
-<summary>Cliquez pour développer les détails des fonctionnalités</summary>
-
-- **Contrôle d'accès par défaut** : Toutes les ressources sont cachées par défaut, ne devenant accessibles qu'après authentification et autorisation.
-- **Authentification basée sur l'identité et les appareils** : Garantit que seuls les utilisateurs connus sur des appareils approuvés peuvent accéder.
-- **Résolution DNS chiffrée** : Empêche le piratage DNS et les attaques de phishing associées.
-- **Atténuation des DDoS** : Conception d'infrastructure distribuée aide à protéger contre les attaques par DDoS.
-- **Architecture évolutive** : Les composants découplés permettent un déploiement et une évolution flexibles.
-- **Intégration IAM** : Fonctionne avec vos systèmes de gestion des identités et des accès.
-- **Déploiement flexible** : Prend en charge divers modèles, y compris client-à-passerelle, client-à-serveur, et plus encore.
-- **Cryptographie forte** : Utilise des algorithmes modernes comme ECC, Noise Protocol, et IBC pour une sécurité robuste.
-</details>
-
-## Déploiement
-
-OpenNHP prend en charge plusieurs modèles de déploiement pour répondre à différents cas d'utilisation :
-
-- Client-à-Passerelle : Sécurise l'accès à plusieurs serveurs derrière une passerelle
-- Client-à-Serveur : Sécurise directement des serveurs/applications individuels
-- Serveur-à-Serveur : Sécurise la communication entre les services backend
-- Passerelle-à-Passerelle : Sécurise les connexions site-à-site
-
-> Veuillez consulter la [documentation OpenNHP](https://docs.opennhp.org/deploy/) pour des instructions de déploiement détaillées.
-
-## Comparaison entre SPA et NHP
-Le protocole d'Autorisation par Paquet Unique (SPA) est inclus dans la [spécification du Périmètre Défini par Logiciel (SDP)](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) publiée par l'[Alliance pour la Sécurité Cloud (CSA)](https://cloudsecurityalliance.org/). NHP améliore la sécurité, la fiabilité, la scalabilité et l'extensibilité grâce à un cadre et une architecture de cryptographie modernes, comme démontré dans l'article de recherche [AHAC](https://www.mdpi.com/2076-3417/14/13/5593).
-
-| - | SPA | NHP | Avantages de NHP |
-|:---|:---|:---|:---|
-| **Architecture** | Le déchiffrement du paquet SPA et le composant d'authentification de l'utilisateur/appareil sont couplés au composant de contrôle d'accès réseau dans le serveur SPA. | NHP-Server (le composant de déchiffrement de paquet et d'authentification utilisateur/appareil) et NHP-AC (le composant de contrôle d'accès) sont découplés. NHP-Server peut être déployé sur des hôtes distincts et prend en charge la mise à l'échelle horizontale. | <ul><li>Performance : le composant gourmand en ressources NHP-server est séparé du serveur protégé.</li><li>Scalabilité : NHP-server peut être déployé en mode distribué ou en cluster.</li><li>Sécurité : l'adresse IP du serveur protégé n'est pas visible par le client tant que l'authentification n'a pas réussi.</li></ul>|
-| **Communication** | Simple direction | Bidirectionnelle | Meilleure fiabilité avec la notification d'état du contrôle d'accès |
-| **Cadre cryptographique** | Secrets partagés | PKI ou IBC, Cadre Noise | <ul><li>Sécurité : mécanisme éprouvé d'échange de clés pour atténuer les menaces MITM</li><li>Coût faible : distribution efficace des clés pour le modèle de zéro confiance</li><li>Performance : chiffrement/déchiffrement haute performance</li></ul>|
-| **Capacité de Masquage de l'Infrastructure Réseau** | Uniquement les ports de serveur | Domaines, IP et ports | Plus puissant contre diverses attaques (e.g., vulnérabilités, piratage DNS, et attaques DDoS) |
-| **Extensibilité** | Aucune, uniquement pour SDP | Tout usage | Prise en charge de tout scénario nécessitant un obscurcissement de service |
-| **Interopérabilité** | Non disponible | Personnalisable | NHP peut s'intégrer de manière transparente avec les protocoles existants (e.g., DNS, FIDO, etc.) |
-
-## Contribuer
-
-Nous accueillons avec plaisir les contributions à OpenNHP ! Veuillez consulter nos [lignes directrices de contribution](CONTRIBUTING.md) pour plus d'informations sur la manière de participer.
-
-## Licence
-
-OpenNHP est publié sous la [licence Apache 2.0](LICENSE).
-
-## Contact
-
-- Site Web du Projet : [https://github.com/OpenNHP/opennhp](https://github.com/OpenNHP/opennhp)
-- E-mail : [opennhp@gmail.com](mailto:opennhp@gmail.com)
-- Discord : [Rejoignez notre Discord](https://discord.gg/CpyVmspx5x)
-
-Pour plus de documentation détaillée, veuillez visiter notre [Documentation Officielle](https://opennhp.org).
-
-## Références
-
-- [Spécification du Périmètre Défini par Logiciel (SDP) v2.0](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2). Jason Garbis, Juanita Koilpillai, Junaid lslam, Bob Flores, Daniel Bailey, Benfeng Chen, Eitan Bremler, Michael Roza, Ahmed Refaey Hussein. [*Cloud Security Alliance (CSA)*](https://cloudsecurityalliance.org/). Mar 2022.
-- [AHAC : Cadre Avancé de Contrôle d'Accès Caché au Réseau](https://www.mdpi.com/2076-3417/14/13/5593). Mudi Xu, Benfeng Chen, Zhizhong Tan, Shan Chen, Lei Wang, Yan Liu, Tai Io San, Sou Wang Fong, Wenyong Wang, et Jing Feng. *Journal des Sciences Appliquées*. Juin 2024.
-- [STALE : Un schéma d'authentification transfrontalière évolutif et sécurisé tirant parti du courrier électronique et de l'échange de clés ECDH](https://www.mdpi.com/2079-9292/14/12/2399) Jiexin Zheng, Mudi Xu, Jianqing Li, Benfeng Chen, Zhizhong Tan, Anyu Wang, Shuo Zhang, Yan Liu, Kevin Qi Zhang, Lirong Zheng, et Wenyong Wang. *électronique*. Juin 2025.
-- [DRL-AMIR : Planification intelligente des flux pour les réseaux de confiance zéro définis par logiciel](https://www.techscience.com/cmc/v84n2/62920) WenLong Ke, Zilong Li, Peiyu Chen, Benfeng Chen, Jinglin Lv, Qiang Wang, Ziyi Jia et Shigen Shen. *CMC*. Juillet 2025.
-[méthode de contrôle du trafic réseau de NHP basée sur l’apprentissage par renforcement profond](https://www.nature.com/articles/s41598-025-31556-3). Qinglin Huang, Zhizhong Tan, Qiang Wang, Ziyi Jia et Benfeng Chen. *rapports scientifiques par Nature* décembre 2025.
-- Noise Protocol Framework. https://noiseprotocol.org/
-- Projet de Cadre de Gestion des Vulnérabilités. https://phoenix.security/web-vuln-management/
+> Pour les détails du protocole, les modèles de déploiement et la conception cryptographique, consultez la [documentation](https://docs.opennhp.org).
 
 ---
 
-🌟 Merci pour votre intérêt dans OpenNHP ! Nous attendons vos contributions et vos commentaires avec impatience.
+## Structure du dépôt
 
+```
+opennhp/
+├── nhp/              # Bibliothèque principale du protocole (module Go)
+│   ├── core/         # Traitement des paquets, cryptographie, protocole Noise, gestion des périphériques
+│   ├── common/       # Types partagés et définitions de messages
+│   ├── utils/        # Fonctions utilitaires
+│   ├── plugins/      # Interfaces des gestionnaires de plugins
+│   ├── log/          # Infrastructure de journalisation
+│   └── etcd/         # Support de configuration distribuée
+└── endpoints/        # Implémentations des daemons (module Go, dépend de nhp)
+    ├── agent/        # Daemon NHP-Agent
+    ├── server/       # Daemon NHP-Server
+    ├── ac/           # Daemon NHP-AC (contrôleur d'accès)
+    ├── db/           # NHP-DB (Data Broker pour DHP)
+    ├── kgc/          # Key Generation Center (IBC)
+    └── relay/        # Relais TCP
+```
+
+---
+
+## Démarrage rapide
+
+### Prérequis
+
+- Go 1.25.6+
+- `make`
+- Docker et Docker Compose (pour la démo complète)
+
+### Construction
+
+```bash
+# Construire tous les composants
+make
+
+# Construire les daemons individuellement
+make agentd    # NHP-Agent
+make serverd   # NHP-Server
+make acd       # NHP-AC
+make db        # NHP-DB
+make kgc       # Key Generation Center
+```
+
+### Tests
+
+```bash
+cd nhp && go test ./...
+cd endpoints && go test ./...
+```
+
+### Exécution avec Docker
+
+```bash
+cd docker && docker-compose up --build
+```
+
+Suivez le [tutoriel de démarrage rapide](https://docs.opennhp.org/nhp_quick_start/) pour simuler le workflow d'authentification complet dans un environnement Docker.
+
+---
+
+## Contribuer
+
+Les contributions sont les bienvenues ! Veuillez lire [CONTRIBUTING.md](CONTRIBUTING.md) avant de soumettre une Pull Request.
+
+**Remarque :** tous les commits doivent être signés avec une clé GPG ou SSH vérifiée.
+
+```bash
+git commit -S -m "your message"
+```
+
+---
+
+## Sécurité
+
+Vous avez trouvé une vulnérabilité ? Merci de suivre le processus de divulgation responsable décrit dans [SECURITY.md](SECURITY.md) plutôt que d'ouvrir un ticket public.
+
+---
+
+## Sponsors
+
+<a href="https://layerv.ai">
+  <img src="docs/images/layerv_logo.png" height="40" alt="LayerV.ai logo">
+</a>
+
+---
+
+## Licence
+
+Publié sous [licence Apache 2.0](LICENSE).
+
+## Contact
+
+- E-mail : [support@opennhp.org](mailto:support@opennhp.org)
+- Discord : [Rejoindre notre Discord](https://discord.gg/CpyVmspx5x)
+- Site web : [https://opennhp.org](https://opennhp.org)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,151 +1,176 @@
 [![en](https://img.shields.io/badge/lang-en-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.md)
 [![zh-cn](https://img.shields.io/badge/lang-zh--cn-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-cn.md)
+[![zh-tw](https://img.shields.io/badge/lang-zh--tw-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-tw.md)
 [![de](https://img.shields.io/badge/lang-de-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.de.md)
 [![ja](https://img.shields.io/badge/lang-ja-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.ja.md)
 [![fr](https://img.shields.io/badge/lang-fr-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.fr.md)
 [![es](https://img.shields.io/badge/lang-es-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.es.md)
 
 ![OpenNHP Logo](docs/images/logo11.png)
-# OpenNHP: ゼロトラストネットワークインフラストラクチャ隠蔽プロトコル
-攻撃者からサーバーとデータを隠すためのOSI第5層に位置する、軽量の暗号化駆動型ゼロトラストネットワークプロトコルです。
 
-![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
+# OpenNHP：オープンソースのゼロトラスト・セキュリティ・ツールキット
+
+[![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
+[![Release](https://img.shields.io/github/v/tag/OpenNHP/opennhp?label=release)](https://github.com/OpenNHP/opennhp/tags)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green)
+[![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
+
+**OpenNHP** は軽量かつ暗号技術を基盤としたオープンソースのツールキットであり、インフラ・アプリケーション・データに対してゼロトラスト・セキュリティを実現します。[**クラウドセキュリティアライアンス（CSA）**](https://cloudsecurityalliance.org/) の *[Network-infrastructure Hiding Protocol（NHP）仕様](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)* のリファレンス実装であり、次の 2 つのコアプロトコルを備えています：
+
+- **Network-infrastructure Hiding Protocol（NHP）：** サーバーのポート、IP アドレス、ドメイン名を隠蔽し、アプリケーションやインフラを不正アクセスから保護します。
+- **Data-content Hiding Protocol（DHP）：** 暗号化とコンフィデンシャル・コンピューティングによりデータのセキュリティとプライバシーを確保し、データを*「使えるが見えない」*状態にします。
+
+**[ウェブサイト](https://opennhp.org) · [ドキュメント](https://docs.opennhp.org) · [ライブデモ](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 
-## セキュリティの利点
+## なぜ OpenNHP か
 
-OpenNHPは*OSIセッション層*でゼロトラストの原則を実装しているため、次のような大きな利点があります。
+現代のインターネットは[暗黒森林](https://en.wikipedia.org/wiki/Dark_forest_hypothesis)です。攻撃者は—— LLM の力を得て [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) により機械的なスピードでスキャン、フィンガープリンティング、エクスプロイトを実行し——到達可能なすべてのサービスを標的とみなします。[Gartner は](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI 駆動型サイバー攻撃が急増すると予測しています。従来の防御策はネットワークにユーザーを通した *後* に認証を行うため、露出したポート、IP、ドメインは永続的な攻撃面となり続けます。
 
-- インフラの隠蔽による攻撃面の削減
-- 不正なネットワーク偵察の防止
-- 脆弱性の悪用を防ぐ
-- 暗号化されたDNSによるフィッシング防止
-- DDoS攻撃に対する防御
-- 細粒度のアクセス制御を実現
-- アイデンティティベースの接続追跡
-- 攻撃の帰属
+OpenNHP はこのモデルを反転させます：**信頼されるまで不可視**。すべてのポート、IP、ホスト名はデフォルト拒否のゲートの背後に置かれます。アクセスが許可されるのは、暗号署名された「ノック」がアウトオブバンドで認証・認可された後に限られます。攻撃者は発見できないものを悪用できません。
+
+### 第 3 世代のネットワーク隠蔽プロトコル
+
+NHP は「まずサービスを隠す」という設計思想の次なる一歩です：
+
+| 世代 | プロトコル | 制限事項 |
+|---|---|---|
+| 1 | ポートノッキング（Port Knocking） | 平文、リプレイ攻撃に弱い |
+| 2 | Single Packet Authorization（SPA） | 共有秘密、一方向通信、通常はポートのみを隠蔽、多くが C/C++ 実装 |
+| **3** | **NHP** | 現代的な暗号、ステータス付きの双方向通信、ドメイン + IP + ポートを隠蔽、ステートレスで水平スケール可能、メモリ安全な Go |
+
+NHP は既存の IAM、DNS、FIDO、ゼロトラスト・ポリシーエンジンを置き換えるのではなく、それらと並んで動作します——スタックをフォークせず拡張します。
+
+---
 
 ## アーキテクチャ
 
-OpenNHPのアーキテクチャは[NISTゼロトラストアーキテクチャ標準](https://www.nist.gov/publications/zero-trust-architecture)に触発されています。以下の図に示すように、3つの主要なコンポーネント（**NHP-Server**、**NHP-AC**、**NHP-Agent**）を持つモジュール設計に従います。
+OpenNHP は [NIST ゼロトラスト・アーキテクチャ](https://www.nist.gov/publications/zero-trust-architecture) を参考に、3 つのコアコンポーネントから成るモジュラー設計を採用しています：
 
 ![OpenNHP architecture](docs/images/OpenNHP_Arch.gif)
 
-> アーキテクチャとワークフローの詳細については、[OpenNHPドキュメント](https://docs.opennhp.org/)を参照してください。
+| コンポーネント | 役割 |
+|-----------|------|
+| **NHP-Agent** | 暗号化された「ノック」リクエストを送信し、アクセスを得るクライアント |
+| **NHP-Server** | リクエストを認証・認可。独立して稼働し、保護対象ホストとアーキテクチャ上分離されている |
+| **NHP-AC** | 保護対象サーバーのファイアウォール・ルールを管理するアクセス・コントローラ |
 
-## コア: 暗号化アルゴリズム
+### プロトコル・フロー
 
-暗号化はOpenNHPの中心にあり、強力なセキュリティ、高いパフォーマンス、およびスケーラビリティを提供するために最新の暗号化アルゴリズムを利用しています。以下は、OpenNHPで使用されている主要な暗号化アルゴリズムとフレームワークです。
+1. Agent が暗号化されたノック（`NHP_KNK`）を Server に送信する。
+2. Server がノックを検証し、操作リクエスト（`NHP_AOP`）を AC に送る。
+3. AC がファイアウォールを開き、Server に応答（`NHP_ART`）する。
+4. Server が Agent にアクセス情報を含む確認応答（`NHP_ACK`）を返す。
+5. Agent は AC を通して保護対象リソースに到達する。
 
-- **[楕円曲線暗号（ECC）](https://en.wikipedia.org/wiki/Elliptic-curve_cryptography)**：効率的な公開鍵暗号に使用されています。
+### 暗号方式
 
-> RSAと比較して、ECCは短い鍵長で強力な暗号化を提供し、ネットワーク伝送と計算パフォーマンスを向上させます。以下の表は、RSAとECCのセキュリティ強度、鍵長、および鍵長の比率の違いを示し、それぞれの有効期間を示しています。
+OpenNHP は 2 つの互換可能な暗号スイートを提供します：
 
-| セキュリティ強度（ビット） | DSA/RSA鍵長（ビット） | ECC鍵長（ビット） | 比率：ECC対DSA/RSA | 有効期限 |
-|:------------------------:|:-------------------------:|:---------------------:|:----------------------:|:--------:|
-| 80                       | 1024                      | 160-223               | 1:6                    | 2010年まで |
-| 112                      | 2048                      | 224-255               | 1:9                    | 2030年まで |
-| 128                      | 3072                      | 256-383               | 1:12                   | 2031年以降 |
-| 192                      | 7680                      | 384-511               | 1:20                   | |
-| 256                      | 15360                     | 512+                  | 1:30                   | |
+- **`CIPHER_SCHEME_CURVE`** —— Curve25519 + AES-256-GCM + BLAKE2s
+- **`CIPHER_SCHEME_GMSM`** —— SM2 + SM4-GCM + SM3
 
-- **[ノイズプロトコルフレームワーク](https://noiseprotocol.org/)**：安全な鍵交換、メッセージの暗号化/復号化、および相互認証を可能にします。
+いずれも [Noise Protocol Framework](https://noiseprotocol.org/) に基づきます。Identity-Based Cryptography（IBC）モードは Key Generation Center（KGC）経由で利用できます。
 
-> ノイズプロトコルは[ディフィー・ヘルマン鍵共有](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)に基づいており、相互およびオプションの認証、アイデンティティの隠蔽、前方秘匿性、ゼロラウンドトリップ暗号化などの最新の暗号化ソリューションを提供します。そのセキュリティとパフォーマンスは、[WhatsApp](https://www.whatsapp.com/security/WhatsApp-Security-Whitepaper.pdf)、[Slack](https://github.com/slackhq/nebula)、および[WireGuard](https://www.wireguard.com/)などの人気アプリケーションで既に証明されています。
-
-- **[アイデンティティベース暗号（IBC）](https://en.wikipedia.org/wiki/Identity-based_cryptography)**：大規模な鍵配布を簡素化します。
-
-> 効率的な鍵配布は、ゼロトラストの実装に不可欠です。OpenNHPはPKIとIBCの両方をサポートしています。PKIは数十年にわたって広く使用されてきましたが、アイデンティティの確認と鍵管理に中央集権的な認証局（CA）に依存しており、時間とコストがかかることがあります。一方、IBCは、アイデンティティの確認と鍵管理を分散型で自己管理可能な方法で行うことができ、リアルタイムで何十億ものデバイスやサーバーを保護し、オンボーディングする必要があるOpenNHPのゼロトラスト環境において、よりコスト効率的です。
-
-- **[証明書レス公開鍵暗号（CL-PKC）](https://en.wikipedia.org/wiki/Certificateless_cryptography)**：推奨されるIBCアルゴリズム
-
-> CL-PKCは、鍵エスクローを回避し、アイデンティティベース暗号（IBC）の制限に対処することでセキュリティを強化するスキームです。ほとんどのIBCシステムでは、ユーザーの秘密鍵は鍵生成センター（KGC）によって生成され、これは重大なリスクをもたらします。KGCが侵害された場合、すべてのユーザーの秘密鍵が公開される可能性があり、KGCへの完全な信頼が必要です。CL-PKCは鍵生成プロセスを分割し、KGCは部分的な秘密鍵のみを知っているため、CL-PKCはPKIとIBCの両方の強みを組み合わせ、中央集権的な鍵管理の欠点なしに強力なセキュリティを提供します。
-
-詳細について：
-
-> OpenNHPで使用されている暗号化アルゴリズムの詳細な説明については、[OpenNHPドキュメント](https://docs.opennhp.org/cryptography/)を参照してください。
-
-## 主な機能
-
-- デフォルトで「すべて拒否」ルールを適用することにより、脆弱性の悪用を軽減
-- 暗号化されたDNS解決を通じてフィッシング攻撃を防止
-- インフラの隠蔽によるDDoS攻撃の防御
-- アイデンティティベースの接続による攻撃の帰属
-- 保護されたリソースに対するすべてのアクセスをデフォルトで拒否
-- ネットワークアクセス前にアイデンティティおよびデバイスベースの認証
-- DNSハイジャックを防止するための暗号化されたDNS解決
-- DDoS攻撃を緩和するための分散インフラ
-- 分離されたコンポーネントによるスケーラブルなアーキテクチャ
-- 既存のアイデンティティおよびアクセス管理システムとの統合
-- さまざまな展開モデルをサポート（クライアント対ゲートウェイ、クライアント対サーバーなど）
-- 最新のアルゴリズム（ECC、ノイズプロトコル、IBC）を使用した暗号化によるセキュリティの確保
-
-<details>
-<summary>機能の詳細を表示</summary>
-
-- **デフォルト拒否のアクセス制御**：すべてのリソースはデフォルトで隠蔽され、認証と認可が行われた後にのみアクセス可能になります。
-- **アイデンティティおよびデバイスベースの認証**：既知のユーザーと承認されたデバイスのみがアクセス可能です。
-- **暗号化されたDNS解決**：DNSハイジャックとそれに伴うフィッシング攻撃を防止します。
-- **DDoS緩和**：分散型インフラ設計により、分散型サービス拒否攻撃を防御します。
-- **スケーラブルなアーキテクチャ**：分離されたコンポーネントにより柔軟な展開とスケーリングが可能です。
-- **IAM統合**：既存のアイデンティティおよびアクセス管理システムと連携します。
-- **柔軟な展開**：クライアント対ゲートウェイ、クライアント対サーバーなど、さまざまなモデルをサポートします。
-- **強力な暗号化**：ECC、ノイズプロトコル、IBCなどの最新アルゴリズムを使用して強力なセキュリティを提供します。
-</details>
-
-## 展開
-
-OpenNHPは、さまざまなユースケースに合わせた複数の展開モデルをサポートしています。
-
-- クライアント対ゲートウェイ：ゲートウェイの背後にある複数のサーバーへのアクセスを保護します
-- クライアント対サーバー：個々のサーバー/アプリケーションを直接保護します
-- サーバー対サーバー：バックエンドサービス間の通信を保護します
-- ゲートウェイ対ゲートウェイ：サイト間接続を保護します
-
-> 詳細な展開手順については、[OpenNHPドキュメント](https://docs.opennhp.org/deploy/)を参照してください。
-
-## SPAとNHPの比較
-[クラウドセキュリティアライアンス（CSA）](https://cloudsecurityalliance.org/)がリリースした[ソフトウェア定義境界（SDP）仕様](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2)には、シングルパケット認証（SPA）プロトコルが含まれています。NHPは、最新の暗号化フレームワークとアーキテクチャを通じてセキュリティ、信頼性、スケーラビリティ、拡張性を向上させ、[AHAC研究論文](https://www.mdpi.com/2076-3417/14/13/5593)で示されているように従来の技術の限界を克服しています。
-
-| - | SPA |NHP | NHPの利点  |
-|:---|:---|:---|:---|
-| **アーキテクチャ** | SPAサーバーのパケット復号化およびユーザー/デバイス認証コンポーネントがネットワークアクセス制御コンポーネントと結合されています。 | NHP-Server（パケット復号化およびユーザー/デバイス認証コンポーネント）とNHP-AC（アクセス制御コンポーネント）が分離されています。NHP-Serverは別のホストに展開でき、水平スケーリングをサポートします。 | <ul><li>パフォーマンス：リソース消費の多いコンポーネントNHP-Serverが保護されたサーバーから分離されています。</li><li>スケーラビリティ：NHP-Serverは分散またはクラスター化モードで展開可能です。</li><li>セキュリティ：認証が成功するまでは、保護されたサーバーのIPアドレスがクライアントには見えません。</li></ul>|
-| **通信** | 単方向 | 双方向 | アクセス制御のステータス通知による信頼性の向上 |
-| **暗号化フレームワーク** | 共有シークレット | PKIまたはIBC、ノイズフレームワーク |<ul><li>セキュリティ：MITM脅威を軽減する証明された安全な鍵交換メカニズム</li><li>低コスト：ゼロトラストモデルにおける効率的な鍵配布</li><li>パフォーマンス：高パフォーマンスの暗号化/復号化</li></ul>|
-| **ネットワークインフラストラクチャ隠蔽能力** | サーバーポートのみ | ドメイン、IP、ポート | 脆弱性、DNSハイジャック、DDoS攻撃など、さまざまな攻撃に対する強力な防御 |
-| **拡張性** | なし、SDP専用 | 汎用 | あらゆるサービス暗黒化の必要があるシナリオに対応 |
-| **相互運用性** | 利用不可 | カスタマイズ可能| NHPは既存のプロトコル（例：DNS、FIDOなど）とシームレスに統合可能 |
-
-## コントリビューション
-
-OpenNHPへの貢献を歓迎します！貢献方法の詳細については、[コントリビューションガイドライン](CONTRIBUTING.md)を参照してください。
-
-## ライセンス
-
-OpenNHPは[Apache 2.0ライセンス](LICENSE)の下でリリースされています。
-
-## 連絡先
-
-- プロジェクトウェブサイト：[https://github.com/OpenNHP/opennhp](https://github.com/OpenNHP/opennhp)
-- メール：[opennhp@gmail.com](mailto:opennhp@gmail.com)
-- Discord：[Discordに参加する](https://discord.gg/CpyVmspx5x)
-
-詳細なドキュメントについては、[公式ドキュメント](https://opennhp.org)をご覧ください。
-
-## 参考文献
-
-- [ソフトウェア定義境界（SDP）仕様 v2.0](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2)。Jason Garbis、Juanita Koilpillai、Junaid Islam、Bob Flores、Daniel Bailey、Benfeng Chen、Eitan Bremler、Michael Roza、Ahmed Refaey Hussein。[*クラウドセキュリティアライアンス（CSA）*](https://cloudsecurityalliance.org/)。2022年3月。
-- [AHAC：高度なネットワーク隠蔽アクセス制御フレームワーク](https://www.mdpi.com/2076-3417/14/13/5593)。Mudi Xu、Benfeng Chen、Zhizhong Tan、Shan Chen、Lei Wang、Yan Liu、Tai Io San、Sou Wang Fong、Wenyong Wang、Jing Feng。*応用科学ジャーナル*。2024年6月。
-- [STALE ：電子メールと ECDH 鍵交換を活用したスケーラブルでセキュアなクロスボーダー認証スキーム](https://www.mdpi.com/2079-9292/14/12/2399) Jiexin Zheng, Mudi Xu, Jianqing Li, Benfeng Chen, Zhizhong Tan, Anyu Wang, Shuo Zhang, Yan Liu, Kevin Qi Zhang, Lirong Zheng, Wenyong Wang. *電子ジャーナル*。2025 年 6 月。
-- [DRL—AMIR：ソフトウェア定義ゼロ信頼ネットワークのインテリジェントストリームスケジューリング]（https://www.techscience.com/cmc/v84n2/62920）Wenlong Ke, Zilong Li, Peiyu Chen, Benfeng Chen, Jinglin Lv,Qiang Wang, Ziyi Jia と Shigen Shen 。*コンピュータ材料と連続通信*。2025 年 7 月。
-- [深層強化学習に基づくNHPネットワークトラフィック制御手法](https://www.nature.com/articles/s41598-025-31556-3) Qinglin Huang, Zhizhong Tan, Qiang Wang, Ziyi Jia と Benfeng Chen. 『科学報告』。2025年12月。
-- ノイズプロトコルフレームワーク。https://noiseprotocol.org/
-- 脆弱性管理フレームワークプロジェクト。https://phoenix.security/web-vuln-management/
+> プロトコルの詳細、デプロイメント・モデル、暗号設計については [ドキュメント](https://docs.opennhp.org) をご覧ください。
 
 ---
 
-✨ OpenNHPにご関心をお寄せいただき、ありがとうございます！皆様の貢献とフィードバックをお待ちしております。
+## リポジトリ構成
 
+```
+opennhp/
+├── nhp/              # コアプロトコル・ライブラリ（Go モジュール）
+│   ├── core/         # パケット処理、暗号、Noise プロトコル、デバイス管理
+│   ├── common/       # 共有型とメッセージ定義
+│   ├── utils/        # ユーティリティ関数
+│   ├── plugins/      # プラグイン・ハンドラ・インタフェース
+│   ├── log/          # ロギング基盤
+│   └── etcd/         # 分散設定サポート
+└── endpoints/        # デーモン実装（Go モジュール、nhp に依存）
+    ├── agent/        # NHP-Agent デーモン
+    ├── server/       # NHP-Server デーモン
+    ├── ac/           # NHP-AC（アクセス・コントローラ）デーモン
+    ├── db/           # NHP-DB（DHP のデータ・ブローカー）
+    ├── kgc/          # Key Generation Center（IBC）
+    └── relay/        # TCP リレー
+```
+
+---
+
+## クイックスタート
+
+### 前提条件
+
+- Go 1.25.6+
+- `make`
+- Docker と Docker Compose（フルスタック・デモ用）
+
+### ビルド
+
+```bash
+# すべてのコンポーネントをビルド
+make
+
+# 個別のデーモンをビルド
+make agentd    # NHP-Agent
+make serverd   # NHP-Server
+make acd       # NHP-AC
+make db        # NHP-DB
+make kgc       # Key Generation Center
+```
+
+### テスト
+
+```bash
+cd nhp && go test ./...
+cd endpoints && go test ./...
+```
+
+### Docker で実行
+
+```bash
+cd docker && docker-compose up --build
+```
+
+[クイックスタート・チュートリアル](https://docs.opennhp.org/nhp_quick_start/)に従い、Docker 環境で完全な認証ワークフローをシミュレートしてください。
+
+---
+
+## コントリビューション
+
+コントリビューションを歓迎します！ Pull Request を送る前に [CONTRIBUTING.md](CONTRIBUTING.md) をご一読ください。
+
+**注意：** すべてのコミットは検証済みの GPG または SSH キーで署名されている必要があります。
+
+```bash
+git commit -S -m "your message"
+```
+
+---
+
+## セキュリティ
+
+脆弱性を発見した場合は、公開の issue を開くのではなく、[SECURITY.md](SECURITY.md) に記載された責任ある情報開示プロセスに従ってください。
+
+---
+
+## スポンサー
+
+<a href="https://layerv.ai">
+  <img src="docs/images/layerv_logo.png" height="40" alt="LayerV.ai logo">
+</a>
+
+---
+
+## ライセンス
+
+[Apache 2.0 ライセンス](LICENSE) の下で公開されています。
+
+## お問い合わせ
+
+- メール：[support@opennhp.org](mailto:support@opennhp.org)
+- Discord：[Discord に参加](https://discord.gg/CpyVmspx5x)
+- ウェブサイト：[https://opennhp.org](https://opennhp.org)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![en](https://img.shields.io/badge/lang-en-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.md)
 [![zh-cn](https://img.shields.io/badge/lang-zh--cn-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-cn.md)
+[![zh-tw](https://img.shields.io/badge/lang-zh--tw-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-tw.md)
 [![de](https://img.shields.io/badge/lang-de-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.de.md)
 [![ja](https://img.shields.io/badge/lang-ja-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.ja.md)
 [![fr](https://img.shields.io/badge/lang-fr-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.fr.md)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,222 +1,176 @@
 [![en](https://img.shields.io/badge/lang-en-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.md)
 [![zh-cn](https://img.shields.io/badge/lang-zh--cn-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-cn.md)
+[![zh-tw](https://img.shields.io/badge/lang-zh--tw-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-tw.md)
 [![de](https://img.shields.io/badge/lang-de-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.de.md)
 [![ja](https://img.shields.io/badge/lang-ja-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.ja.md)
 [![fr](https://img.shields.io/badge/lang-fr-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.fr.md)
 [![es](https://img.shields.io/badge/lang-es-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.es.md)
 
 ![OpenNHP Logo](docs/images/logo11.png)
-# OpenNHP: 零信任网络隐身协议
-OpenNHP是一个轻量级、基于加密算法的零信任网络协议，其工作在OSI网络模型第五层，用于隐藏您的服务器和数据，避免被攻击者发现和访问
 
-![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
+# OpenNHP：开源零信任安全工具套件
+
+[![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
+[![Release](https://img.shields.io/github/v/tag/OpenNHP/opennhp?label=release)](https://github.com/OpenNHP/opennhp/tags)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green)
+[![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
+
+**OpenNHP** 是一个轻量级、基于加密技术的开源工具套件，为基础设施、应用和数据提供零信任安全保障。它是[**云安全联盟（CSA）**](https://cloudsecurityalliance.org/) *[网络基础设施隐藏协议（NHP）规范](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)*的参考实现，包含两项核心协议：
+
+- **网络基础设施隐藏协议（NHP）：** 隐藏服务器端口、IP 地址和域名，防止应用和基础设施被未授权访问。
+- **数据内容隐藏协议（DHP）：** 通过加密和机密计算保障数据安全与隐私，实现数据*"可用而不可见"*。
+
+**[官方网站](https://opennhp.org) · [文档](https://docs.opennhp.org) · [在线演示](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 
-## 挑战：AI 将互联网变为“黑暗森林”
+## 为什么选择 OpenNHP
 
-**AI** 技术的快速发展，尤其是大语言模型（LLM），正在显著改变网络安全格局。**自主漏洞利用（AVE）** 的兴起是 AI 时代的一个重大飞跃，大大简化了漏洞的利用，这一点在[这篇研究论文](https://arxiv.org/abs/2404.08144)中有详细说明。这一发展显著增加了任何暴露网络服务的风险，与互联网的[黑暗森林假说](https://en.wikipedia.org/wiki/Dark_forest_hypothesis)不谋而合。AI 驱动的工具不断扫描数字环境，迅速识别和利用弱点。因此，互联网正逐渐成为一个**“黑暗森林”**，**可见性意味着脆弱性**。
+当今的互联网是一片[黑暗森林](https://en.wikipedia.org/wiki/Dark_forest_hypothesis)。攻击者——越来越多地借助大语言模型（LLM）通过[自主漏洞利用（AVE）](https://arxiv.org/abs/2404.08144)以机器速度进行扫描、指纹识别和漏洞利用——将所有可达的服务都视为攻击目标。[Gartner 预测](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI 驱动的网络攻击将快速增长。传统防御仅在*网络放行之后*才对用户进行身份验证，使得暴露的端口、IP 和域名成为永久的攻击面。
 
-![Vulnerability Risks](docs/images/Vul_Risks.png)
+OpenNHP 颠覆了这一模式：**验证之前不可见。** 所有端口、IP 和主机名均置于默认拒绝的门之后。只有经过加密签名的"敲门"请求通过带外认证与授权之后，才会开放访问。攻击者无法利用他们发现不了的东西。
 
-Gartner 研究预测，[AI 驱动的网络攻击将迅速增加](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025)。这一变化要求重新评估传统的网络安全策略，重点放在主动防御、快速响应机制和网络隐藏技术的采用，以保护关键基础设施。
+### 第三代网络隐藏协议
 
----
+NHP 是"先隐藏服务"这一设计思路的下一代演进：
 
-## 快速演示：查看 OpenNHP 的工作原理
+| 代际 | 协议 | 局限 |
+|---|---|---|
+| 1 | 端口敲门（Port Knocking） | 明文传输，易受重放攻击 |
+| 2 | 单包授权（SPA） | 共享密钥、单向通信、通常仅隐藏端口、通常使用 C/C++ 实现 |
+| **3** | **NHP** | 现代加密、带状态的双向通信、同时隐藏域名 + IP + 端口、无状态可水平扩展、内存安全的 Go 实现 |
 
-在深入了解 OpenNHP 的详细信息之前，让我们先来看一个 OpenNHP 如何保护服务器免受未经授权访问的演示。您可以通过访问 https://acdemo.opennhp.org 查看其实际效果。
-
-### 1) 受保护的服务器对未经身份验证的用户“不可见”
-
-默认情况下，任何试图连接受保护服务器的操作都会导致超时错误，因为所有端口都是关闭的，使服务器看起来像是*“离线”*且实际上是“不可见”的。
-
-![OpenNHP Demo](docs/images/OpenNHP_ACDemo0.png)
-
-对服务器进行端口扫描也会返回超时错误。
-
-![OpenNHP Demo](docs/images/OpenNHP_ScanDemo.png)
-
-### 2) 身份验证后，受保护的服务器变得可访问
-
-OpenNHP 支持多种身份验证方法，如 OAuth、SAML、二维码等。为了演示方便，本次演示使用 https://demologin.opennhp.org 上的基本用户名/密码身份验证服务来展示该过程。
-
-![OpenNHP Demo](docs/images/OpenNHP_DemoLogin.png)
-
-点击“登录”按钮后，身份验证成功完成，您会被重定向到受保护的服务器。此时，服务器在您的设备上变得*“可见”*并且可以访问。
-
-![OpenNHP Demo](docs/images/OpenNHP_ACDemo1.png)
+NHP 与现有的 IAM、DNS、FIDO 和零信任策略引擎协同工作，而不是取代它们——它是对现有技术栈的扩展，而非分叉。
 
 ---
-
-## 快速开始: 构建和测试 OpenNHP
-
-按照我们的[快速入门教程](https://docs.opennhp.org/zh-cn/nhp_quick_start/) 构建 OpenNHP 源代码，并在 Docker 环境中进行测试。您将启动自己的 OpenNHP 调试环境，模拟“不可见”的网络隐藏行为并测试身份验证工作流。
-
----
-
-## 愿景：让互联网变得值得信赖
-
-TCP/IP 协议的开放性推动了互联网应用的爆炸式增长，但也暴露了漏洞，使得恶意攻击者可以获得未经授权的访问并利用任何暴露的 IP 地址。尽管 [OSI 网络模型](https://en.wikipedia.org/wiki/OSI_model) 在*第五层（会话层）*定义了连接管理，但在实际中很少有有效的解决方案能够应对这一挑战。
-
-**NHP**，即**“网络基础设施隐藏协议”**，是一种轻量级、基于加密的零信任网络协议，旨在工作于*OSI 会话层*，该层在管理网络可见性和连接方面是最佳选择。NHP 的主要目标是将受保护的资源隐藏于未授权的实体，只允许经过验证的用户通过持续认证访问，从而为更值得信赖的互联网作出贡献。
-
-![Trustworthy Internet](docs/images/TrustworthyCyberspace.png)
-
----
-
-## 解决方案：OpenNHP 解决网络可见性控制问题
-
-**OpenNHP** 是 NHP 协议的开源实现。它基于加密技术，采用安全优先的原则，在*OSI 会话层*实现了真正的零信任架构。
-
-![OpenNHP as the OSI 5th layer](docs/images/OSI_OpenNHP.png)
-
-OpenNHP 构建在早期的网络隐藏技术研究基础之上，利用现代加密框架和架构确保安全性和高性能，从而克服了前代技术的局限性。
-
-| 网络隐藏协议 | 第一代 | 第二代 | 第三代 |
-|:---|:---|:---|:---|
-| **核心技术** | [端口敲门](https://en.wikipedia.org/wiki/Port_knocking) | [单包认证（SPA）](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) | 网络基础设施隐藏协议（NHP） |
-| **身份认证** | 端口序列 | 共享密钥 | 现代加密框架 |
-| **架构** | 无控制平面 | 无控制平面 | 可扩展控制平面 |
-| **功能** | 隐藏端口 | 隐藏端口 | 隐藏端口、IP 和域名 |
-| **访问控制** | IP 层级 | 端口层级 | 应用层级 |
-| **开源项目** | [knock](https://github.com/jvinet/knock) *(C)* | [fwknop](https://github.com/mrash/fwknop) *(C++)* | [OpenNHP](https://github.com/OpenNHP/opennhp) *(Go)* |
-
-> 开发 OpenNHP 选择使用**内存安全**的语言如 *Go*，这一点在[美国政府技术报告](https://www.whitehouse.gov/wp-content/uploads/2024/02/Final-ONCD-Technical-Report.pdf)中得到了强调。有关 **SPA 和 NHP** 之间详细的比较，请参见[下文](#comparison-between-spa-and-nhp)。
-
-## 安全性优势
-
-由于 OpenNHP 在 *OSI 会话层*实现了零信任原则，因此具有显著的优势：
-
-- 通过隐藏基础设施减少攻击面
-- 防止未经授权的网络侦察
-- 减少漏洞利用的可能性
-- 通过加密的 DNS 保护防止钓鱼
-- 抵御 DDoS 攻击
-- 提供细粒度的访问控制
-- 实现基于身份的连接追踪
-- 支持攻击溯源
 
 ## 架构
 
-OpenNHP 的架构受 [NIST 零信任架构标准](https://www.nist.gov/publications/zero-trust-architecture) 启发，采用模块化设计，包含三个核心组件：**NHP-Server**、**NHP-AC** 和 **NHP-Agent**，如下图所示。
+OpenNHP 采用模块化设计，包含三个核心组件，灵感来自 [NIST 零信任架构](https://www.nist.gov/publications/zero-trust-architecture)：
 
 ![OpenNHP architecture](docs/images/OpenNHP_Arch.gif)
 
-> 有关架构和工作流程的详细信息，请参阅 [OpenNHP 文档](https://docs.opennhp.org/)。
+| 组件 | 职责 |
+|-----------|------|
+| **NHP-Agent** | 客户端，发送加密的"敲门"请求以获得访问权限 |
+| **NHP-Server** | 认证并授权请求；独立部署，在架构上与受保护主机解耦 |
+| **NHP-AC** | 访问控制器，管理受保护服务器上的防火墙规则 |
 
-## 核心：加密算法
+### 协议流程
 
-加密是 OpenNHP 的核心，提供强大的安全性、出色的性能和可扩展性，使用了先进的加密算法。以下是 OpenNHP 采用的关键加密算法和框架：
+1. Agent 向 Server 发送加密的敲门请求（`NHP_KNK`）。
+2. Server 校验敲门请求，并向 AC 发送操作请求（`NHP_AOP`）。
+3. AC 打开防火墙，并回复（`NHP_ART`）给 Server。
+4. Server 向 Agent 返回带访问信息的确认（`NHP_ACK`）。
+5. Agent 通过 AC 访问受保护资源。
 
-- **[椭圆曲线密码学（ECC）](https://en.wikipedia.org/wiki/Elliptic-curve_cryptography)**：用于高效的公钥密码学。
+### 加密算法
 
-> 与 RSA 相比，ECC 具有更高的效率，以较短的密钥长度提供更强的加密能力，从而提高网络传输和计算性能。下表显示了 RSA 和 ECC 在安全强度、密钥长度和密钥长度比率上的差异，以及其有效期。
+OpenNHP 提供两种可互换的加密套件：
 
-| 安全强度（位） | DSA/RSA 密钥长度（位） | ECC 密钥长度（位） | 比率：ECC 与 DSA/RSA | 有效期 |
-|:---------------:|:----------------------:|:-----------------:|:------------------:|:------:|
-| 80              | 1024                   | 160-223           | 1:6                | 到 2010 年 |
-| 112             | 2048                   | 224-255           | 1:9                | 到 2030 年 |
-| 128             | 3072                   | 256-383           | 1:12               | 2031 年后 |
-| 192             | 7680                   | 384-511           | 1:20               | |
-| 256             | 15360                  | 512+              | 1:30               | |
+- **`CIPHER_SCHEME_CURVE`** —— Curve25519 + AES-256-GCM + BLAKE2s
+- **`CIPHER_SCHEME_GMSM`** —— SM2 + SM4-GCM + SM3
 
-- **[Noise 协议框架](https://noiseprotocol.org/)**：用于安全的密钥交换、消息加密/解密和相互身份认证。
+两者均基于 [Noise 协议框架](https://noiseprotocol.org/)。基于身份的加密（IBC）模式通过密钥生成中心（KGC）提供。
 
-> Noise 协议基于[Diffie-Hellman 密钥交换](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)，提供了现代加密解决方案，如相互和可选认证、身份隐藏、前向安全性和零轮次加密。它已被 WhatsApp、Slack 和 WireGuard 等应用广泛验证并使用，证明其安全性和性能。
-
-- **[基于身份的加密（IBC）](https://en.wikipedia.org/wiki/Identity-based_cryptography)**：简化了大规模的密钥分发。
-
-> 高效的密钥分发是实现零信任的关键。OpenNHP 支持 PKI 和 IBC。虽然 PKI 已经被广泛使用，但它依赖于集中式的证书颁发机构（CA）进行身份验证和密钥管理，这在时间和成本上较为昂贵。相比之下，IBC 允许在身份验证和密钥管理方面采用去中心化和自我管理的方法，使其在 OpenNHP 的零信任环境中更具成本效益，尤其是在需要实时保护和管理数十亿设备或服务器的情况下。
-
-- **[无证书公钥加密（CL-PKC）](https://en.wikipedia.org/wiki/Certificateless_cryptography)**：推荐的 IBC 算法。
-
-> CL-PKC 是一种通过避免密钥托管和解决基于身份的加密（IBC）局限性来增强安全性的方案。在大多数 IBC 系统中，用户的私钥由密钥生成中心（KGC）生成，这带来了显著的风险。如果 KGC 被攻破，所有用户的私钥都可能被泄露，这要求对 KGC 完全信任。CL-PKC 通过将密钥生成过程分离，使 KGC 仅了解部分私钥，从而避免这一问题。结果，CL-PKC 结合了 PKI 和 IBC 的优点，在不牺牲安全性的情况下提供更强的保护。
-
-更多阅读：
-
-> 有关 OpenNHP 中使用的加密算法的详细说明，请参阅 [OpenNHP 文档](https://docs.opennhp.org/cryptography/)。
-
-## 主要特性
-
-- 通过强制默认“全部拒绝”规则减少漏洞利用
-- 通过加密的 DNS 解决防止钓鱼攻击
-- 通过隐藏基础设施保护免受 DDoS 攻击
-- 通过身份追踪连接实现攻击溯源
-- 对所有受保护资源的默认拒绝访问控制
-- 在网络访问前进行基于身份和设备的身份认证
-- 加密的 DNS 解决防止 DNS 劫持
-- 分布式基础设施抵御 DDoS 攻击
-- 解耦组件实现可扩展架构
-- 与现有身份和访问管理系统集成
-- 支持多种部署模型（客户端到网关、客户端到服务器等）
-- 使用现代算法（ECC、Noise 协议、IBC）进行加密确保安全性
-
-<details>
-<summary>点击展开特性详情</summary>
-
-- **默认拒绝访问控制**：所有资源默认隐藏，只有通过身份验证和授权后才会变得可访问。
-- **基于身份和设备的身份验证**：确保只有已知用户在授权设备上可以访问。
-- **加密的 DNS 解决**：防止 DNS 劫持和相关的钓鱼攻击。
-- **DDoS 缓解**：分布式基础设施设计有助于抵御分布式拒绝服务攻击。
-- **可扩展架构**：解耦组件允许灵活部署和扩展。
-- **IAM 集成**：可以与现有身份和访问管理系统配合使用。
-- **灵活部署**：支持包括客户端到网关、客户端到服务器等多种模型。
-- **强大加密**：使用现代算法如 ECC、Noise 协议和 IBC 确保安全性。
-</details>
-
-## 部署
-
-OpenNHP 支持多种部署模型，以适应不同的使用场景：
-
-- 客户端到网关：保护网关后面的多个服务器的访问
-- 客户端到服务器：直接保护单个服务器/应用
-- 服务器到服务器：保护后端服务之间的通信
-- 网关到网关：保护站点到站点的连接
-
-> 有关详细部署说明，请参阅 [OpenNHP 文档](https://docs.opennhp.org/deploy/)。
-
-## SPA 和 NHP 的比较
-单包认证（SPA）协议被包含在 [软件定义边界（SDP）规范](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2) 中，由 [云安全联盟（CSA）](https://cloudsecurityalliance.org/) 发布。NHP 通过现代加密框架和架构在安全性、可靠性、可扩展性和可扩展性方面进行了改进，这一点在 [AHAC 研究论文](https://www.mdpi.com/2076-3417/14/13/5593) 中得到了验证。
-
-| - | SPA | NHP | NHP 优势 |
-|:---|:---|:---|:---|
-| **架构** | SPA 服务器中的 SPA 数据包解密和用户/设备身份验证组件与网络访问控制组件是耦合的。 | NHP-Server（数据包解密和用户/设备身份验证组件）和 NHP-AC（访问控制组件）是解耦的。NHP-Server 可以部署在独立的主机上，并支持水平扩展。 | <ul><li>性能：资源消耗大的组件 NHP-Server 从受保护服务器分离。</li><li>可扩展性：NHP-Server 可以以分布式或集群模式部署。</li><li>安全性：受保护服务器的 IP 地址在身份验证成功之前对客户端是不可见的。</li></ul> |
-| **通信** | 单向 | 双向 | 更好的可靠性，访问控制状态通知 |
-| **加密框架** | 共享密钥 | PKI 或 IBC，Noise 框架 | <ul><li>安全性：经过验证的安全密钥交换机制，减轻中间人攻击威胁</li><li>低成本：适合零信任模型的高效密钥分发</li><li>性能：高性能加密/解密</li></ul> |
-| **隐藏网络基础设施的能力** | 仅服务器端口 | 域名、IP 和端口 | 更强大，针对各种攻击（如漏洞利用、DNS 劫持和 DDoS 攻击） |
-| **可扩展性** | 无，仅适用于 SDP | 通用 | 支持任何需要服务暗化的场景 |
-| **互操作性** | 不支持 | 可定制 | NHP 可以无缝集成现有协议（如 DNS、FIDO 等） |
-
-## 贡献
-
-我们欢迎对 OpenNHP 的贡献！有关如何参与的更多信息，请参阅我们的[贡献指南](CONTRIBUTING.md)。
-
-## 许可协议
-
-OpenNHP 遵循 [Apache 2.0 许可协议](LICENSE)。
-
-## 联系方式
-
-- 项目网站：[https://github.com/OpenNHP/opennhp](https://github.com/OpenNHP/opennhp)
-- 电子邮件：[opennhp@gmail.com](mailto:opennhp@gmail.com)
-- Discord：[加入我们的 Discord](https://discord.gg/CpyVmspx5x)
-
-有关更详细的文档，请访问我们的[官方网站](https://opennhp.org)。
-
-## 参考文献
-
-- [软件定义边界（SDP）规范 v2.0](https://cloudsecurityalliance.org/artifacts/software-defined-perimeter-zero-trust-specification-v2)。Jason Garbis、Juanita Koilpillai、Junaid lslam、Bob Flores、Daniel Bailey、Benfeng Chen、Eitan Bremler、Michael Roza、Ahmed Refaey Hussein。[*云安全联盟（CSA）*](https://cloudsecurityalliance.org/)。2022 年 3 月。
-- [AHAC：高级网络隐藏访问控制框架](https://www.mdpi.com/2076-3417/14/13/5593)。Mudi Xu、Benfeng Chen、Zhizhong Tan、Shan Chen、Lei Wang、Yan Liu、Tai Io San、Sou Wang Fong、Wenyong Wang 和 Jing Feng。*应用科学杂志*。2024 年 6 月。
-- [STALE：利用电子邮件和ECDH密钥交换的可扩展、安全的跨境认证方案](https://www.mdpi.com/2079-9292/14/12/2399).Jiexin Zheng, Mudi Xu, Jianqing Li, Benfeng Chen, Zhizhong Tan, Anyu Wang, Shuo Zhang, Yan Liu, Kevin Qi Zhang, Lirong Zheng, 和 Wenyong Wang.*电子学报*。2025年6月。
-- [DRL-AMIR：软件定义的零信任网络的智能流调度](https://www.techscience.com/cmc/v84n2/62920).Wenlong Ke, Zilong Li, Peiyu Chen, Benfeng Chen, Jinglin Lv, Qiang Wang, Ziyi Jia 和 Shigen Shen. *计算机材料和连续通信*。2025年7月。
--- [基于深度强化学习的NHP网络流量控制方法](https://www.nature.com/articles/s41598-025-31556-3)。Qinglin Huang, Zhizhong Tan, Qiang Wang, Ziyi Jia 和 Benfeng Chen. *科学报告*。 2025年12月。
-- Noise 协议框架。https://noiseprotocol.org/
-- 漏洞管理框架项目。https://phoenix.security/web-vuln-management/
+> 更多协议细节、部署模型和加密设计，请参阅[官方文档](https://docs.opennhp.org)。
 
 ---
 
-🌟 感谢您对 OpenNHP 的关注！我们期待您的贡献和反馈。
+## 仓库结构
 
+```
+opennhp/
+├── nhp/              # 核心协议库（Go 模块）
+│   ├── core/         # 数据包处理、加密、Noise 协议、设备管理
+│   ├── common/       # 共享类型与消息定义
+│   ├── utils/        # 工具函数
+│   ├── plugins/      # 插件处理接口
+│   ├── log/          # 日志基础设施
+│   └── etcd/         # 分布式配置支持
+└── endpoints/        # 守护进程实现（Go 模块，依赖 nhp）
+    ├── agent/        # NHP-Agent 守护进程
+    ├── server/       # NHP-Server 守护进程
+    ├── ac/           # NHP-AC（访问控制器）守护进程
+    ├── db/           # NHP-DB（DHP 的数据经纪人）
+    ├── kgc/          # 密钥生成中心（IBC）
+    └── relay/        # TCP 中继
+```
+
+---
+
+## 快速开始
+
+### 先决条件
+
+- Go 1.25.6+
+- `make`
+- Docker 与 Docker Compose（用于完整的演示环境）
+
+### 构建
+
+```bash
+# 构建所有组件
+make
+
+# 构建单个守护进程
+make agentd    # NHP-Agent
+make serverd   # NHP-Server
+make acd       # NHP-AC
+make db        # NHP-DB
+make kgc       # 密钥生成中心
+```
+
+### 测试
+
+```bash
+cd nhp && go test ./...
+cd endpoints && go test ./...
+```
+
+### 使用 Docker 运行
+
+```bash
+cd docker && docker-compose up --build
+```
+
+请参考[快速入门教程](https://docs.opennhp.org/nhp_quick_start/)，在 Docker 环境中模拟完整的认证工作流。
+
+---
+
+## 贡献
+
+欢迎贡献代码！提交 Pull Request 前请先阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+**注意：** 所有提交必须使用已验证的 GPG 或 SSH 密钥签名。
+
+```bash
+git commit -S -m "your message"
+```
+
+---
+
+## 安全
+
+发现漏洞了吗？请遵循 [SECURITY.md](SECURITY.md) 中的负责任披露流程，而不是提交公开 issue。
+
+---
+
+## 赞助商
+
+<a href="https://layerv.ai">
+  <img src="docs/images/layerv_logo.png" height="40" alt="LayerV.ai logo">
+</a>
+
+---
+
+## 许可协议
+
+基于 [Apache 2.0 许可协议](LICENSE)发布。
+
+## 联系方式
+
+- 邮箱：[support@opennhp.org](mailto:support@opennhp.org)
+- Discord：[加入我们的 Discord](https://discord.gg/CpyVmspx5x)
+- 官网：[https://opennhp.org](https://opennhp.org)

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -1,0 +1,176 @@
+[![en](https://img.shields.io/badge/lang-en-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.md)
+[![zh-cn](https://img.shields.io/badge/lang-zh--cn-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-cn.md)
+[![zh-tw](https://img.shields.io/badge/lang-zh--tw-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.zh-tw.md)
+[![de](https://img.shields.io/badge/lang-de-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.de.md)
+[![ja](https://img.shields.io/badge/lang-ja-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.ja.md)
+[![fr](https://img.shields.io/badge/lang-fr-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.fr.md)
+[![es](https://img.shields.io/badge/lang-es-green.svg)](https://github.com/OpenNHP/opennhp/blob/master/README.es.md)
+
+![OpenNHP Logo](docs/images/logo11.png)
+
+# OpenNHP：開源零信任安全工具套件
+
+[![Build](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/OpenNHP/opennhp/actions/workflows/ubuntu-build.yml)
+[![Release](https://img.shields.io/github/v/tag/OpenNHP/opennhp?label=release)](https://github.com/OpenNHP/opennhp/tags)
+![License](https://img.shields.io/badge/license-Apache%202.0-green)
+[![codecov](https://codecov.io/gh/OpenNHP/opennhp/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenNHP/opennhp)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenNHP/opennhp)
+
+**OpenNHP** 是一套輕量級、以密碼學為基礎的開源工具套件，為基礎架構、應用程式與資料提供零信任安全保障。它是[**雲端安全聯盟（CSA）**](https://cloudsecurityalliance.org/) *[網路基礎架構隱藏協定（NHP）規範](https://cloudsecurityalliance.org/artifacts/stealth-mode-sdp-for-zero-trust-network-infrastructure)*的參考實作，包含兩項核心協定：
+
+- **網路基礎架構隱藏協定（NHP）：** 隱藏伺服器連接埠、IP 位址與網域名稱，避免應用程式與基礎架構遭未授權存取。
+- **資料內容隱藏協定（DHP）：** 透過加密與機密運算保障資料安全與隱私，使資料*「可用但不可見」*。
+
+**[官方網站](https://opennhp.org) · [文件](https://docs.opennhp.org) · [線上展示](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+
+---
+
+## 為什麼選擇 OpenNHP
+
+當今的網際網路是一座[黑暗森林](https://en.wikipedia.org/wiki/Dark_forest_hypothesis)。攻擊者——日益仰賴大型語言模型（LLM）透過[自主漏洞利用（AVE）](https://arxiv.org/abs/2404.08144)以機器速度進行掃描、指紋辨識與漏洞利用——將每一個可達的服務都視為攻擊目標。[Gartner 預測](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI 驅動的網路攻擊將快速增長。傳統防禦僅在*網路放行之後*才對使用者進行身分驗證，讓暴露的連接埠、IP 與網域成為永久的攻擊面。
+
+OpenNHP 翻轉了這個模式：**驗證前不可見。** 所有連接埠、IP 與主機名稱皆置於預設拒絕的閘門之後。只有經加密簽署的「敲門」請求通過頻外認證與授權後，才會開放存取。攻擊者無法利用他們發現不了的東西。
+
+### 第三代網路隱藏協定
+
+NHP 是「先隱藏服務」這條設計路線的下一代演進：
+
+| 世代 | 協定 | 限制 |
+|---|---|---|
+| 1 | 連接埠敲門（Port Knocking） | 明文傳輸，易受重放攻擊 |
+| 2 | 單封包授權（SPA） | 共享金鑰、單向通訊、通常僅隱藏連接埠、通常以 C/C++ 實作 |
+| **3** | **NHP** | 現代密碼學、具狀態的雙向通訊、同時隱藏網域 + IP + 連接埠、無狀態且可水平擴展、記憶體安全的 Go 實作 |
+
+NHP 與既有的 IAM、DNS、FIDO 與零信任政策引擎並肩運作，而非取代它們——它是對既有技術棧的擴充，而非分支。
+
+---
+
+## 架構
+
+OpenNHP 採模組化設計，包含三個核心元件，設計靈感來自 [NIST 零信任架構](https://www.nist.gov/publications/zero-trust-architecture)：
+
+![OpenNHP architecture](docs/images/OpenNHP_Arch.gif)
+
+| 元件 | 職責 |
+|-----------|------|
+| **NHP-Agent** | 用戶端，發送加密的「敲門」請求以取得存取權限 |
+| **NHP-Server** | 認證與授權請求；獨立部署，在架構上與受保護主機解耦 |
+| **NHP-AC** | 存取控制器，管理受保護伺服器上的防火牆規則 |
+
+### 協定流程
+
+1. Agent 向 Server 發送加密的敲門請求（`NHP_KNK`）。
+2. Server 驗證敲門請求，並向 AC 發送操作請求（`NHP_AOP`）。
+3. AC 開啟防火牆，並回覆（`NHP_ART`）給 Server。
+4. Server 向 Agent 回傳含存取資訊的確認（`NHP_ACK`）。
+5. Agent 透過 AC 存取受保護資源。
+
+### 密碼學
+
+OpenNHP 提供兩套可互換的加密套件：
+
+- **`CIPHER_SCHEME_CURVE`** —— Curve25519 + AES-256-GCM + BLAKE2s
+- **`CIPHER_SCHEME_GMSM`** —— SM2 + SM4-GCM + SM3
+
+兩者皆以 [Noise 協定框架](https://noiseprotocol.org/)為基礎。以身分為基礎的密碼學（IBC）模式透過金鑰產生中心（KGC）提供。
+
+> 更多協定細節、部署模型與密碼學設計，請參閱[官方文件](https://docs.opennhp.org)。
+
+---
+
+## 儲存庫結構
+
+```
+opennhp/
+├── nhp/              # 核心協定函式庫（Go 模組）
+│   ├── core/         # 封包處理、密碼學、Noise 協定、裝置管理
+│   ├── common/       # 共用型別與訊息定義
+│   ├── utils/        # 工具函式
+│   ├── plugins/      # 外掛處理介面
+│   ├── log/          # 日誌基礎架構
+│   └── etcd/         # 分散式設定支援
+└── endpoints/        # 背景程式實作（Go 模組，依賴 nhp）
+    ├── agent/        # NHP-Agent 背景程式
+    ├── server/       # NHP-Server 背景程式
+    ├── ac/           # NHP-AC（存取控制器）背景程式
+    ├── db/           # NHP-DB（DHP 的資料經紀人）
+    ├── kgc/          # 金鑰產生中心（IBC）
+    └── relay/        # TCP 中繼
+```
+
+---
+
+## 快速開始
+
+### 先決條件
+
+- Go 1.25.6+
+- `make`
+- Docker 與 Docker Compose（用於完整展示環境）
+
+### 建置
+
+```bash
+# 建置所有元件
+make
+
+# 建置個別背景程式
+make agentd    # NHP-Agent
+make serverd   # NHP-Server
+make acd       # NHP-AC
+make db        # NHP-DB
+make kgc       # 金鑰產生中心
+```
+
+### 測試
+
+```bash
+cd nhp && go test ./...
+cd endpoints && go test ./...
+```
+
+### 以 Docker 執行
+
+```bash
+cd docker && docker-compose up --build
+```
+
+請依循[快速入門教學](https://docs.opennhp.org/nhp_quick_start/)，在 Docker 環境中模擬完整的認證工作流程。
+
+---
+
+## 貢獻
+
+歡迎貢獻！送出 Pull Request 前請先閱讀 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+**注意：** 所有 commit 必須以已驗證的 GPG 或 SSH 金鑰簽署。
+
+```bash
+git commit -S -m "your message"
+```
+
+---
+
+## 安全
+
+發現漏洞了嗎？請依循 [SECURITY.md](SECURITY.md) 所述的負責任揭露流程，請勿直接提交公開 issue。
+
+---
+
+## 贊助商
+
+<a href="https://layerv.ai">
+  <img src="docs/images/layerv_logo.png" height="40" alt="LayerV.ai logo">
+</a>
+
+---
+
+## 授權條款
+
+依 [Apache 2.0 授權條款](LICENSE)發布。
+
+## 聯絡方式
+
+- 電子郵件：[support@opennhp.org](mailto:support@opennhp.org)
+- Discord：[加入我們的 Discord](https://discord.gg/CpyVmspx5x)
+- 官方網站：[https://opennhp.org](https://opennhp.org)


### PR DESCRIPTION
## Summary

Replaces the five existing translated READMEs (**zh-cn**, **de**, **ja**, **fr**, **es**) with faithful translations of the current English README, and adds a new **Traditional Chinese (zh-tw)** README. The zh-tw language badge is threaded through every language file so readers can switch between all seven languages from any page.

Previously, the translated READMEs were structured very differently from the English one — they carried additional sections (Vision, Solution, SPA/NHP comparison table, academic references) that didn't exist in the English version, creating a permanent divergence where translations led English. This PR brings all seven language versions to structural parity with the canonical English README:

- Language badges + project badges
- Intro (CSA spec link + NHP/DHP bullets + navigation)
- **Why OpenNHP** (dark forest / AI-era framing, third-generation protocol table)
- **Architecture** (component table, protocol flow, cryptography)
- **Repository Structure**
- **Quick Start** (prereqs, build, test, Docker)
- **Contributing**, **Security**, **Sponsors**, **License**, **Contact**

Technical content (product names, message types like `NHP_KNK`, code blocks, file paths, badge URLs) is preserved verbatim across all languages.

## Language notes

- **zh-tw** uses Traditional characters with Taiwan dialect terminology (伺服器, 網路, 連接埠, 金鑰, 資訊, 軟體 etc.) rather than a mechanical character conversion from zh-cn.
- **ja** uses natural Japanese technical writing conventions; protocol/product names stay in Latin script.
- **de/fr/es** preserve technical protocol names (NHP, DHP, SPA) untranslated, in line with the norm for cryptography docs.

## Test plan

- [ ] Render each README on GitHub and verify formatting (tables, code blocks, links).
- [ ] Verify the seven language badges link to their respective README files.
- [ ] Spot-check technical terms (cipher suite strings, message type names, paths) are identical across languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)