### PR TITLE
docs: add Vision link to README navigation

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -21,7 +21,7 @@
 - **Network-infrastructure Hiding Protocol (NHP):** Verbirgt Server-Ports, IP-Adressen und Domainnamen, um Anwendungen und Infrastruktur vor unbefugtem Zugriff zu schützen.
 - **Data-content Hiding Protocol (DHP):** Sorgt für Datensicherheit und -vertraulichkeit durch Verschlüsselung und Confidential Computing, sodass Daten *„nutzbar, aber nicht sichtbar"* werden.
 
-**[Website](https://opennhp.org) · [Dokumentation](https://docs.opennhp.org) · [Live-Demo](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[Website](https://opennhp.org) · [Vision](https://opennhp.org/vision/) · [Live-Demo](https://opennhp.org/demo/) · [Dokumentation](https://docs.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -21,7 +21,7 @@
 - **Network-infrastructure Hiding Protocol (NHP):** oculta puertos del servidor, direcciones IP y nombres de dominio para proteger aplicaciones e infraestructura frente a accesos no autorizados.
 - **Data-content Hiding Protocol (DHP):** garantiza la seguridad y la privacidad de los datos mediante cifrado y confidential computing, haciendo que los datos sean *«utilizables pero no visibles»*.
 
-**[Sitio web](https://opennhp.org) · [Documentación](https://docs.opennhp.org) · [Demo en vivo](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[Sitio web](https://opennhp.org) · [Visión](https://opennhp.org/vision/) · [Demo en vivo](https://opennhp.org/demo/) · [Documentación](https://docs.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -21,7 +21,7 @@
 - **Network-infrastructure Hiding Protocol (NHP) :** dissimule les ports serveur, les adresses IP et les noms de domaine pour protéger les applications et l'infrastructure contre les accès non autorisés.
 - **Data-content Hiding Protocol (DHP) :** assure la sécurité et la confidentialité des données grâce au chiffrement et au confidential computing, rendant les données *« utilisables mais invisibles »*.
 
-**[Site web](https://opennhp.org) · [Documentation](https://docs.opennhp.org) · [Démo en direct](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[Site web](https://opennhp.org) · [Vision](https://opennhp.org/vision/) · [Démo en direct](https://opennhp.org/demo/) · [Documentation](https://docs.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@
 - **Network-infrastructure Hiding Protocol（NHP）：** サーバーのポート、IP アドレス、ドメイン名を隠蔽し、アプリケーションやインフラを不正アクセスから保護します。
 - **Data-content Hiding Protocol（DHP）：** 暗号化とコンフィデンシャル・コンピューティングによりデータのセキュリティとプライバシーを確保し、データを*「使えるが見えない」*状態にします。
 
-**[ウェブサイト](https://opennhp.org) · [ドキュメント](https://docs.opennhp.org) · [ライブデモ](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[ウェブサイト](https://opennhp.org) · [ビジョン](https://opennhp.org/vision/) · [ライブデモ](https://opennhp.org/demo/) · [ドキュメント](https://docs.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **Network-infrastructure Hiding Protocol (NHP):** Conceals server ports, IP addresses, and domain names to protect applications and infrastructure from unauthorized access.
 - **Data-content Hiding Protocol (DHP):** Ensures data security and privacy via encryption and confidential computing, making data *"usable but not visible."*
 
-**[Website](https://opennhp.org) · [Documentation](https://docs.opennhp.org) · [Live Demo](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[Website](https://opennhp.org) · [Vision](https://opennhp.org/vision/) · [Live Demo](https://opennhp.org/demo/) · [Documentation](https://docs.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -21,7 +21,7 @@
 - **网络基础设施隐藏协议（NHP）：** 隐藏服务器端口、IP 地址和域名，防止应用和基础设施被未授权访问。
 - **数据内容隐藏协议（DHP）：** 通过加密和机密计算保障数据安全与隐私，实现数据*"可用而不可见"*。
 
-**[官方网站](https://opennhp.org) · [文档](https://docs.opennhp.org) · [在线演示](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[官方网站](https://opennhp.org) · [愿景](https://opennhp.org/vision/) · [在线演示](https://opennhp.org/demo/) · [文档](https://docs.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -21,7 +21,7 @@
 - **網路基礎架構隱藏協定（NHP）：** 隱藏伺服器連接埠、IP 位址與網域名稱，避免應用程式與基礎架構遭未授權存取。
 - **資料內容隱藏協定（DHP）：** 透過加密與機密運算保障資料安全與隱私，使資料*「可用但不可見」*。
 
-**[官方網站](https://opennhp.org) · [文件](https://docs.opennhp.org) · [線上展示](https://opennhp.org/demo/) · [Discord](https://discord.gg/CpyVmspx5x)**
+**[官方網站](https://opennhp.org) · [願景](https://opennhp.org/vision/) · [線上展示](https://opennhp.org/demo/) · [文件](https://docs.opennhp.org) · [Discord](https://discord.gg/CpyVmspx5x)**
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Vision link (https://opennhp.org/vision/) to quick navigation in all README files
- New link order: Website · Vision · Live Demo · Documentation · Discord
- Updated all 7 language versions (en, zh-cn, zh-tw, de, ja, fr, es)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify Vision link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)