### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-demo-v2.yml
+++ b/.github/workflows/deploy-demo-v2.yml
@@ -11,6 +11,9 @@
 
 name: Deploy Demo v2
 
+permissions:
+  contents: read
+
 # Manual-only. Deploying binaries to the production demo is a risky action
 # (key material, firewall state, live service) so we require an operator to
 # explicitly dispatch this workflow rather than auto-running on push.


### PR DESCRIPTION
Potential fix for [https://github.com/OpenNHP/opennhp/security/code-scanning/15](https://github.com/OpenNHP/opennhp/security/code-scanning/15)

Add an explicit `permissions` block at the workflow root so all jobs (including `summary`) get a restricted baseline token scope. The safest non-breaking baseline is:

- `contents: read`

This preserves typical read access needed by actions while avoiding broad write defaults. Jobs requiring elevated permissions can continue to override at job level (as `deploy-jsagent` already does with `id-token: write`).

**Where to change:** `.github/workflows/deploy-demo-v2.yml`, directly after `name: Deploy Demo v2` (before `on:`).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
