### PR TITLE
chore: skip bot Claude reviews + target v0.7.2

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       (github.event.action == 'opened' || github.event.action == 'synchronize') &&
-      github.actor != 'dependabot[bot]'
+      !endsWith(github.actor, '[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Two small, related cleanups that prepare the way for a clean v0.7.2 release.

## Summary

### 1. Skip Claude auto-review for any bot-authored PR

Now that release-please runs as `opennhp-release-please[bot]` (after the GitHub App switch in #1530), every release PR fails Claude's "non-human actor" guard with a noisy red ❌. Bot-authored PRs are mechanically generated (release-please changelogs, dependabot bumps, future automation), so skipping them keeps the review queue focused on human changes.

```diff
- github.actor != 'dependabot[bot]'
+ !endsWith(github.actor, '[bot]')
```

### 2. Pin the next release to v0.7.2

release-please currently computes 0.8.0 from the conventional commits since v0.7.1, but the changes are incremental (UX polish, doc tweaks, dep bumps) — a patch bump is more honest. Adding a `Release-As: 0.7.2` trailer overrides the auto-computed version on the next workflow run, exactly the same pattern used to land v0.7.1.

## Test plan
- [ ] CI passes
- [ ] On merge, release-please workflow runs with `opennhp-release-please[bot]`, claude-pr-review is skipped (not failed)
- [ ] PR #1531 updates from `chore(main): release 0.8.0` to `chore(main): release 0.7.2`, commit still shows ✓ Verified
- [ ] Merging #1531 will then drive the v0.7.2 release