### PR TITLE
fix(core): remove cgo dependency from errors

### DIFF
--- a/nhp/core/errors.go
+++ b/nhp/core/errors.go
@@ -1,12 +1,6 @@
 package core
 
-/*
-#include "main/nhpdevicedef.h"
-*/
-import "C"
-import (
-	"strconv"
-)
+import "strconv"
 
 var errorMap map[int]*Error = make(map[int]*Error)
 
@@ -42,9 +36,9 @@ func (e *Error) ErrorNumber() int {
 	return e.num
 }
 
-func newError(number C.int, msg string) *Error {
+func newError(number int, msg string) *Error {
 	e := &Error{
-		num: int(number),
+		num: number,
 		msg: msg,
 	}
 	errorMap[e.num] = e
@@ -75,40 +69,84 @@ func ErrorCodeToError(number int) *Error {
 	return nil // should not happen
 }
 
+// NHP error numbers. Keep these in sync with the NhpError enum
+// in nhp/core/main/nhpdevicedef.h; errors_test.go verifies parity.
+const (
+	errNHPSuccess = 0
+)
+
+const (
+	errNHPDeviceNotInitialized = 30000 + iota
+	errNHPDeviceAlreadyCreated
+	errNHPCipherNotSupported
+	errNHPOperationNotApplicable
+	errNHPCreateDeviceFailed
+	errNHPCloseDeviceFailed
+	errNHPSDKRuntimePanic
+)
+
+const (
+	errNHPWrongCipherScheme = 31000 + iota
+	errNHPEmptyPeerPublicKey
+	errNHPEphermalECDHPeerFailed
+	errNHPDeviceECDHPeerFailed
+	errNHPIdentityTooLong
+	errNHPDataCompressionFailed
+	errNHPPacketSizeExceedsBuffer
+)
+
+const (
+	errNHPCloseConnection = 32001 + iota
+	errNHPIncorrectPacketSize
+	errNHPMessageTypeNotMatchDevice
+	errNHPServerOverload
+	errNHPHMACCheckFailed
+	errNHPServerHMACCheckFailed
+	errNHPDeviceECDHEphermalFailed
+	errNHPPeerIdentityVerificationFailed
+	errNHPAEADDecryptionFailed
+	errNHPDataDecompressionFailed
+	errNHPDeviceECDHObtainedPeerFailed
+	errNHPServerRejectWithCookie
+	errNHPReplayPacketReceived
+	errNHPFloodPacketReceived
+	errNHPStalePacketReceived
+)
+
 // device sdk errors
 var (
-	ErrSuccess = newError(C.ERR_NHP_SUCCESS, "")
+	ErrSuccess = newError(errNHPSuccess, "")
 
 	// device
-	ErrCipherNotSupported = newError(C.ERR_NHP_CIPHER_NOT_SUPPORTED, "cipher scheme not supported")
-	ErrNotApplicable      = newError(C.ERR_NHP_OPERATION_NOT_APPLICABLE, "operation not applicable")
-	ErrCreateDeviceFailed = newError(C.ERR_NHP_CREATE_DEVICE_FAILED, "failed to create nhp device")
-	ErrCloseDeviceFailed  = newError(C.ERR_NHP_CLOSE_DEVICE_FAILED, "attempt to close a non-initialized nhp device")
-	ErrRuntimePanic       = newError(C.ERR_NHP_SDK_RUNTIME_PANIC, "runtime panic encountered")
+	ErrCipherNotSupported = newError(errNHPCipherNotSupported, "cipher scheme not supported")
+	ErrNotApplicable      = newError(errNHPOperationNotApplicable, "operation not applicable")
+	ErrCreateDeviceFailed = newError(errNHPCreateDeviceFailed, "failed to create nhp device")
+	ErrCloseDeviceFailed  = newError(errNHPCloseDeviceFailed, "attempt to close a non-initialized nhp device")
+	ErrRuntimePanic       = newError(errNHPSDKRuntimePanic, "runtime panic encountered")
 
 	// initiator and encryption
-	ErrWrongCipherScheme       = newError(C.ERR_NHP_WRONG_CIPHER_SCHEME, "a wrong cipher scheme is used")
-	ErrEmptyPeerPublicKey      = newError(C.ERR_NHP_EMPTY_PEER_PUBLIC_KEY, "remote peer public key is not set")
-	ErrEphermalECDHPeerFailed  = newError(C.ERR_NHP_EPHERMAL_ECDH_PEER_FAILED, "ephermal ECDH failed with peer")
-	ErrDeviceECDHPeerFailed    = newError(C.ERR_NHP_DEVICE_ECDH_PEER_FAILED, "device ECDH failed with peer")
-	ErrIdentityTooLong         = newError(C.ERR_NHP_IDENTITY_TOO_LONG, "identity exceeds max length")
-	ErrDataCompressionFailed   = newError(C.ERR_NHP_DATA_COMPRESSION_FAILED, "data compression failed")
-	ErrPacketSizeExceedsBuffer = newError(C.ERR_NHP_PACKET_SIZE_EXCEEDS_BUFFER, "packet size longer than send buffer")
+	ErrWrongCipherScheme       = newError(errNHPWrongCipherScheme, "a wrong cipher scheme is used")
+	ErrEmptyPeerPublicKey      = newError(errNHPEmptyPeerPublicKey, "remote peer public key is not set")
+	ErrEphermalECDHPeerFailed  = newError(errNHPEphermalECDHPeerFailed, "ephermal ECDH failed with peer")
+	ErrDeviceECDHPeerFailed    = newError(errNHPDeviceECDHPeerFailed, "device ECDH failed with peer")
+	ErrIdentityTooLong         = newError(errNHPIdentityTooLong, "identity exceeds max length")
+	ErrDataCompressionFailed   = newError(errNHPDataCompressionFailed, "data compression failed")
+	ErrPacketSizeExceedsBuffer = newError(errNHPPacketSizeExceedsBuffer, "packet size longer than send buffer")
 
 	// responder and decryption
-	ErrCloseConnection                = newError(C.ERR_NHP_CLOSE_CONNECTION, "disengage nhp access immediately")
-	ErrIncorrectPacketSize            = newError(C.ERR_NHP_INCORRECT_PACKET_SIZE, "incorrect packet size")
-	ErrMessageTypeNotMatchDevice      = newError(C.ERR_NHP_MESSAGE_TYPE_NOT_MATCH_DEVICE, "message type does not match device")
-	ErrServerOverload                 = newError(C.ERR_NHP_SERVER_OVERLOAD, "the packet is dropped due to server overload")
-	ErrHMACCheckFailed                = newError(C.ERR_NHP_HMAC_CHECK_FAILED, "HMAC validation failed")
-	ErrServerHMACCheckFailed          = newError(C.ERR_NHP_SERVER_HMAC_CHECK_FAILED, "server HMAC validation failed")
-	ErrDeviceECDHEphermalFailed       = newError(C.ERR_NHP_DEVICE_ECDH_EPHERMAL_FAILED, "device ECDH failed with ephermal")
-	ErrPeerIdentityVerificationFailed = newError(C.ERR_NHP_PEER_IDENTITY_VERIFICATION_FAILED, "failed to verify peer's identity with apk")
-	ErrAEADDecryptionFailed           = newError(C.ERR_NHP_AEAD_DECRYPTION_FAILED, "aead decryption failed")
-	ErrDataDecompressionFailed        = newError(C.ERR_NHP_DATA_DECOMPRESSION_FAILED, "data decompression failed")
-	ErrDeviceECDHObtainedPeerFailed   = newError(C.ERR_NHP_DEVICE_ECDH_OBTAINED_PEER_FAILED, "device ECDH failed with obtained peer")
-	ErrServerRejectWithCookie         = newError(C.ERR_NHP_SERVER_REJECT_WITH_COOKIE, "server overload, stop processing packet and return cookie")
-	ErrReplayPacketReceived           = newError(C.ERR_NHP_REPLAY_PACKET_RECEIVED, "received replay packet, drop")
-	ErrFloodPacketReceived            = newError(C.ERR_NHP_FLOOD_PACKET_RECEIVED, "received flood packet, drop")
-	ErrStalePacketReceived            = newError(C.ERR_NHP_STALE_PACKET_RECEIVED, "received stale packet, drop")
+	ErrCloseConnection                = newError(errNHPCloseConnection, "disengage nhp access immediately")
+	ErrIncorrectPacketSize            = newError(errNHPIncorrectPacketSize, "incorrect packet size")
+	ErrMessageTypeNotMatchDevice      = newError(errNHPMessageTypeNotMatchDevice, "message type does not match device")
+	ErrServerOverload                 = newError(errNHPServerOverload, "the packet is dropped due to server overload")
+	ErrHMACCheckFailed                = newError(errNHPHMACCheckFailed, "HMAC validation failed")
+	ErrServerHMACCheckFailed          = newError(errNHPServerHMACCheckFailed, "server HMAC validation failed")
+	ErrDeviceECDHEphermalFailed       = newError(errNHPDeviceECDHEphermalFailed, "device ECDH failed with ephermal")
+	ErrPeerIdentityVerificationFailed = newError(errNHPPeerIdentityVerificationFailed, "failed to verify peer's identity with apk")
+	ErrAEADDecryptionFailed           = newError(errNHPAEADDecryptionFailed, "aead decryption failed")
+	ErrDataDecompressionFailed        = newError(errNHPDataDecompressionFailed, "data decompression failed")
+	ErrDeviceECDHObtainedPeerFailed   = newError(errNHPDeviceECDHObtainedPeerFailed, "device ECDH failed with obtained peer")
+	ErrServerRejectWithCookie         = newError(errNHPServerRejectWithCookie, "server overload, stop processing packet and return cookie")
+	ErrReplayPacketReceived           = newError(errNHPReplayPacketReceived, "received replay packet, drop")
+	ErrFloodPacketReceived            = newError(errNHPFloodPacketReceived, "received flood packet, drop")
+	ErrStalePacketReceived            = newError(errNHPStalePacketReceived, "received stale packet, drop")
 )

--- a/nhp/core/errors_test.go
+++ b/nhp/core/errors_test.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestNHPErrorCodesMatchCHeader(t *testing.T) {
+	headerCodes := parseNHPErrorCodes(t)
+
+	tests := []struct {
+		name   string
+		goCode int
+	}{
+		{name: "ERR_NHP_SUCCESS", goCode: errNHPSuccess},
+		{name: "ERR_NHP_DEVICE_NOT_INITIALIZED", goCode: errNHPDeviceNotInitialized},
+		{name: "ERR_NHP_DEVICE_ALREADY_CREATED", goCode: errNHPDeviceAlreadyCreated},
+		{name: "ERR_NHP_CIPHER_NOT_SUPPORTED", goCode: errNHPCipherNotSupported},
+		{name: "ERR_NHP_OPERATION_NOT_APPLICABLE", goCode: errNHPOperationNotApplicable},
+		{name: "ERR_NHP_CREATE_DEVICE_FAILED", goCode: errNHPCreateDeviceFailed},
+		{name: "ERR_NHP_CLOSE_DEVICE_FAILED", goCode: errNHPCloseDeviceFailed},
+		{name: "ERR_NHP_SDK_RUNTIME_PANIC", goCode: errNHPSDKRuntimePanic},
+		{name: "ERR_NHP_WRONG_CIPHER_SCHEME", goCode: errNHPWrongCipherScheme},
+		{name: "ERR_NHP_EMPTY_PEER_PUBLIC_KEY", goCode: errNHPEmptyPeerPublicKey},
+		{name: "ERR_NHP_EPHERMAL_ECDH_PEER_FAILED", goCode: errNHPEphermalECDHPeerFailed},
+		{name: "ERR_NHP_DEVICE_ECDH_PEER_FAILED", goCode: errNHPDeviceECDHPeerFailed},
+		{name: "ERR_NHP_IDENTITY_TOO_LONG", goCode: errNHPIdentityTooLong},
+		{name: "ERR_NHP_DATA_COMPRESSION_FAILED", goCode: errNHPDataCompressionFailed},
+		{name: "ERR_NHP_PACKET_SIZE_EXCEEDS_BUFFER", goCode: errNHPPacketSizeExceedsBuffer},
+		{name: "ERR_NHP_CLOSE_CONNECTION", goCode: errNHPCloseConnection},
+		{name: "ERR_NHP_INCORRECT_PACKET_SIZE", goCode: errNHPIncorrectPacketSize},
+		{name: "ERR_NHP_MESSAGE_TYPE_NOT_MATCH_DEVICE", goCode: errNHPMessageTypeNotMatchDevice},
+		{name: "ERR_NHP_SERVER_OVERLOAD", goCode: errNHPServerOverload},
+		{name: "ERR_NHP_HMAC_CHECK_FAILED", goCode: errNHPHMACCheckFailed},
+		{name: "ERR_NHP_SERVER_HMAC_CHECK_FAILED", goCode: errNHPServerHMACCheckFailed},
+		{name: "ERR_NHP_DEVICE_ECDH_EPHERMAL_FAILED", goCode: errNHPDeviceECDHEphermalFailed},
+		{name: "ERR_NHP_PEER_IDENTITY_VERIFICATION_FAILED", goCode: errNHPPeerIdentityVerificationFailed},
+		{name: "ERR_NHP_AEAD_DECRYPTION_FAILED", goCode: errNHPAEADDecryptionFailed},
+		{name: "ERR_NHP_DATA_DECOMPRESSION_FAILED", goCode: errNHPDataDecompressionFailed},
+		{name: "ERR_NHP_DEVICE_ECDH_OBTAINED_PEER_FAILED", goCode: errNHPDeviceECDHObtainedPeerFailed},
+		{name: "ERR_NHP_SERVER_REJECT_WITH_COOKIE", goCode: errNHPServerRejectWithCookie},
+		{name: "ERR_NHP_REPLAY_PACKET_RECEIVED", goCode: errNHPReplayPacketReceived},
+		{name: "ERR_NHP_FLOOD_PACKET_RECEIVED", goCode: errNHPFloodPacketReceived},
+		{name: "ERR_NHP_STALE_PACKET_RECEIVED", goCode: errNHPStalePacketReceived},
+	}
+
+	for _, tt := range tests {
+		headerCode, ok := headerCodes[tt.name]
+		if !ok {
+			t.Fatalf("%s missing from nhpdevicedef.h NhpError enum", tt.name)
+		}
+		if tt.goCode != headerCode {
+			t.Fatalf("%s = %d, want header value %d", tt.name, tt.goCode, headerCode)
+		}
+	}
+}
+
+func parseNHPErrorCodes(t *testing.T) map[string]int {
+	t.Helper()
+
+	header, err := os.ReadFile(filepath.Join("main", "nhpdevicedef.h"))
+	if err != nil {
+		t.Fatalf("read nhpdevicedef.h: %v", err)
+	}
+
+	const start = "typedef enum _NhpError {"
+	text := string(header)
+	startIdx := strings.Index(text, start)
+	if startIdx < 0 {
+		t.Fatalf("NhpError enum start not found in nhpdevicedef.h")
+	}
+	enumBody := text[startIdx+len(start):]
+	endIdx := strings.Index(enumBody, "} NhpError;")
+	if endIdx < 0 {
+		t.Fatalf("NhpError enum end not found in nhpdevicedef.h")
+	}
+	enumBody = enumBody[:endIdx]
+
+	codes := make(map[string]int)
+	value := -1
+	for _, rawLine := range strings.Split(enumBody, "\n") {
+		line, _, _ := strings.Cut(rawLine, "//")
+		line = strings.TrimSpace(line)
+		line = strings.TrimSpace(strings.TrimSuffix(line, ","))
+		if line == "" {
+			continue
+		}
+
+		name := line
+		if before, after, ok := strings.Cut(line, "="); ok {
+			name = strings.TrimSpace(before)
+			value, err = strconv.Atoi(strings.TrimSpace(after))
+			if err != nil {
+				t.Fatalf("parse %s value %q: %v", name, after, err)
+			}
+		} else {
+			value++
+		}
+		codes[name] = value
+	}
+	return codes
+}


### PR DESCRIPTION
## Summary

- Remove the accidental `import "C"` dependency from `nhp/core/errors.go` by mirroring the NHP error numbers in Go.
- Add a pure-Go parity test that parses `nhp/core/main/nhpdevicedef.h` so the Go constants stay aligned with the C SDK ABI.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD improvement

## Related Issues

N/A

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] All existing tests pass

Focused checks run:

- `CGO_ENABLED=0 go test ./core` from `nhp/`
- `go test ./core` from `nhp/`
- `CGO_ENABLED=0 go test ./agent` from `endpoints/`
- `CGO_ENABLED=0 go test ./...` from `nhp/`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced