### PR TITLE
docs(readme): state the VISIBILITY = VULNERABILITY thesis explicitly

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -29,6 +29,8 @@
 
 Das moderne Internet ist ein [dunkler Wald](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Angreifer – zunehmend unterstützt durch LLMs, die mittels [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) in Maschinengeschwindigkeit scannen, Fingerprinting betreiben und ausnutzen – behandeln jeden erreichbaren Dienst als Ziel. [Gartner prognostiziert](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025), dass KI-gestützte Cyberangriffe rasant zunehmen werden. Herkömmliche Verteidigungsmaßnahmen authentifizieren Nutzer erst *nachdem* das Netzwerk sie hereingelassen hat, sodass offene Ports, IPs und Domains zur dauerhaften Angriffsfläche werden.
 
+> **Im KI-Zeitalter gilt: SICHTBARKEIT = VERWUNDBARKEIT.**
+
 OpenNHP dreht dieses Modell um: **unsichtbar bis vertrauenswürdig.** Jeder Port, jede IP und jeder Hostname liegt hinter einem Default-Deny-Gate. Zugriff wird erst nach einem kryptographisch signierten Knock gewährt, der außerhalb des Datenkanals authentifiziert und autorisiert wurde. Angreifer können nicht ausnutzen, was sie nicht entdecken können.
 
 ### Das Netzwerkverstecker-Protokoll der dritten Generation

--- a/README.es.md
+++ b/README.es.md
@@ -29,6 +29,8 @@
 
 La internet moderna es un [bosque oscuro](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Los atacantes —respaldados cada vez más por LLMs que escanean, toman huellas y explotan a velocidad de máquina mediante [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144)— tratan todo servicio alcanzable como un objetivo. [Gartner prevé](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) un rápido aumento de los ciberataques impulsados por IA. Las defensas tradicionales autentican a los usuarios *después* de que la red los deja entrar, dejando los puertos, IPs y dominios expuestos como una superficie de ataque permanente.
 
+> **En la era de la IA, VISIBILIDAD = VULNERABILIDAD.**
+
 OpenNHP invierte ese modelo: **invisible hasta la confianza**. Cada puerto, IP y nombre de host se sitúa detrás de una puerta de denegación por defecto. El acceso se concede solo después de que un «golpe en la puerta» firmado criptográficamente haya sido autenticado y autorizado fuera de banda. Los atacantes no pueden explotar lo que no pueden descubrir.
 
 ### El protocolo de ocultación de red de tercera generación

--- a/README.fr.md
+++ b/README.fr.md
@@ -29,6 +29,8 @@
 
 L'internet moderne est une [forêt sombre](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Les attaquants — de plus en plus soutenus par des LLM qui scannent, identifient et exploitent à la vitesse de la machine via l'[Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) — considèrent chaque service accessible comme une cible. [Gartner prévoit](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) une hausse rapide des cyberattaques pilotées par l'IA. Les défenses traditionnelles authentifient les utilisateurs *après* que le réseau les ait laissés entrer, laissant les ports, IP et domaines exposés comme une surface d'attaque permanente.
 
+> **À l'ère de l'IA, VISIBILITÉ = VULNÉRABILITÉ.**
+
 OpenNHP inverse ce modèle : **invisible jusqu'à la confiance**. Chaque port, IP et nom d'hôte est placé derrière une porte refusant tout par défaut. L'accès n'est accordé qu'après qu'un « toc-toc » cryptographiquement signé a été authentifié et autorisé hors bande. Les attaquants ne peuvent pas exploiter ce qu'ils ne peuvent pas découvrir.
 
 ### Le protocole de masquage réseau de troisième génération

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,6 +29,8 @@
 
 現代のインターネットは[暗黒森林](https://en.wikipedia.org/wiki/Dark_forest_hypothesis)です。攻撃者は—— LLM の力を得て [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) により機械的なスピードでスキャン、フィンガープリンティング、エクスプロイトを実行し——到達可能なすべてのサービスを標的とみなします。[Gartner は](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI 駆動型サイバー攻撃が急増すると予測しています。従来の防御策はネットワークにユーザーを通した *後* に認証を行うため、露出したポート、IP、ドメインは永続的な攻撃面となり続けます。
 
+> **AI 時代において、可視性 = 脆弱性。**
+
 OpenNHP はこのモデルを反転させます：**信頼されるまで不可視**。すべてのポート、IP、ホスト名はデフォルト拒否のゲートの背後に置かれます。アクセスが許可されるのは、暗号署名された「ノック」がアウトオブバンドで認証・認可された後に限られます。攻撃者は発見できないものを悪用できません。
 
 ### 第 3 世代のネットワーク隠蔽プロトコル

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 
 The modern internet is a [dark forest](https://en.wikipedia.org/wiki/Dark_forest_hypothesis). Attackers — increasingly backed by LLMs that scan, fingerprint, and exploit at machine speed via [Autonomous Vulnerability Exploitation](https://arxiv.org/abs/2404.08144) — treat every reachable service as a target. [Gartner projects](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI-driven cyberattacks will rise rapidly. Traditional defenses authenticate users *after* the network lets them in, leaving exposed ports, IPs, and domains as a permanent attack surface.
 
+> **In the AI era, VISIBILITY = VULNERABILITY.**
+
 OpenNHP inverts that model: **invisible until trusted.** Every port, IP, and hostname sits behind a default-deny gate. Access is granted only after a cryptographically signed knock is authenticated and authorized out-of-band. Attackers can't exploit what they can't discover.
 
 ### The third-generation network hiding protocol

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -29,6 +29,8 @@
 
 当今的互联网是一片[黑暗森林](https://en.wikipedia.org/wiki/Dark_forest_hypothesis)。攻击者——越来越多地借助大语言模型（LLM）通过[自主漏洞利用（AVE）](https://arxiv.org/abs/2404.08144)以机器速度进行扫描、指纹识别和漏洞利用——将所有可达的服务都视为攻击目标。[Gartner 预测](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI 驱动的网络攻击将快速增长。传统防御仅在*网络放行之后*才对用户进行身份验证，使得暴露的端口、IP 和域名成为永久的攻击面。
 
+> **在 AI 时代，可见性 = 脆弱性。**
+
 OpenNHP 颠覆了这一模式：**验证之前不可见。** 所有端口、IP 和主机名均置于默认拒绝的门之后。只有经过加密签名的"敲门"请求通过带外认证与授权之后，才会开放访问。攻击者无法利用他们发现不了的东西。
 
 ### 第三代网络隐藏协议

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -29,6 +29,8 @@
 
 當今的網際網路是一座[黑暗森林](https://en.wikipedia.org/wiki/Dark_forest_hypothesis)。攻擊者——日益仰賴大型語言模型（LLM）透過[自主漏洞利用（AVE）](https://arxiv.org/abs/2404.08144)以機器速度進行掃描、指紋辨識與漏洞利用——將每一個可達的服務都視為攻擊目標。[Gartner 預測](https://www.gartner.com/en/newsroom/press-releases/2024-08-28-gartner-forecasts-global-information-security-spending-to-grow-15-percent-in-2025) AI 驅動的網路攻擊將快速增長。傳統防禦僅在*網路放行之後*才對使用者進行身分驗證，讓暴露的連接埠、IP 與網域成為永久的攻擊面。
 
+> **在 AI 時代，可見性 = 脆弱性。**
+
 OpenNHP 翻轉了這個模式：**驗證前不可見。** 所有連接埠、IP 與主機名稱皆置於預設拒絕的閘門之後。只有經加密簽署的「敲門」請求通過頻外認證與授權後，才會開放存取。攻擊者無法利用他們發現不了的東西。
 
 ### 第三代網路隱藏協定


### PR DESCRIPTION
## Summary

Follow-up to #1500. The **"VISIBILITY = VULNERABILITY in the AI era"** line is the core thesis of OpenNHP and was only implicit in the dark-forest paragraph. This PR adds it as an explicit blockquote callout between the threat description and the solution inversion, across all seven language versions.

- Latin-alphabet languages (en, de, fr, es) capitalise the two key nouns for emphasis.
- CJK versions (zh-cn, zh-tw, ja) use bold only since those scripts have no case.

## Test plan

- [ ] Render each README on GitHub and verify the blockquote renders as a prominent callout.
- [ ] Confirm the thesis appears in all seven language versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)