### PR TITLE
fix(noise): never carry zeroed intermediate chain key between packets

### DIFF
--- a/nhp/core/derive_chainkey_test.go
+++ b/nhp/core/derive_chainkey_test.go
@@ -1,0 +1,160 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/OpenNHP/opennhp/nhp/common"
+)
+
+// TestDerivePacketParserData_DoesNotCarryChainKey and its
+// responder-side twin fence the chain-key fix: the derive functions
+// must never copy the previous transaction's chainKey into the new
+// MAD/PPD. The intermediate-chain-key carry-over design was
+// abandoned; encryptBody/decryptBody defer-zero the chainKey on the
+// way out, so any surviving copy() in derive* picks up a zeroed
+// buffer in Go-Go (which both ends symmetrically "agree on") but
+// breaks JS-Go interop because a spec-following JS implementation
+// does not replicate the zero-carry-over quirk.
+//
+// Asymmetric assertion: the parent (MAD/PPD) is seeded with a
+// non-zero sentinel; the child must come out zero. The newly
+// allocated child struct starts zero by default, so this only
+// fails if derive* *actively* copies the sentinel — which is
+// exactly the regression we want to fence. Do not "fix" the
+// asymmetry by also seeding the child; the test would then no
+// longer distinguish "derive copied" from "derive did nothing".
+func TestDerivePacketParserData_DoesNotCarryChainKey(t *testing.T) {
+	dev := newDeviceForChainKeyTest(t)
+
+	mad := &MsgAssemblerData{
+		device:       dev,
+		CipherScheme: common.CIPHER_SCHEME_CURVE,
+		ciphers:      NewCipherSuite(common.CIPHER_SCHEME_CURVE),
+	}
+	for i := range mad.chainKey {
+		mad.chainKey[i] = 0xAB
+	}
+
+	pkt := dev.AllocatePoolPacket()
+	if pkt == nil {
+		t.Fatal("AllocatePoolPacket returned nil")
+	}
+	t.Cleanup(func() { dev.ReleasePoolPacket(pkt) })
+
+	ppd := mad.derivePacketParserData(pkt, time.Now().UnixNano())
+
+	var zero [SymmetricKeySize]byte
+	if ppd.chainKey != zero {
+		t.Errorf("derivePacketParserData copied chainKey from parent MAD — chain-key fix regression. ppd.chainKey=%x", ppd.chainKey)
+	}
+}
+
+func TestDeriveMsgAssemblerData_DoesNotCarryChainKey(t *testing.T) {
+	dev := newDeviceForChainKeyTest(t)
+
+	ppd := &PacketParserData{
+		device:       dev,
+		CipherScheme: common.CIPHER_SCHEME_CURVE,
+		Ciphers:      NewCipherSuite(common.CIPHER_SCHEME_CURVE),
+	}
+	for i := range ppd.chainKey {
+		ppd.chainKey[i] = 0xCD
+	}
+
+	mad := ppd.deriveMsgAssemblerData(NHP_ACK, false, nil)
+	if mad == nil {
+		t.Fatal("deriveMsgAssemblerData returned nil")
+	}
+	t.Cleanup(func() { mad.Destroy() })
+
+	var zero [SymmetricKeySize]byte
+	if mad.chainKey != zero {
+		t.Errorf("deriveMsgAssemblerData copied chainKey from parent PPD — chain-key fix regression. mad.chainKey=%x", mad.chainKey)
+	}
+}
+
+// TestCreateMsgAssemblerData_InitsCanonicalChainKey fences the
+// other regression mode: deleting (or skipping) the always-run
+// chain-key init block in createMsgAssemblerData. Both branches
+// (no-prev / with-prev) must produce the canonical ChainKey0 (a
+// non-zero, deterministic value), and they must agree — pre-fix
+// code had the with-prev branch carrying over a zeroed chainKey
+// from the prior transaction. Companion to the derive-level tests
+// above (the derive tests catch a reintroduced copy(); this test
+// catches a deleted init block).
+func TestCreateMsgAssemblerData_InitsCanonicalChainKey(t *testing.T) {
+	dev := newDeviceForChainKeyTest(t)
+
+	peerPk := testPeerPk()
+
+	madNoPrev, err := dev.createMsgAssemblerData(&MsgData{
+		HeaderType:    NHP_KNK,
+		CipherScheme:  common.CIPHER_SCHEME_CURVE,
+		TransactionId: 1,
+		PeerPk:        peerPk,
+	})
+	if err != nil {
+		t.Fatalf("no-prev createMsgAssemblerData: %v", err)
+	}
+	t.Cleanup(madNoPrev.Destroy)
+
+	madWithPrev, err := dev.createMsgAssemblerData(&MsgData{
+		HeaderType: NHP_ACK,
+		PrevParserData: &PacketParserData{
+			device:       dev,
+			CipherScheme: common.CIPHER_SCHEME_CURVE,
+			Ciphers:      NewCipherSuite(common.CIPHER_SCHEME_CURVE),
+			RemotePubKey: peerPk,
+			SenderTrxId:  1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("with-prev createMsgAssemblerData: %v", err)
+	}
+	t.Cleanup(madWithPrev.Destroy)
+
+	var zero [SymmetricKeySize]byte
+	if madNoPrev.chainKey == zero {
+		t.Error("no-prev chainKey is zero — canonical ChainKey0 was not initialized")
+	}
+	if madWithPrev.chainKey == zero {
+		t.Error("with-prev chainKey is zero — chain-key fix regression (always-run init block did not run on the carry-over path)")
+	}
+	if madNoPrev.chainKey != madWithPrev.chainKey {
+		t.Errorf("chainKey diverges between branches; both must produce canonical ChainKey0.\nno-prev:   %x\nwith-prev: %x", madNoPrev.chainKey, madWithPrev.chainKey)
+	}
+}
+
+// TestCreatePacketParserData_InitsCanonicalChainKey is the responder-
+// side twin of TestCreateMsgAssemblerData_InitsCanonicalChainKey.
+// The packet has no valid HMAC so the function returns
+// ErrHMACCheckFailed — but chain-key init runs BEFORE HMAC
+// validation (see createPacketParserData), and the function uses
+// named returns so ppd is populated even on the HMAC failure path.
+func TestCreatePacketParserData_InitsCanonicalChainKey(t *testing.T) {
+	// runResponderWithPrevHMACFailure pins the
+	// errors.Is(err, ErrHMACCheckFailed) + ppd != nil contract; we
+	// inspect chainKey on the returned ppd to confirm the init block
+	// ran above the HMAC check.
+	ppd := runResponderWithPrevHMACFailure(t, newDeviceForChainKeyTest(t), nil)
+
+	var zero [SymmetricKeySize]byte
+	if ppd.chainKey == zero {
+		t.Error("ppd.chainKey is zero — chain-key fix regression (always-run init block did not run on the carry-over path)")
+	}
+}
+
+func newDeviceForChainKeyTest(t *testing.T) *Device {
+	t.Helper()
+	priv := make([]byte, 32)
+	for i := range priv {
+		priv[i] = byte(i + 1)
+	}
+	dev := NewDevice(NHP_AGENT, priv, nil)
+	if dev == nil {
+		t.Fatal("NewDevice returned nil")
+	}
+	t.Cleanup(dev.Stop)
+	return dev
+}

--- a/nhp/core/initiator.go
+++ b/nhp/core/initiator.go
@@ -128,18 +128,18 @@ func (d *Device) createMsgAssemblerData(md *MsgData) (mad *MsgAssemblerData, err
 
 		// init header counter
 		mad.header.SetCounter(mad.TransactionId)
-
-		// init chain hash -> ChainHash0
-		mad.chainHash, err = NewHash(mad.ciphers.HashType)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create chain hash: %w", err)
-		}
-		mad.chainHash.Write([]byte(InitialHashString))
-
-		// init chain key -> ChainKey0
-		mad.noise.HashType = mad.ciphers.HashType
-		mad.noise.MixKey(&mad.chainKey, mad.chainHash.Sum(nil), []byte(InitialChainKeyString))
 	}
+
+	// init chain hash -> ChainHash0
+	mad.chainHash, err = NewHash(mad.ciphers.HashType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chain hash: %w", err)
+	}
+	mad.chainHash.Write([]byte(InitialHashString))
+
+	// init chain key -> ChainKey0
+	mad.noise.HashType = mad.ciphers.HashType
+	mad.noise.MixKey(&mad.chainKey, mad.chainHash.Sum(nil), []byte(InitialChainKeyString))
 
 	// init timestamp
 	mad.LocalInitTime = time.Now().UnixNano()
@@ -176,19 +176,7 @@ func (mad *MsgAssemblerData) derivePacketParserData(pkt *Packet, initTime int64)
 	ppd.header = ppd.basePacket.HeaderWithCipherScheme(ppd.CipherScheme)
 	ppd.Ciphers = NewCipherSuite(ppd.CipherScheme)
 	ppd.deviceEcdh = ppd.device.GetEcdhByCipherScheme(ppd.CipherScheme)
-
-	// init chain hash -> ChainHash0
-	var err error
-	ppd.chainHash, err = NewHash(ppd.Ciphers.HashType)
-	if err != nil {
-		// This should never happen with valid CipherSuite parameters
-		panic(fmt.Sprintf("failed to create chain hash in derivePacketParserData: %v", err))
-	}
-	ppd.chainHash.Write([]byte(InitialHashString))
-
-	// continue with initiator's chain key -> ChainKey4
 	ppd.noise.HashType = mad.ciphers.HashType
-	copy(ppd.chainKey[:], mad.chainKey[:])
 
 	return ppd
 }

--- a/nhp/core/responder.go
+++ b/nhp/core/responder.go
@@ -109,18 +109,18 @@ func (d *Device) createPacketParserData(pd *PacketData) (ppd *PacketParserData, 
 		log.Info("start decryption using CIPHER_SCHEME_%d(0: CURVE; 1: GMSM.)", ppd.CipherScheme)
 		ppd.Ciphers = NewCipherSuite(ppd.CipherScheme)
 		ppd.deviceEcdh = d.GetEcdhByCipherScheme(ppd.CipherScheme)
-
-		// init chain hash -> ChainHash0
-		ppd.chainHash, err = NewHash(ppd.Ciphers.HashType)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create chain hash: %w", err)
-		}
-		ppd.chainHash.Write([]byte(InitialHashString))
-
-		// init chain key -> ChainKey0
-		ppd.noise.HashType = ppd.Ciphers.HashType
-		ppd.noise.MixKey(&ppd.chainKey, ppd.chainHash.Sum(nil), []byte(InitialChainKeyString))
 	}
+
+	// init chain hash -> ChainHash0
+	ppd.chainHash, err = NewHash(ppd.Ciphers.HashType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chain hash: %w", err)
+	}
+	ppd.chainHash.Write([]byte(InitialHashString))
+
+	// init chain key -> ChainKey0
+	ppd.noise.HashType = ppd.Ciphers.HashType
+	ppd.noise.MixKey(&ppd.chainKey, ppd.chainHash.Sum(nil), []byte(InitialChainKeyString))
 
 	ppd.HeaderType, ppd.BodySize = ppd.header.TypeAndPayloadSize()
 
@@ -198,22 +198,7 @@ func (ppd *PacketParserData) deriveMsgAssemblerData(t int, compress bool, messag
 
 	// continue with the sender's counter
 	mad.header.SetCounter(ppd.SenderTrxId)
-
-	// init chain hash -> ChainHash0
-	var err error
-	mad.chainHash, err = NewHash(mad.ciphers.HashType)
-	if err != nil {
-		// This should never happen with valid CipherSuite parameters
-		panic(fmt.Sprintf("failed to create chain hash in deriveMsgAssemblerData: %v", err))
-	}
-	mad.chainHash.Write([]byte(InitialHashString))
-
-	// continue with responder's chain key
-	// Note: ppd.chainKey is cleared by decryptBody's defer, so this is
-	// effectively all-zeros.  The Go agent's initiator side has the same
-	// behavior (encryptBody clears mad.chainKey), so both sides match.
 	mad.noise.HashType = ppd.Ciphers.HashType
-	copy(mad.chainKey[:], ppd.chainKey[:])
 
 	return mad
 }

--- a/nhp/core/testhelpers_test.go
+++ b/nhp/core/testhelpers_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/OpenNHP/opennhp/nhp/common"
+)
+
+// testPeerPk returns the deterministic byte-pattern public key the
+// chain-key tests use as a stand-in. Not a valid curve25519 key —
+// callers are expected to be on paths where peer-key validation
+// doesn't fire (e.g., setPeerPublicKey accepts arbitrary
+// PublicKeySize-byte inputs; signing/AEAD steps that would reject
+// are gated behind earlier checks the tests don't reach).
+func testPeerPk() []byte {
+	peerPk := make([]byte, PublicKeySize)
+	for i := range peerPk {
+		peerPk[i] = byte(i + 1)
+	}
+	return peerPk
+}
+
+// runResponderWithPrevHMACFailure builds a prev MAD and a junk
+// packet, calls createPacketParserData with PrevAssemblerData set
+// plus any extra config the caller applies via `configure`, asserts
+// the HMAC-failure / bare-return contract (err is ErrHMACCheckFailed,
+// ppd is non-nil), and returns the populated ppd for further
+// inspection. Shared by the responder-side chain-key tests in
+// derive_chainkey_test.go.
+func runResponderWithPrevHMACFailure(t *testing.T, dev *Device, configure func(*PacketData)) *PacketParserData {
+	t.Helper()
+
+	prevMad, err := dev.createMsgAssemblerData(&MsgData{
+		HeaderType:    NHP_KNK,
+		CipherScheme:  common.CIPHER_SCHEME_CURVE,
+		TransactionId: 1,
+		PeerPk:        testPeerPk(),
+	})
+	if err != nil {
+		t.Fatalf("build prev MAD: %v", err)
+	}
+	t.Cleanup(prevMad.Destroy)
+
+	pkt := dev.AllocatePoolPacket()
+	if pkt == nil {
+		t.Fatal("AllocatePoolPacket returned nil")
+	}
+	pkt.Content = pkt.Buf[:prevMad.header.Size()]
+
+	pd := &PacketData{
+		BasePacket:        pkt,
+		PrevAssemblerData: prevMad,
+		InitTime:          time.Now().UnixNano(),
+	}
+	if configure != nil {
+		configure(pd)
+	}
+
+	ppd, err := dev.createPacketParserData(pd)
+	if !errors.Is(err, ErrHMACCheckFailed) {
+		t.Fatalf("expected ErrHMACCheckFailed, got %v", err)
+	}
+	if ppd == nil {
+		t.Fatal("ppd nil — createPacketParserData did not populate named return on err path")
+	}
+	t.Cleanup(ppd.Destroy)
+
+	return ppd
+}


### PR DESCRIPTION
Backports the chain-key initialization fix that already exists on
`enable_webrtc` (commit `03619015e82ae0c14ae1fd5de96de03814e2e455` by
@craftleon) to `main`, so that downstream consumers tracking `main` /
released versions get the fix.

## Bug

`derivePacketParserData` and `deriveMsgAssemblerData` copied the
previous transaction's chain key into the new MAD/PPD, but
`encryptBody` / `decryptBody`'s deferred `SetZero(chainKey)` had
already zeroed the source — so the "intermediate" key the response
was supposed to chain from was actually all zeros.

Go-to-Go peers absorbed this silently: both ends symmetrically
derived from a zeroed buffer and agreed. The Go-to-JS interop broke
because the JS implementation did not replicate the zero-carry-over
quirk, producing `cipher: message authentication failed` on response
packets (knock ACKs, AOP/ART forwarding, AC online responses).

## Fix

Always initialize chain hash + chain key to `ChainHash0` / `ChainKey0`
per packet — move the init out of the no-`PrevAssemblerData` /
no-`PrevParserData` `if` branch in `createMsgAssemblerData` /
`createPacketParserData`, and drop the now-redundant copy in the
`derive*` helpers.

## Wire-compat note

This fix changes the on-the-wire AEAD key for response-direction
packets (anything that flows through `PrevParserData` /
`PrevAssemblerData`). Old-code-derives-from-zeros vs.
new-code-derives-from-`ChainKey0` is silently incompatible on those
packets — old↔new peer pairs will fail body-AEAD with
`ErrAEADDecryptionFailed`. Request-direction (fresh transactions) is
unaffected. No protocol-version gate exists, so deployments should
roll server + agent fleets together within a single release window.

## Provenance

Cherry-picked from `03619015` on `enable_webrtc`. One trivial merge
conflict in `responder.go::deriveMsgAssemblerData` (resolved by
keeping the fix's intent — remove the dead re-init that targeted a
zeroed source key).

Tests pass on the resulting branch (`cd nhp && go test ./...`).