### PR TITLE
ci: run Claude PR review on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,8 +9,13 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
-  pull_request:
-    types: [opened, synchronize]
+  # SECURITY: pull_request_target (not pull_request) so the auto-review can run on
+  # PRs from forks. Fork `pull_request` runs get a read-only token and no secrets,
+  # so the review job fails on every external contribution. pull_request_target runs
+  # in the base-repo context (secrets + write token available); the claude-pr-review
+  # job below is hardened to never check out or execute untrusted PR-head code.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   # Respond to @claude mentions
@@ -44,8 +49,8 @@ jobs:
   # Automatic code review on PR open/update
   claude-pr-review:
     if: |
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' || github.event.action == 'synchronize') &&
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened') &&
       !endsWith(github.actor, '[bot]')
     runs-on: ubuntu-latest
     permissions:
@@ -55,9 +60,15 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - name: Checkout repository
+      # SECURITY: pull_request_target exposes repository secrets and a write token.
+      # Pin the checkout to the BASE commit so untrusted PR-head code is never placed
+      # on disk or executed. The PR is reviewed entirely through the GitHub API
+      # (gh pr diff/view) and Claude's tools are restricted to read-only `gh pr`
+      # subcommands below, so the diff content is treated as data, not code.
+      - name: Checkout base (trusted) — never the PR head
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Summary

The `claude-pr-review` auto-review job uses the `pull_request` trigger. GitHub runs `pull_request` jobs from **forks** with a read-only token and **no repository secrets**, so the job fails on every external (fork) contribution — even though it works fine on internal branches.

Evidence on this repo:
- ✅ `success` on internal branches (`chore/js-agent-demo-tweaks`, `chore/bump-version-0.8.0`)
- ❌ `failure` on fork PR #1584 (`fix/knock-headertype-verify`) — [failing run](https://github.com/OpenNHP/opennhp/actions/runs/27551266701/job/81437907613): empty `ANTHROPIC_API_KEY` and `Could not fetch an OIDC token` (write-scoped OIDC is denied to fork `pull_request` runs).

## Fix

Switch the auto-review trigger from `pull_request` to **`pull_request_target`**, which runs in the **base-repo context** where secrets and a write token are available for *all* PRs, including forks. This is the documented pattern for supporting fork PR review.

## Security hardening

`pull_request_target` is privileged (secrets + write token), so the job is hardened to never trust contributor code:

- **Checkout pinned to the base commit** (`github.event.pull_request.base.sha`), never the PR head — untrusted contributor code is never placed at the workspace root or executed. This follows the action's own security guidance (*"Preferred — check out the base ref"*); the action reads the PR through the GitHub API and does **not** need the head on disk.
- **Tools stay restricted** to read-only `gh pr` subcommands (unchanged), so the diff is treated as data, not code. The residual surface is bounded to a possible misleading review/comment via prompt-injection — **not** code execution or secret exfiltration.
- The PR number and repo slug are the only values interpolated into the prompt (no untrusted free-text in `run:`).

## ⚠️ Validation note (by design, not oversight)

`pull_request_target` always reads the workflow from the **default branch**, so this change **cannot be exercised until it is merged to `main`**:

- This PR's own checks will **not** show a Claude review (the `pull_request_target` event reads the old `main`; the `pull_request` handler is removed on this branch). Expected.
- After merge, re-trigger a fork PR (e.g. close/reopen #1584 — `reopened` is in the trigger types) to confirm the review actually posts on a fork. The one-file change is trivially revertable if it misbehaves.

## What changed

`.github/workflows/claude.yml`:
- `on: pull_request` → `on: pull_request_target` (`types: [opened, synchronize, reopened]`). `pull_request` was used only by this job.
- `claude-pr-review` `if:` guard updated to `pull_request_target`.
- Checkout pinned to `base.sha` with a security comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
