### PR TITLE
ci(release-please): use GitHub App token for signed commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,16 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - name: Release Please
         uses: googleapis/release-please-action@v5
         with:
           release-type: go
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Switch `release-please.yml` from a personal access token + (no-op) GPG import to a **GitHub App token** so commits authored by release-please are auto-marked `Verified` by GitHub.

## Background

The previous workflow had a `crazy-max/ghaction-import-gpg` step intended to sign release-please commits, but **it never worked**: `googleapis/release-please-action@v5` creates commits via the GitHub Contents API and never invokes local `git`, so the GPG config had no effect on its output. Every release-please commit landed unsigned, and main's "Require signed commits" rule then blocked release PRs (most recently #1385) — the only escape hatch was an admin manually amending and force-pushing the bot's branch.

## How the new approach works

Commits authored by GitHub Apps are automatically signed by GitHub itself and shown as `Verified` in the web UI. By generating a short-lived App installation token (via `actions/create-github-app-token@v1`) and passing it to release-please-action, every commit it produces will satisfy branch protection without any signing logic on our side.

## Required repo configuration

Already configured prior to this PR:

- `vars.RELEASE_PLEASE_APP_ID` — App ID (public-safe)
- `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY` — App private key (`.pem`)

The App is `opennhp-release-please`, installed on `OpenNHP/opennhp` with `Contents: R/W`, `Pull requests: R/W`, `Metadata: R`.

## Cleanup

- Removed the dead `Import GPG key` step.
- Left `secrets.GPG_PRIVATE_KEY` / `secrets.GPG_PASSPHRASE` untouched (they may be referenced by other workflows; can be retired later in a separate PR).

## Test plan

- [ ] CI passes on this PR (this PR doesn't itself run release-please)
- [ ] After merge, next push to main triggers release-please workflow
- [ ] release-please updates PR #1385 with a new commit
- [ ] That commit is marked **Verified** in GitHub's UI
- [ ] PR #1385 becomes mergeable (no longer "Commits must have verified signatures" blocker)