### PR TITLE
feat(server-plugin): polish basic auth-plugin demo page

### DIFF
--- a/examples/server_plugin/basic/etc/resource.toml
+++ b/examples/server_plugin/basic/etc/resource.toml
@@ -34,5 +34,5 @@ PortSuffix = false
 
 # extra information as per-plugin defined fields
 ["demo".ExInfo]
-Title = "OpenNHP Demo - Authentication"
+Title = "OpenNHP Auth Plugin Demo - Authentication"
 

--- a/examples/server_plugin/basic/templates/example_login.html
+++ b/examples/server_plugin/basic/templates/example_login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenNHP Demo - Authentication</title>
+    <title>OpenNHP Auth Plugin Demo - Authentication</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&family=Outfit:wght@300;400;600;700&display=swap" rel="stylesheet">
@@ -32,19 +32,35 @@
             font-family: 'Outfit', sans-serif;
             min-height: 100vh;
             display: flex;
-            justify-content: center;
-            align-items: center;
+            flex-direction: column;
             background: var(--bg-primary);
             background-image:
                 radial-gradient(ellipse at 20% 20%, rgba(0, 212, 255, 0.08) 0%, transparent 50%),
                 radial-gradient(ellipse at 80% 80%, rgba(0, 255, 136, 0.06) 0%, transparent 50%),
                 linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-            padding: 2rem;
+            padding: 1.25rem 2rem 2rem 2rem;
+        }
+
+        .page-header {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            max-width: 720px;
+            margin: 0 auto 1rem auto;
+        }
+
+        .page-header-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+            flex-wrap: wrap;
         }
 
         .container {
-            max-width: 520px;
+            max-width: 720px;
             width: 100%;
+            margin: 0 auto;
             background: var(--bg-card);
             backdrop-filter: blur(20px);
             border: 1px solid var(--border-color);
@@ -62,8 +78,17 @@
         }
 
         .language-select {
-            text-align: right;
-            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            margin: 0;
+        }
+
+        .language-icon {
+            width: 16px;
+            height: 16px;
+            fill: var(--text-secondary);
+            flex-shrink: 0;
         }
 
         .language-select select {
@@ -91,9 +116,8 @@
         .logo-title {
             display: flex;
             align-items: center;
-            justify-content: center;
             gap: 0.75rem;
-            margin-bottom: 0.5rem;
+            margin: 0;
         }
 
         .logo-title img {
@@ -109,41 +133,80 @@
         }
 
         .subtitle {
-            text-align: center;
             font-size: 0.85rem;
             color: var(--text-secondary);
-            margin-bottom: 1rem;
+            line-height: 1.5;
+            margin: 0.5rem 0 0 0;
+        }
+        .subtitle a {
+            color: var(--accent-cyan);
+            text-decoration: none;
+        }
+        .subtitle a:hover { text-decoration: underline; }
+
+        /* In-container section heading (e.g. "Basic Auth") */
+        .section-header {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 1rem;
+            flex-wrap: wrap;
+            margin-bottom: 1.25rem;
+        }
+
+        .section-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin: 0;
+        }
+
+        .section-source {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            text-decoration: none;
+            margin: 0;
+        }
+
+        .section-source:hover {
+            color: var(--accent-cyan);
+            text-decoration: underline;
         }
 
         .server-info {
-            padding: 0.5rem 0;
-            margin-bottom: 1rem;
+            width: 100%;
+            max-width: 720px;
+            margin: 0 auto 1rem auto;
+            padding: 1rem 1.5rem;
             text-align: center;
+            background: rgba(0, 212, 255, 0.06);
+            border: 1px solid rgba(0, 212, 255, 0.25);
+            border-radius: 12px;
         }
 
         .server-info-row {
             display: flex;
             flex-direction: column;
             align-items: center;
-            gap: 0.5rem;
+            gap: 0.6rem;
         }
 
         .server-url-part {
             display: flex;
             align-items: center;
             justify-content: center;
-            gap: 0.5rem;
+            gap: 0.6rem;
             flex-wrap: wrap;
         }
 
         .server-url-part span {
             color: var(--text-secondary);
-            font-size: 0.8rem;
+            font-size: 1rem;
         }
 
         .server-url-part a {
             font-family: 'JetBrains Mono', monospace;
-            font-size: 0.75rem;
+            font-size: 0.95rem;
             color: var(--accent-cyan);
             text-decoration: none;
         }
@@ -153,11 +216,11 @@
         }
 
         .scan-link {
-            font-size: 0.65rem;
+            font-size: 0.85rem;
             font-family: 'Outfit', sans-serif !important;
             color: var(--accent-green);
             text-decoration: none;
-            padding: 0.15rem 0.4rem;
+            padding: 0.25rem 0.6rem;
             background: rgba(0, 255, 136, 0.1);
             border-radius: 4px;
         }
@@ -166,30 +229,24 @@
             background: rgba(0, 255, 136, 0.2);
         }
 
-        .status-part {
+        .server-scan-part {
             display: flex;
             align-items: center;
             justify-content: center;
-            gap: 1rem;
-            font-size: 0.75rem;
+            gap: 0.6rem;
+            flex-wrap: wrap;
+            font-size: 0.9rem;
         }
 
-        .status-item {
-            display: flex;
-            align-items: center;
-            gap: 0.3rem;
-        }
-
-        .status-label {
+        .scan-hint {
             color: var(--text-secondary);
+            font-style: italic;
         }
 
-        .status-value.timeout {
-            color: var(--accent-red);
-        }
-
-        .status-value.success {
-            color: var(--accent-green);
+        .scan-hint strong {
+            color: var(--accent-orange);
+            font-weight: 700;
+            font-style: normal;
         }
 
         /* Auth Methods Section */
@@ -197,6 +254,33 @@
             display: flex;
             flex-direction: column;
             gap: 0.6rem;
+        }
+
+        .auth-method {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .auth-method > .auth-btn {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .auth-source {
+            flex-shrink: 0;
+            font-size: 0.7rem;
+            color: var(--text-secondary);
+            text-decoration: none;
+            padding: 0 0.25rem;
+            text-align: right;
+            line-height: 1.3;
+        }
+
+        .auth-source:hover {
+            color: var(--accent-cyan);
+            text-decoration: underline;
         }
 
         .auth-btn {
@@ -462,38 +546,41 @@
     </style>
 </head>
 <body>
-    <div class="container" id="mainContainer">
-        <div class="language-select" id="languageSelectContainer">
-            <select id="languageSelect" onchange="changeLanguage()">
-                <option value="en">English</option>
-                <option value="zh">中文</option>
-                <option value="es">Español</option>
-            </select>
-        </div>
-
-        <div class="logo-title">
-            <img src="https://raw.githubusercontent.com/OpenNHP/opennhp/main/docs/images/logo10.png" alt="OpenNHP Logo">
-            <h1 id="title">OpenNHP Demo</h1>
-        </div>
-        
-        <div class="server-info" id="serverInfoBox">
-            <div class="server-info-row">
-                <div class="server-url-part">
-                    <span id="protectedServerLabel">Protected Server:</span>
-                    <a href="https://ac.opennhp.org" target="_blank">https://ac.opennhp.org</a>
-                    <a href="https://dnschecker.org/port-scanner.php?query=ac.opennhp.org&ptype=server" target="_blank" class="scan-link" id="scanPortsLink">Scan Ports</a>
-                </div>
-                <div class="status-part">
-                    <div class="status-item">
-                        <span class="status-label" id="beforeLogin">Before:</span>
-                        <span class="status-value timeout" id="timeoutStatus">Invisible</span>
-                    </div>
-                    <div class="status-item">
-                        <span class="status-label" id="afterLogin">After:</span>
-                        <span class="status-value success" id="successStatus">Accessible</span>
-                    </div>
-                </div>
+    <header class="page-header">
+        <div class="page-header-row">
+            <div class="logo-title">
+                <img src="https://raw.githubusercontent.com/OpenNHP/opennhp/main/docs/images/logo10.png" alt="OpenNHP Logo">
+                <h1 id="title">OpenNHP Auth Plugin Demo</h1>
             </div>
+            <div class="language-select" id="languageSelectContainer">
+                <svg class="language-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95c-.32-1.25-.78-2.45-1.38-3.56 1.84.63 3.37 1.91 4.33 3.56zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56-1.84-.63-3.37-1.9-4.33-3.56zm2.95-8H5.08c.96-1.66 2.49-2.93 4.33-3.56C8.81 5.55 8.35 6.75 8.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2 0-.68.07-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95c-.96 1.65-2.49 2.93-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"/></svg>
+                <select id="languageSelect" onchange="changeLanguage()" aria-label="Language" title="Language">
+                    <option value="en">English</option>
+                    <option value="zh">中文</option>
+                    <option value="es">Español</option>
+                </select>
+            </div>
+        </div>
+        <p class="subtitle" id="subtitle">This demo shows how to build a nhp-server plugin that authenticates users before granting access to a protected resource. The plugin runs on the nhp-server itself — simple to implement, but it exposes the nhp-server to clients. For higher security, route authentication through a nhp-agent instead.</p>
+    </header>
+
+    <div class="server-info" id="serverInfoBox">
+        <div class="server-info-row">
+            <div class="server-url-part">
+                <span id="protectedServerLabel">Protected Server:</span>
+                <a href="https://ac.opennhp.org" target="_blank" rel="noopener">https://ac.opennhp.org</a>
+            </div>
+            <div class="server-scan-part">
+                <span class="scan-hint" id="scanHint"><strong>Invisible</strong> by default, scan its ports to verify</span>
+                <a href="https://dnschecker.org/port-scanner.php?query=ac.opennhp.org&ptype=server" target="_blank" rel="noopener" class="scan-link" id="scanPortsLink">Scan Ports</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="container" id="mainContainer">
+        <div class="section-header">
+            <h2 class="section-title" id="basicAuthTitle">Basic Auth</h2>
+            <a class="section-source" id="basicAuthSource" href="https://github.com/OpenNHP/opennhp/tree/main/examples/server_plugin/basic" target="_blank" rel="noopener">View plugin source on GitHub</a>
         </div>
 
         <!-- Password Login Section -->
@@ -518,20 +605,26 @@
 
         <!-- Alternative Auth Methods -->
         <div class="auth-methods" id="authMethods">
-            <a href="https://nhp.opennhp.org/plugins/oidc?resid=demo&action=login" class="auth-btn sso">
-                <svg viewBox="0 0 24 24"><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"/></svg>
-                <div class="auth-btn-content">
-                    <span class="auth-btn-title" id="ssoBtn">Single Sign-On</span>
-                    <span class="auth-btn-desc" id="ssoDesc">OpenID Connect</span>
-                </div>
-            </a>
-            <a href="https://otplogin.opennhp.org/" class="auth-btn otp">
-                <svg viewBox="0 0 24 24"><path d="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zm0 18H7V5h10v14zm-5-1c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1zm-3-4h6v-2H9v2zm0-4h6V8H9v2z"/></svg>
-                <div class="auth-btn-content">
-                    <span class="auth-btn-title" id="otpBtn">One-Time Password</span>
-                    <span class="auth-btn-desc" id="otpDesc">Authenticator App</span>
-                </div>
-            </a>
+            <div class="auth-method">
+                <a href="https://nhp.opennhp.org/plugins/oidc?resid=demo&action=login" class="auth-btn sso">
+                    <svg viewBox="0 0 24 24"><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"/></svg>
+                    <div class="auth-btn-content">
+                        <span class="auth-btn-title" id="ssoBtn">Single Sign-On</span>
+                        <span class="auth-btn-desc" id="ssoDesc">OpenID Connect</span>
+                    </div>
+                </a>
+                <a href="https://github.com/OpenNHP/opennhp/tree/main/examples/server_plugin/oidc" target="_blank" rel="noopener" class="auth-source" id="ssoSource">View plugin source on GitHub</a>
+            </div>
+            <div class="auth-method">
+                <a href="https://otplogin.opennhp.org/" class="auth-btn otp">
+                    <svg viewBox="0 0 24 24"><path d="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zm0 18H7V5h10v14zm-5-1c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1zm-3-4h6v-2H9v2zm0-4h6V8H9v2z"/></svg>
+                    <div class="auth-btn-content">
+                        <span class="auth-btn-title" id="otpBtn">One-Time Password</span>
+                        <span class="auth-btn-desc" id="otpDesc">Authenticator App</span>
+                    </div>
+                </a>
+                <a href="https://github.com/OpenNHP/opennhp/tree/main/examples/server_plugin/authenticator" target="_blank" rel="noopener" class="auth-source" id="otpSource">View plugin source on GitHub</a>
+            </div>
         </div>
 
         <!-- Success Message -->
@@ -561,14 +654,12 @@
     <script>
         const translations = {
             en: {
-                title: "OpenNHP Demo",
-                subtitle: "Zero Trust Network Access",
+                title: "OpenNHP Auth Plugin Demo",
+                subtitle: 'This demo shows how to build a nhp-server plugin that authenticates users before granting access to a protected resource. The plugin runs on the nhp-server itself — simple to implement, but it exposes the nhp-server to clients. For higher security, route authentication through a nhp-agent instead.',
+                basicAuthTitle: "Basic Auth",
                 protectedServer: "Protected Server:",
                 scanPorts: "Scan Ports",
-                beforeLogin: "Before login:",
-                afterLogin: "After login:",
-                timeoutStatus: "Invisible",
-                successStatus: "Accessible",
+                scanHint: "<strong>Invisible</strong> by default, scan its ports to verify",
                 usernameLabel: "Username",
                 passwordLabel: "Password",
                 loginButton: "Sign In",
@@ -577,20 +668,19 @@
                 ssoDesc: "OpenID Connect",
                 otpBtn: "One-Time Password",
                 otpDesc: "Authenticator App",
+                pluginSource: "View plugin source on GitHub",
                 authSuccess: "Authentication Succeeded!",
                 redirectMessage: "You can now access",
                 timeUnit: "seconds",
                 welcomeMessage: "Redirecting in"
             },
             zh: {
-                title: "OpenNHP 演示",
-                subtitle: "零信任网络访问",
+                title: "OpenNHP 认证插件演示",
+                subtitle: '本演示展示如何开发 nhp-server 插件：先对用户进行身份认证，再授权访问受保护的资源。该插件直接运行在 nhp-server 上，实现简单，但会向客户端暴露 nhp-server；若需更高安全性，建议通过 nhp-agent 完成认证。',
+                basicAuthTitle: "基本认证",
                 protectedServer: "受保护服务器：",
                 scanPorts: "端口扫描",
-                beforeLogin: "登录前：",
-                afterLogin: "登录后：",
-                timeoutStatus: "不可见",
-                successStatus: "可访问",
+                scanHint: "默认<strong>不可见</strong>，可扫描端口验证",
                 usernameLabel: "用户名",
                 passwordLabel: "密码",
                 loginButton: "登录",
@@ -599,20 +689,19 @@
                 ssoDesc: "OpenID Connect",
                 otpBtn: "动态密码",
                 otpDesc: "Authenticator App",
+                pluginSource: "查看插件源码（GitHub）",
                 authSuccess: "认证成功！",
                 redirectMessage: "您现在可以访问",
                 timeUnit: "秒后跳转",
                 welcomeMessage: ""
             },
             es: {
-                title: "OpenNHP Demo",
-                subtitle: "Acceso de Red Zero Trust",
+                title: "OpenNHP Auth Plugin Demo",
+                subtitle: 'Esta demostración muestra cómo crear un plugin de nhp-server que autentica a los usuarios antes de permitir el acceso a un recurso protegido. El plugin se ejecuta en el propio nhp-server: es fácil de implementar, pero lo expone a los clientes. Para mayor seguridad, realiza la autenticación a través de un nhp-agent.',
+                basicAuthTitle: "Autenticación Básica",
                 protectedServer: "Servidor Protegido:",
                 scanPorts: "Escanear Puertos",
-                beforeLogin: "Antes:",
-                afterLogin: "Después:",
-                timeoutStatus: "Invisible",
-                successStatus: "Accesible",
+                scanHint: "<strong>Invisible</strong> por defecto, escanea sus puertos para verificar",
                 usernameLabel: "Usuario",
                 passwordLabel: "Contraseña",
                 loginButton: "Iniciar Sesión",
@@ -621,6 +710,7 @@
                 ssoDesc: "OpenID Connect",
                 otpBtn: "Contraseña de Un Solo Uso",
                 otpDesc: "Authenticator App",
+                pluginSource: "Ver código fuente del plugin en GitHub",
                 authSuccess: "¡Autenticación Exitosa!",
                 redirectMessage: "Ahora puedes acceder a",
                 timeUnit: "segundos",
@@ -634,12 +724,12 @@
             const t = translations[lang];
 
             document.getElementById('title').textContent = t.title;
+            document.getElementById('subtitle').textContent = t.subtitle;
+            document.getElementById('basicAuthTitle').textContent = t.basicAuthTitle;
+            document.getElementById('basicAuthSource').textContent = t.pluginSource;
             document.getElementById('protectedServerLabel').textContent = t.protectedServer;
             document.getElementById('scanPortsLink').textContent = t.scanPorts;
-            document.getElementById('beforeLogin').textContent = t.beforeLogin;
-            document.getElementById('afterLogin').textContent = t.afterLogin;
-            document.getElementById('timeoutStatus').textContent = t.timeoutStatus;
-            document.getElementById('successStatus').textContent = t.successStatus;
+            document.getElementById('scanHint').innerHTML = t.scanHint;
             document.getElementById('usernameLabel').textContent = t.usernameLabel;
             document.getElementById('passwordLabel').textContent = t.passwordLabel;
             document.getElementById('loginButton').textContent = t.loginButton;
@@ -648,6 +738,8 @@
             document.getElementById('ssoDesc').textContent = t.ssoDesc;
             document.getElementById('otpBtn').textContent = t.otpBtn;
             document.getElementById('otpDesc').textContent = t.otpDesc;
+            document.getElementById('ssoSource').textContent = t.pluginSource;
+            document.getElementById('otpSource').textContent = t.pluginSource;
         }
 
         function nhpValidate() {


### PR DESCRIPTION
## Summary
Reworks the basic plugin's login page (deployed at auth-plugin.opennhp.org) into a clearer onboarding surface for developers writing their own nhp-server auth plugin.

- **Layout.** Title + language switcher + explanatory subtitle moved into a page-level `<header>` aligned with the main container width (720px). The "Protected Server: ac.opennhp.org" status is lifted into its own emphasized card above the login form.
- **Subtitle.** Now explains that the plugin runs on the nhp-server itself (simple to implement but exposes nhp-server) and points to nhp-agent as the more secure pattern.
- **Section heading.** "Basic Auth" + inline "View plugin source on GitHub" link (→ `examples/server_plugin/basic`) at the top of the login container; matching per-card source links for the SSO (`/oidc`) and OTP (`/authenticator`) auth methods.
- **Status row.** Replaced "Before/After Auth: Invisible/Accessible" pair with a single "**Invisible** by default, scan its ports to verify" hint (the "Invisible" word highlighted in accent-orange) and an enlarged Scan Ports pill.
- **Title rename.** Browser tab, page H1, and `resource.toml` Title field: `OpenNHP Demo` → `OpenNHP Auth Plugin Demo`.
- **Header globe icon** next to the language `<select>`, with `aria-label="Language"` to satisfy the a11y linter.
- **Container width** bumped 520px → 720px to fit the longer subtitle and the new inline section header without wrapping.

i18n: en / zh / es kept in sync across all updated strings (subtitle, scanHint, basicAuthTitle, pluginSource, etc.).

## Test plan
- [ ] Hit auth-plugin.opennhp.org after the next `deploy-server` workflow run; verify the new layout, the Protected Server card, and the inline "Basic Auth + source" header
- [ ] Switch language between English / 中文 / Español and confirm subtitle, scanHint (with bold "Invisible"/不可见), section title, and source-link labels all update
- [ ] Click "Scan Ports" — link should open dnschecker.org in a new tab
- [ ] Click each "View plugin source on GitHub" link — confirm they open `examples/server_plugin/{basic,oidc,authenticator}` respectively
- [ ] Sign in with the demo `user` / `password` and verify the existing success / redirect flow still works
- [ ] Verify mobile (≤520px viewport) — header should wrap (lang select drops below title), no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)