### PR TITLE
feat(server): optional DisableKnockHeaderTypeValidation flag (default: enforced)

### DIFF
--- a/endpoints/server/config.go
+++ b/endpoints/server/config.go
@@ -88,6 +88,17 @@ type Config struct {
 	DefaultCipherScheme    int    `json:"defaultCipherScheme"`
 	DisableAgentValidation bool   `json:"disableAgentValidation"`
 
+	// DisableKnockHeaderTypeValidation opts OUT of the knock HeaderType
+	// authentication check (see knock_headertype.go). Default false = enforced
+	// (secure): a knock whose AEAD-authenticated body HeaderType is missing
+	// (legacy agent) or disagrees with the wire HeaderType (on-path tampering)
+	// is rejected. Set true ONLY as a temporary transition escape hatch while a
+	// legacy agent fleet that predates the body HeaderType is migrated; each
+	// suppressed rejection is logged at WARN so the open window stays visible.
+	// Return to false once the fleet is migrated. Read race-free in the knock
+	// hot path via the s.disableKnockHeaderTypeValidation atomic mirror.
+	DisableKnockHeaderTypeValidation bool `json:"disableKnockHeaderTypeValidation"`
+
 	// AllowPrivateRelaySource relaxes the SourceAddr public-routability check
 	// that HandleRelayForward applies to inner KNK packets arriving via a
 	// relay. When false (production default), private / loopback / CGNAT
@@ -587,6 +598,16 @@ func (s *UdpServer) updateBaseConfig(conf Config) (err error) {
 		// the field comment in UdpServer for why the bool isn't read
 		// directly from s.config under no lock.
 		s.allowPrivateRelaySource.Store(conf.AllowPrivateRelaySource)
+	}
+
+	if s.config.DisableKnockHeaderTypeValidation != conf.DisableKnockHeaderTypeValidation {
+		log.Info("DisableKnockHeaderTypeValidation set to %v (knock HeaderType authentication is %s)",
+			conf.DisableKnockHeaderTypeValidation,
+			map[bool]string{true: "DISABLED (transition escape hatch)", false: "enforced"}[conf.DisableKnockHeaderTypeValidation])
+		s.config.DisableKnockHeaderTypeValidation = conf.DisableKnockHeaderTypeValidation
+		// Mirror onto the atomic-read field the knock hot path consults; see
+		// the field comment in UdpServer.
+		s.disableKnockHeaderTypeValidation.Store(conf.DisableKnockHeaderTypeValidation)
 	}
 
 	if s.config.DefaultCipherScheme != conf.DefaultCipherScheme {

--- a/endpoints/server/knock_headertype.go
+++ b/endpoints/server/knock_headertype.go
@@ -60,3 +60,22 @@ func verifyKnockHeaderType(bodyType, wireType int, transactionId uint64, addrStr
 	}
 	return nil
 }
+
+// enforceKnockHeaderType applies the HeaderType gate for one knock and is the
+// sole request-path caller of verifyKnockHeaderType. It returns a non-nil
+// *common.Error to reject when enforcement is on (the default). When
+// DisableKnockHeaderTypeValidation is set — a temporary transition escape hatch
+// for a legacy agent fleet that predates the body HeaderType (see config.go) —
+// a would-be rejection is instead logged at WARN and nil is returned, so the
+// legacy/mismatched knock is accepted. The flag is read from the atomic mirror
+// so this stays race-free against a concurrent config reload, matching
+// allowPrivateRelaySource.
+func (s *UdpServer) enforceKnockHeaderType(bodyType, wireType int, transactionId uint64, addrStr string) *common.Error {
+	gateErr := verifyKnockHeaderType(bodyType, wireType, transactionId, addrStr)
+	if gateErr == nil || !s.disableKnockHeaderTypeValidation.Load() {
+		return gateErr
+	}
+	log.Warning("server-agent(#%d@%s)[HeaderType] check failed but DisableKnockHeaderTypeValidation=true: accepting anyway (legacy agent or on-path tampering): %s",
+		transactionId, addrStr, gateErr.Error())
+	return nil
+}

--- a/endpoints/server/knock_headertype_test.go
+++ b/endpoints/server/knock_headertype_test.go
@@ -41,3 +41,38 @@ func TestVerifyKnockHeaderType(t *testing.T) {
 		})
 	}
 }
+
+// TestEnforceKnockHeaderType_Gate covers the DisableKnockHeaderTypeValidation
+// gate around verifyKnockHeaderType: with enforcement on (flag false) a legacy
+// or mismatched body is rejected; with enforcement disabled (flag true, the
+// transition escape hatch) the same body is accepted. A matching body is
+// accepted either way.
+func TestEnforceKnockHeaderType_Gate(t *testing.T) {
+	cases := []struct {
+		name     string
+		disabled bool
+		body     int
+		wire     int
+		wantErr  *common.Error
+	}{
+		{"enforced_ok", false, core.NHP_KNK, core.NHP_KNK, nil},
+		{"enforced_legacy_rejected", false, core.NHP_KPL, core.NHP_KNK, common.ErrKnockHeaderTypeLegacy},
+		{"enforced_mismatch_rejected", false, core.NHP_KNK, core.NHP_EXT, common.ErrKnockHeaderTypeMismatch},
+
+		{"disabled_ok_still_ok", true, core.NHP_KNK, core.NHP_KNK, nil},
+		{"disabled_legacy_accepted", true, core.NHP_KPL, core.NHP_KNK, nil},
+		{"disabled_mismatch_accepted", true, core.NHP_KNK, core.NHP_EXT, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &UdpServer{}
+			s.disableKnockHeaderTypeValidation.Store(tc.disabled)
+			got := s.enforceKnockHeaderType(tc.body, tc.wire, 1, "test-addr")
+			if got != tc.wantErr {
+				t.Errorf("enforceKnockHeaderType(disabled=%v, body=%d, wire=%d) = %v, want %v",
+					tc.disabled, tc.body, tc.wire, got, tc.wantErr)
+			}
+		})
+	}
+}

--- a/endpoints/server/nhpauth.go
+++ b/endpoints/server/nhpauth.go
@@ -63,9 +63,11 @@ func (s *UdpServer) HandleKnockRequest(ppd *core.PacketParserData) (err error) {
 		// and forge the open/close decision. Require it to match the
 		// AEAD-authenticated body HeaderType the agent carries; on success
 		// knkMsg.HeaderType already holds that (equal) authenticated value.
-		// Rejected unconditionally on a mismatch or a legacy unpopulated
-		// body — secure by default. See knock_headertype.go.
-		if gateErr := verifyKnockHeaderType(knkMsg.HeaderType, ppd.HeaderType, transactionId, addrStr); gateErr != nil {
+		// Rejected on a mismatch or a legacy unpopulated body — secure by
+		// default. DisableKnockHeaderTypeValidation can suppress the reject
+		// during a fleet-migration transition (each suppression logged at
+		// WARN); see knock_headertype.go / config.go.
+		if gateErr := s.enforceKnockHeaderType(knkMsg.HeaderType, ppd.HeaderType, transactionId, addrStr); gateErr != nil {
 			err = gateErr
 			ackMsg.ErrCode = gateErr.ErrorCode()
 			ackMsg.ErrMsg = gateErr.Error()

--- a/endpoints/server/udpserver.go
+++ b/endpoints/server/udpserver.go
@@ -55,6 +55,11 @@ type UdpServer struct {
 	allowPrivateRelaySource atomic.Bool
 	forceOverload           atomic.Bool
 
+	// disableKnockHeaderTypeValidation mirrors Config.DisableKnockHeaderTypeValidation
+	// for the knock hot path (enforceKnockHeaderType), read without a lock the
+	// same way allowPrivateRelaySource is. Stored at startup and on config reload.
+	disableKnockHeaderTypeValidation atomic.Bool
+
 	// connection and remote transaction management
 
 	remoteConnectionMapMutex sync.Mutex
@@ -327,6 +332,7 @@ func (s *UdpServer) Start(dirPath string, logLevel int) (err error) {
 	// trigger may also be active and we don't want to fight it.
 	s.forceOverload.Store(s.config.ForceOverload)
 	s.allowPrivateRelaySource.Store(s.config.AllowPrivateRelaySource)
+	s.disableKnockHeaderTypeValidation.Store(s.config.DisableKnockHeaderTypeValidation)
 	if s.config.ForceOverload {
 		// Critical (not Warning): each of these flags disables a real
 		// production safeguard, and Warning is filtered out of default


### PR DESCRIPTION
## What

Adds an opt-out server config flag, `DisableKnockHeaderTypeValidation`, **default `false` = enforced** — the secure-by-default behavior from `cfa08718` is unchanged.

## Why

`cfa08718` made knock HeaderType authentication **unconditional**: a server carrying it rejects any agent that doesn't populate `AgentKnockMsg.HeaderType` (`ErrKnockHeaderTypeLegacy`) and any wire/body mismatch. That's the correct secure default, but it forces a **flag-day cutover** when a server is upgraded ahead of a legacy agent fleet that predates the body HeaderType — every old agent's knock breaks the instant the server upgrades.

This flag is a **temporary transition escape hatch**: set `disableKnockHeaderTypeValidation = true` to run a new-protocol server that still admits legacy agents during a migration window, then **remove it to return to enforced** once the fleet is upgraded. It lets the server move first without a flag day; the intended end state is the flag gone.

## Behavior

- **Default (`false`): enforced** — no change from `cfa08718`.
- **`true`:** a would-be rejection is logged at `WARN` (`…check failed but DisableKnockHeaderTypeValidation=true: accepting anyway…`) and the knock is accepted — so the relaxed window is visible and migration progress (how many legacy knocks still land) is observable.
- Read via an atomic mirror (matching `allowPrivateRelaySource`) so the knock hot path stays race-free against a config reload; **hot-reloadable** (no restart to flip).
- The gate lives in a new `enforceKnockHeaderType` method wrapping the **unchanged** `verifyKnockHeaderType`.

## Testing

- `go build` + `go vet` clean on `endpoints/server`.
- Added `TestEnforceKnockHeaderType_Gate` (table test, both enforced and disabled). Note: `go test ./server/...` can't run in a plain dev checkout because `kbs/resource`'s package `init()` does `mkdir /opt/confidential-containers` (unrelated to this change) and panics without it — CI is the test executor.

## Security note

Enabling this flag **relaxes the on-path HeaderType-tampering protection** `cfa08718` added. It is secure-by-default and intended only as a bounded, observable migration window; suppressed rejections are logged at WARN so the relaxed window cannot go unnoticed.