### PR TITLE
fix(js-agent): prevent protected server section from wrapping to two lines

### DIFF
--- a/endpoints/js-agent/examples/relay-test.html
+++ b/endpoints/js-agent/examples/relay-test.html
@@ -294,7 +294,6 @@
       border-radius: 6px;
       margin-bottom: 12px;
       font-size: 13px;
-      flex-wrap: wrap;
     }
     .protected-target .label { color: #8b949e; font-size: 13px; }
     .protected-target .target-url {


### PR DESCRIPTION
## Summary
- Remove `flex-wrap: wrap` from `.protected-target` CSS class so all elements stay on a single line

## Test plan
- [ ] Verify the "Protected Server" section displays on one line in the demo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)