### PR TITLE
ci: use GITHUB_TOKEN for Claude PR review under pull_request_target

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,6 +76,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # GitHub auth: use the workflow GITHUB_TOKEN directly. Under
+          # pull_request_target the default OIDC -> GitHub-App token exchange is
+          # rejected ("Invalid OIDC token", anthropics/claude-code-action#873), so
+          # bypass it. Reviews post as github-actions[bot]; the job's permissions
+          # block scopes this token (pull-requests/issues: write, contents: read).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Restrict tools to safe GitHub CLI operations for PR review
           claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr checks:*),Bash(gh pr comment:*)"'
           prompt: |
@@ -99,8 +105,10 @@ jobs:
               `gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your review"`
             - If you find only minor issues (categories 4-5):
               `gh pr review ${{ github.event.pull_request.number }} --comment --body "your review"`
-            - If the code looks good:
-              `gh pr review ${{ github.event.pull_request.number }} --approve --body "your review"`
+            - If the code looks good (post a comment, NOT a formal approval — the
+              GITHUB_TOKEN bot cannot approve PRs, and a bot approval must not
+              satisfy required-review branch protection):
+              `gh pr review ${{ github.event.pull_request.number }} --comment --body "your review"`
 
             ## Response Format
             Start your review with a summary line:


### PR DESCRIPTION
## Summary

Follow-up to #1586. That PR switched `claude-pr-review` to `pull_request_target` so the job *runs* on fork PRs (secrets + token now available). Re-triggering fork PR #1584 confirmed the secrets half is fixed (`ANTHROPIC_API_KEY` now populated, OIDC token obtained) — but it surfaced a **second, separate failure** in the GitHub-auth half:

```
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

The action's default GitHub auth exchanges the OIDC token for a **GitHub App** installation token. That exchange does **not** accept the `pull_request_target` context (it works only on internal `pull_request` runs, which is why internal PRs pass). This is a known issue: [anthropics/claude-code-action#873](https://github.com/anthropics/claude-code-action/issues/873).

## Fix

Pass **`github_token: ${{ secrets.GITHUB_TOKEN }}`** so the action uses the workflow token directly and skips the OIDC app-token exchange (the documented workaround in #873).

This routes the **same review-posting path that already succeeds on internal PRs** around the OIDC exchange — the only deltas from that proven path are the token source and one capability:

- Under `pull_request_target`, `GITHUB_TOKEN` is a **base-repo write** token, so posting `--comment` / `--request-changes` reviews on fork PRs works.
- `GITHUB_TOKEN` **cannot approve** PRs (GitHub policy), and a bot approval must not satisfy required-review branch protection — so the "looks good" path now posts a `--comment` review instead of `--approve`.

Tradeoffs (acceptable): reviews post as `github-actions[bot]` instead of `claude[bot]`; `use_sticky_comment` (unused here) is unavailable.

## What changed

`.github/workflows/claude.yml` (claude-pr-review job only):
- Add `github_token: ${{ secrets.GITHUB_TOKEN }}`.
- "Looks good" review path: `--approve` → `--comment`.

`id-token: write` is intentionally left in place (now-unused but harmless; a later least-privilege pass can remove it).

## ⚠️ Validation note

Like #1586, `pull_request_target` reads the workflow from `main`, so this only takes effect **after merge**. Post-merge I'll re-trigger fork PR #1584 and confirm a review actually posts (as `github-actions[bot]`) and the check goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
