### PR TITLE
fix(server,agent): authenticate knock HeaderType to block on-path header flips

### DIFF
--- a/endpoints/agent/knock.go
+++ b/endpoints/agent/knock.go
@@ -99,8 +99,19 @@ func (a *UdpAgent) knockRequest(res *KnockTarget, useCookie bool) (ackMsg *commo
 	}
 	addrStr := sendAddr.String()
 
+	// The body HeaderType MUST equal the wire HeaderType set on knkMd below.
+	// Carrying it inside the AEAD-authenticated body lets the server verify
+	// the (unauthenticated) wire value and detect on-path NHP_KNK / NHP_RKN
+	// <-> NHP_EXT flips. Derive both from this single variable so they can't
+	// drift apart.
+	headerType := core.NHP_KNK
+	if useCookie {
+		headerType = core.NHP_RKN
+	}
+
 	a.knockUserMutex.RLock()
 	knkMsg := &common.AgentKnockMsg{
+		HeaderType:     headerType,
 		UserId:         a.knockUser.UserId,
 		DeviceId:       a.deviceId,
 		OrganizationId: a.knockUser.OrganizationId,
@@ -114,7 +125,7 @@ func (a *UdpAgent) knockRequest(res *KnockTarget, useCookie bool) (ackMsg *commo
 	knkBytes, _ := json.Marshal(knkMsg)
 	knkMd := &core.MsgData{
 		RemoteAddr:    sendAddr.(*net.UDPAddr),
-		HeaderType:    core.NHP_KNK,
+		HeaderType:    headerType,
 		CipherScheme:  a.config.DefaultCipherScheme,
 		TransactionId: a.device.NextCounterIndex(),
 		Compress:      true,
@@ -123,7 +134,6 @@ func (a *UdpAgent) knockRequest(res *KnockTarget, useCookie bool) (ackMsg *commo
 		ResponseMsgCh: make(chan *core.PacketParserData),
 	}
 	if useCookie {
-		knkMd.HeaderType = core.NHP_RKN
 		// Carry the cookie the previous KNK round stashed on this
 		// target. ExternalCookie short-circuits the addHMAC fallback
 		// to ConnData.CookieStore (initiator.go:444), which would
@@ -238,6 +248,9 @@ func (a *UdpAgent) ExitKnockRequest(res *KnockTarget) (ackMsg *common.ServerKnoc
 
 	a.knockUserMutex.RLock()
 	knkMsg := &common.AgentKnockMsg{
+		// Mirror the wire HeaderType (NHP_EXT) inside the AEAD-authenticated
+		// body so the server can verify it (see endpoints/server/knock_headertype.go).
+		HeaderType:     core.NHP_EXT,
 		UserId:         a.knockUser.UserId,
 		DeviceId:       a.deviceId,
 		OrganizationId: a.knockUser.OrganizationId,

--- a/endpoints/js-agent/src/NHPAgent.ts
+++ b/endpoints/js-agent/src/NHPAgent.ts
@@ -360,7 +360,13 @@ export class NHPAgent {
       throw new Error('Agent not initialized');
     }
 
-    const knockMessage = JSON.stringify(knockMsg);
+    // Authenticate the knock type: mirror the wire packet type into the
+    // AEAD-protected body so the server can require body == wire and reject
+    // on-path header-type flips (NHP_KNK <-> NHP_EXT). Both the wire packet
+    // (below) and the body derive from this same `packetType`, so they cannot
+    // drift. Spread rather than mutate `knockMsg` so the caller's shared object
+    // can be reused for the cookie-resend RNK without the KNK type leaking.
+    const knockMessage = JSON.stringify({ ...knockMsg, headerType: packetType });
 
     // Build knock packet
     const packet = await buildNHPPacket(

--- a/endpoints/js-agent/src/types.ts
+++ b/endpoints/js-agent/src/types.ts
@@ -186,6 +186,15 @@ export interface AgentKnockMsg {
   resId: string;
   /** Check mode (optional, for validation only) */
   cknMode?: number;
+  /**
+   * Wire packet type, mirrored into the AEAD-authenticated knock body so the
+   * server can require body == wire and reject on-path header-type flips
+   * (e.g. NHP_KNK <-> NHP_EXT). Populated per send from the same value as the
+   * wire packet type (KNK=1, RNK=8) — see {@link NHPAgent.sendKnock}. Matches
+   * Go `AgentKnockMsg.HeaderType` (`json:"headerType"`); a server that verifies
+   * header types rejects a knock whose body omits it with error 52010.
+   */
+  headerType?: number;
 }
 
 /**

--- a/endpoints/js-agent/test/NHPAgent.test.ts
+++ b/endpoints/js-agent/test/NHPAgent.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NHPAgent } from '../src/NHPAgent.js';
 import { buildNHPPacket, resetGlobalCounter } from '../src/protocol/packet.js';
+import * as packetModule from '../src/protocol/packet.js';
 import { NHP_PACKET_TYPES } from '../src/protocol/constants.js';
 import { generateX25519KeyPairBase64 } from '../src/crypto/ecdh.js';
 import { generateSM2KeyPairBase64 } from '../src/crypto/sm2.js';
@@ -387,6 +388,90 @@ describe('knockResource — success path', () => {
     expect(result.success).toBe(false);
     expect(result.errorCode).toBe(5);
     expect(result.error).toBe('connection refused');
+    await agent.close();
+  });
+});
+
+// ─── Knock body authenticates the HeaderType (on-path flip protection) ───────
+
+describe('knock body HeaderType', () => {
+  it('KNK knock body carries headerType matching the wire packet type', async () => {
+    const server = generateX25519KeyPairBase64();
+    const agent = new NHPAgent({ transport: 'websocket' });
+    await agent.init();
+
+    const ackPacket = await makeAckPacket(
+      server.privateKey, server.publicKey,
+      agent.getPublicKey(), SUCCESS_ACK
+    );
+
+    agent.setIdentity({ userId: 'u', deviceId: 'd' });
+    agent.addServer({ publicKey: server.publicKey, host: 'nhp.example.com', port: 62206 });
+    injectMockTransport(agent, ackPacket);
+
+    // Spy after the ACK is built so only the outbound knock body is captured.
+    const buildSpy = vi.spyOn(packetModule, 'buildNHPPacket');
+
+    const result = await agent.knockResource({
+      resourceId: 'r', serviceId: 's',
+      serverHost: 'nhp.example.com', serverPort: 62206,
+    });
+    expect(result.success).toBe(true);
+
+    // The knock body (5th arg to buildNHPPacket) must serialize headerType ==
+    // the wire packet type, using the exact JSON key the Go server unmarshals
+    // (AgentKnockMsg.HeaderType, `json:"headerType"`). Otherwise the server
+    // rejects the knock as 52010 (legacy/missing) — the demo-breaking bug.
+    const knockCall = buildSpy.mock.calls.find(c => c[0] === NHP_PACKET_TYPES.KNK);
+    expect(knockCall, 'buildNHPPacket was not called with a KNK packet').toBeTruthy();
+    const rawBody = knockCall![4] as string;
+    expect(rawBody).toContain('"headerType"');
+    expect(JSON.parse(rawBody).headerType).toBe(NHP_PACKET_TYPES.KNK);
+    expect(JSON.parse(rawBody).headerType).toBe(1); // wire contract with Go core.NHP_KNK
+
+    await agent.close();
+  });
+
+  it('sets headerType per send (KNK then RNK) without mutating the shared knockMsg', async () => {
+    const server = generateX25519KeyPairBase64();
+    const agent = new NHPAgent({ transport: 'websocket' });
+    await agent.init();
+    agent.setIdentity({ userId: 'u', deviceId: 'd' });
+
+    // Decouple from crypto + networking: capture the body buildNHPPacket
+    // receives and resolve the response immediately, so we exercise the
+    // per-send injection for both packet types deterministically.
+    const buildSpy = vi
+      .spyOn(packetModule, 'buildNHPPacket')
+      .mockResolvedValue(new Uint8Array([0]));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(agent as any, 'sendAndWaitForResponse').mockResolvedValue({
+      type: NHP_PACKET_TYPES.ACK,
+      message: JSON.stringify(SUCCESS_ACK),
+    });
+
+    // One shared body object, reused for the initial knock and the cookie-resend.
+    const knockMsg = { usrId: 'u', devId: 'd', aspId: 's', resId: 'r' };
+    const serverCfg = { id: 's1', publicKey: server.publicKey, host: 'h', port: 1 };
+    const resource = { resourceId: 'r', serviceId: 's' };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (agent as any).sendKnock(NHP_PACKET_TYPES.KNK, knockMsg, serverCfg, resource);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (agent as any).sendKnock(NHP_PACKET_TYPES.RNK, knockMsg, serverCfg, resource);
+
+    const bodyFor = (pt: number) => {
+      const call = buildSpy.mock.calls.find(c => c[0] === pt);
+      expect(call, `buildNHPPacket not called with packet type ${pt}`).toBeTruthy();
+      return JSON.parse(call![4] as string);
+    };
+    expect(bodyFor(NHP_PACKET_TYPES.KNK).headerType).toBe(1); // NHP_KNK
+    expect(bodyFor(NHP_PACKET_TYPES.RNK).headerType).toBe(8); // NHP_RKN
+
+    // The shared object must never be mutated, or the cookie-resend RNK would
+    // carry the KNK type and the server would reject the body/wire mismatch.
+    expect(Object.prototype.hasOwnProperty.call(knockMsg, 'headerType')).toBe(false);
+
     await agent.close();
   });
 });

--- a/endpoints/server/knock_headertype.go
+++ b/endpoints/server/knock_headertype.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"github.com/OpenNHP/opennhp/nhp/common"
+	"github.com/OpenNHP/opennhp/nhp/core"
+	"github.com/OpenNHP/opennhp/nhp/log"
+)
+
+// Knock HeaderType verification (on-path header-flip protection).
+//
+// The server decides whether an incoming knock is an open (NHP_KNK /
+// NHP_RKN) or a close (NHP_EXT) from the packet's WIRE HeaderType. That
+// byte is not covered by the noise chain-hash / AEAD — only the message
+// body is — and the trailing header digest is an unkeyed hash over
+// public values. An on-path attacker can therefore flip a knock's wire
+// HeaderType from NHP_KNK to NHP_EXT, recompute that digest, and make
+// the server treat a legitimate open as a close: HandleKnockRequest ->
+// processACOperation runs with openTime=1 (udpserver.go), revoking the
+// victim's access. No key material is needed and the cryptography is
+// never broken.
+//
+// Defense: the agent mirrors the wire HeaderType inside the
+// AEAD-authenticated knock body (AgentKnockMsg.HeaderType). Because the
+// body sits inside the chain-hash-authenticated payload, an attacker
+// cannot flip it without the initiator's static private key. The server
+// requires the body and wire HeaderType to agree and then uses the
+// authenticated body value for the open/close decision.
+//
+// Verification is unconditional — secure by default, no compatibility
+// switch. A knock whose body HeaderType is missing (agent predates this
+// field) or disagrees with the wire is rejected.
+
+// verifyKnockHeaderType compares the AEAD-authenticated body HeaderType
+// against the unauthenticated wire HeaderType. It returns nil when they
+// agree (the caller then trusts the body value, which equals the wire
+// value), or the reject error otherwise — logging the rejection:
+//
+//   - bodyType is the zero value (NHP_KPL): the agent does not populate
+//     the field and must be upgraded -> ErrKnockHeaderTypeLegacy.
+//   - bodyType is populated but disagrees with wireType: the wire header
+//     was tampered with on path -> ErrKnockHeaderTypeMismatch.
+//
+// A routed knock never has a NHP_KPL wire type (the device dispatcher
+// handles keepalives elsewhere), so the zero-body check unambiguously
+// means "legacy agent".
+func verifyKnockHeaderType(bodyType, wireType int, transactionId uint64, addrStr string) *common.Error {
+	if bodyType == core.NHP_KPL {
+		log.Warning("server-agent(#%d@%s)[HeaderType] knock rejected: body HeaderType missing, upgrade agent; wire=%s",
+			transactionId, addrStr, core.HeaderTypeToString(wireType))
+		return common.ErrKnockHeaderTypeLegacy
+	}
+	if bodyType != wireType {
+		log.Warning("server-agent(#%d@%s)[HeaderType] knock rejected: body/wire HeaderType mismatch, possible on-path tampering; body=%s wire=%s",
+			transactionId, addrStr, core.HeaderTypeToString(bodyType), core.HeaderTypeToString(wireType))
+		return common.ErrKnockHeaderTypeMismatch
+	}
+	return nil
+}

--- a/endpoints/server/knock_headertype.go
+++ b/endpoints/server/knock_headertype.go
@@ -40,9 +40,13 @@ import (
 //   - bodyType is populated but disagrees with wireType: the wire header
 //     was tampered with on path -> ErrKnockHeaderTypeMismatch.
 //
-// A routed knock never has a NHP_KPL wire type (the device dispatcher
-// handles keepalives elsewhere), so the zero-body check unambiguously
-// means "legacy agent".
+// This zero-value test relies on NHP_KPL being the iota-zero sentinel
+// (nhp/core/packet.go) that never appears as a routed knock type on either
+// side: the device dispatcher handles keepalives elsewhere, so no routed
+// knock carries a NHP_KPL wire type, and an upgraded agent always sets a
+// non-zero body type (NHP_KNK/NHP_RKN/NHP_EXT). A zero body therefore
+// unambiguously means "field absent" (legacy agent), not a legitimately
+// sent type whose value happens to be 0.
 func verifyKnockHeaderType(bodyType, wireType int, transactionId uint64, addrStr string) *common.Error {
 	if bodyType == core.NHP_KPL {
 		log.Warning("server-agent(#%d@%s)[HeaderType] knock rejected: body HeaderType missing, upgrade agent; wire=%s",

--- a/endpoints/server/knock_headertype_test.go
+++ b/endpoints/server/knock_headertype_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/OpenNHP/opennhp/nhp/common"
+	"github.com/OpenNHP/opennhp/nhp/core"
+)
+
+// TestVerifyKnockHeaderType pins the secure-by-default behavior: a
+// populated body that matches the wire is accepted (nil), an unpopulated
+// (legacy) body is rejected as legacy, and a populated body that
+// disagrees with the wire is rejected as a mismatch.
+func TestVerifyKnockHeaderType(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    int
+		wire    int
+		wantErr *common.Error
+	}{
+		{"ok_knk", core.NHP_KNK, core.NHP_KNK, nil},
+		{"ok_ext", core.NHP_EXT, core.NHP_EXT, nil},
+		{"ok_rkn", core.NHP_RKN, core.NHP_RKN, nil},
+
+		// Legacy agent: body never populated -> zero value (NHP_KPL).
+		{"legacy_body_zero_vs_knk", core.NHP_KPL, core.NHP_KNK, common.ErrKnockHeaderTypeLegacy},
+		{"legacy_body_zero_vs_ext", core.NHP_KPL, core.NHP_EXT, common.ErrKnockHeaderTypeLegacy},
+
+		// On-path flip: authenticated body disagrees with the wire header.
+		{"mismatch_knk_flipped_to_ext", core.NHP_KNK, core.NHP_EXT, common.ErrKnockHeaderTypeMismatch},
+		{"mismatch_ext_flipped_to_knk", core.NHP_EXT, core.NHP_KNK, common.ErrKnockHeaderTypeMismatch},
+		{"mismatch_knk_flipped_to_rkn", core.NHP_KNK, core.NHP_RKN, common.ErrKnockHeaderTypeMismatch},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := verifyKnockHeaderType(tc.body, tc.wire, 1, "test-addr")
+			if got != tc.wantErr {
+				t.Errorf("verifyKnockHeaderType(body=%d, wire=%d) = %v, want %v", tc.body, tc.wire, got, tc.wantErr)
+			}
+		})
+	}
+}

--- a/endpoints/server/nhpauth.go
+++ b/endpoints/server/nhpauth.go
@@ -58,8 +58,19 @@ func (s *UdpServer) HandleKnockRequest(ppd *core.PacketParserData) (err error) {
 			return
 		}
 
-		// determine knock type
-		knkMsg.HeaderType = ppd.HeaderType
+		// The wire HeaderType (ppd.HeaderType) is NOT authenticated, so
+		// trusting it would let an on-path attacker flip NHP_KNK <-> NHP_EXT
+		// and forge the open/close decision. Require it to match the
+		// AEAD-authenticated body HeaderType the agent carries; on success
+		// knkMsg.HeaderType already holds that (equal) authenticated value.
+		// Rejected unconditionally on a mismatch or a legacy unpopulated
+		// body — secure by default. See knock_headertype.go.
+		if gateErr := verifyKnockHeaderType(knkMsg.HeaderType, ppd.HeaderType, transactionId, addrStr); gateErr != nil {
+			err = gateErr
+			ackMsg.ErrCode = gateErr.ErrorCode()
+			ackMsg.ErrMsg = gateErr.Error()
+			return
+		}
 
 		// find out auth service provider
 		aspData := s.FindAuthSvcProvider(knkMsg.AuthServiceId)

--- a/nhp/common/errors.go
+++ b/nhp/common/errors.go
@@ -115,6 +115,12 @@ var (
 	ErrAuthHandlerNotFound         = newError("52006", "failed to find auth handler", "无法找到验证处理接口")
 	ErrBackendAuthRequired         = newError("52007", "server backend auth required", "服务器需要后端敲门验证")
 	ErrUrlPathInvalid              = newError("52008", "client request url path is invalid", "请求路径无效")
+	// Knock HeaderType verification (on-path header-flip protection). The agent
+	// mirrors the wire HeaderType inside the AEAD-authenticated knock body
+	// (AgentKnockMsg.HeaderType); the server requires the two to match and
+	// rejects otherwise. See endpoints/server/knock_headertype.go.
+	ErrKnockHeaderTypeMismatch = newError("52009", "knock body header type does not match wire header type", "敲门报文体头部类型与报文头部类型不匹配")
+	ErrKnockHeaderTypeLegacy   = newError("52010", "knock body header type missing, please upgrade agent", "敲门报文体缺少头部类型，请升级agent")
 
 	// ac
 	ErrACOperationFailed       = newError("53001", "ac operation failed", "门禁操作失败")


### PR DESCRIPTION
## Summary

The server decides whether an incoming knock is an **open** (`NHP_KNK` / `NHP_RKN`) or a **close** (`NHP_EXT`) from the packet's **wire** `HeaderType`. That byte is **not** covered by the AEAD / noise chain-hash, and the trailing header digest is an unkeyed hash over public values — so an on-path attacker can flip it and the server trusts the flip.

This PR authenticates the knock type: the agent carries it inside the AEAD-protected body, and the server **requires** the body and wire values to match. Verification is **secure by default** — there is no opt-in switch.

## Security context

**Vulnerability.** On the UDP knock path, `endpoints/server/nhpauth.go` set `knkMsg.HeaderType = ppd.HeaderType` — copying the *unauthenticated wire* header type into the message the rest of the handler trusts. The open/close decision is made from it (`endpoints/server/udpserver.go`):

```go
openTime := res.OpenTime
if knkMsg.HeaderType == core.NHP_EXT {
    openTime = 1 // expire the access rule in ~1s
}
```

**Attack.** An attacker on the network path between a legitimate agent and the server (able to modify UDP datagrams) flips a genuine agent's knock from `NHP_KNK` (open) to `NHP_EXT` (close) on the wire. The header type is outside the AEAD and the header digest is an unkeyed hash over public inputs, so the attacker recomputes it after the flip; the packet still carries the legitimate agent's authenticated body, so it passes auth. The server then runs `processACOperation` with `openTime = 1`.

**Impact.** Targeted **denial of access** — the victim agent's access is revoked (expires in ~1s) even though it requested an open. The inverse flip (`NHP_EXT` → `NHP_KNK`) suppresses an intended close. This is an availability/integrity-of-control attack on a legitimate session; no key material is compromised and the tunnel crypto is not broken.

**Affected.** All current versions — the agent never populated the body header type, and the server trusted the wire value.

**Fix.** The agent mirrors the wire `HeaderType` inside the AEAD-authenticated knock body (`AgentKnockMsg.HeaderType` — a field that already existed but was never populated). Because the body is inside the chain-hash-authenticated payload, an attacker cannot flip it without the initiator's static private key. The server requires body == wire and uses the authenticated body value.

## What changed

- **Agent** (`endpoints/agent/knock.go`): populate `AgentKnockMsg.HeaderType` in the knock (`NHP_KNK`/`NHP_RKN`) and exit-knock (`NHP_EXT`) paths, derived from the same variable that sets the wire header so the two can't drift.
- **Server** (`endpoints/server/nhpauth.go` + new `knock_headertype.go`): replace the blind wire→body copy with **unconditional** verification (`verifyKnockHeaderType`). No metrics dependency, logging only.
- **Errors** (`nhp/common/errors.go`): `ErrKnockHeaderTypeMismatch` (52009, on-path tampering) and `ErrKnockHeaderTypeLegacy` (52010, agent missing the field).

Rejection is unconditional — secure by default, no compatibility flag:

- body `HeaderType` **missing** (agent predates this change) → rejected (`52010`)
- body **disagrees** with the wire (tampering) → rejected (`52009`)

## ⚠️ Breaking change

A server built from this change **rejects any agent that does not populate `AgentKnockMsg.HeaderType`** (error `52010`). This PR updates **both first-party agents in lockstep**: the Go agent (`endpoints/agent`) and the JS/TS agent (`endpoints/js-agent`).

**Other clients are affected and must be upgraded before this server is deployed.** Any external/third-party SDK — and the iOS SDK — that builds an `AgentKnockMsg` without `headerType` will be rejected as `52010` (its knock body unmarshals to `HeaderType = 0` / `NHP_KPL`). Build and deploy all agents from this change together with the server. There is intentionally **no opt-in/permit mode**: trusting the unauthenticated wire header is the vulnerability, so it is closed by default.

## Type of Change

- [x] Bug fix (security)
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD improvement

## Related Issues

No existing upstream issue — reported here.

## Testing

- [x] Server unit tests added (`endpoints/server/knock_headertype_test.go`): accepts matching body/wire; rejects an unpopulated (legacy) body as `52010` and a flipped body/wire as `52009`.
- [x] JS agent unit tests added (`endpoints/js-agent/test/NHPAgent.test.ts`): the KNK knock body carries `headerType` matching the wire type over a real round-trip; sequential KNK/RNK sends set `headerType` to `1`/`8` per send without mutating the shared body. `npm run test:run` (124 passing) and `npm run build` are green.
- [x] `go build ./...` and `go vet` pass on both modules (`nhp/`, `endpoints/`).
- [x] Existing tests pass (the in-package `server` suite requires the KBS key directory an `init()` creates, as in CI).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (extensive code comments)
- [x] No new warnings introduced


