### PR TITLE
fix: prevent transaction sends from racing teardown

### DIFF
--- a/endpoints/ac/msghandler.go
+++ b/endpoints/ac/msghandler.go
@@ -81,7 +81,10 @@ func (a *UdpAC) HandleUdpACOperations(ppd *core.PacketParserData) (err error) {
 		return err
 	}
 
-	transaction.NextMsgCh <- md
+	if sendErr := transaction.SendMessage(md); sendErr != nil {
+		log.Error("ac(%s#%d)[HandleUdpACOperations] transaction closed before forward: %v", acId, transactionId, sendErr)
+		return sendErr
+	}
 
 	return err
 }

--- a/endpoints/ac/udpac.go
+++ b/endpoints/ac/udpac.go
@@ -481,7 +481,10 @@ func (a *UdpAC) connectionRoutine(conn *UdpConn) {
 				transactionId := pkt.Counter()
 				transaction := a.device.FindLocalTransaction(transactionId)
 				if transaction != nil {
-					transaction.NextPacketCh <- pkt
+					if err := transaction.SendPacket(pkt); err != nil {
+						log.Warning("local transaction %d closed before packet forward: %v", transactionId, err)
+						a.device.ReleasePoolPacket(pkt)
+					}
 					continue
 				}
 			}

--- a/endpoints/agent/msghandler.go
+++ b/endpoints/agent/msghandler.go
@@ -34,6 +34,9 @@ func (a *UdpAgent) HandleCookieMessage(ppd *core.PacketParserData) bool {
 	}
 
 	log.Info("agent(#%d)[HandleCookieMessage] redirect cookie message to original knock transaction", transactionId)
-	transaction.ExternalMsgCh <- ppd
+	if err := transaction.SendExternalMsg(ppd); err != nil {
+		log.Error("agent(#%d)[HandleCookieMessage] transaction closed before forward: %v", transactionId, err)
+		return false
+	}
 	return true
 }

--- a/endpoints/agent/udpagent.go
+++ b/endpoints/agent/udpagent.go
@@ -721,7 +721,10 @@ func (a *UdpAgent) connectionRoutine(conn *UdpConn) {
 				transactionId := pkt.Counter()
 				transaction := a.device.FindLocalTransaction(transactionId)
 				if transaction != nil {
-					transaction.NextPacketCh <- pkt
+					if err := transaction.SendPacket(pkt); err != nil {
+						log.Warning("local transaction %d closed before packet forward: %v", transactionId, err)
+						a.device.ReleasePoolPacket(pkt)
+					}
 					continue
 				}
 			}

--- a/endpoints/db/udpdevice.go
+++ b/endpoints/db/udpdevice.go
@@ -425,7 +425,10 @@ func (a *UdpDevice) connectionRoutine(conn *UdpConn) {
 				transactionId := pkt.Counter()
 				transaction := a.device.FindLocalTransaction(transactionId)
 				if transaction != nil {
-					transaction.NextPacketCh <- pkt
+					if err := transaction.SendPacket(pkt); err != nil {
+						log.Warning("local transaction %d closed before packet forward: %v", transactionId, err)
+						a.device.ReleasePoolPacket(pkt)
+					}
 					continue
 				}
 			}
@@ -889,7 +892,10 @@ func (a *UdpDevice) HandleUdpDataKeyWrappingOperations(ppd *core.PacketParserDat
 		return err
 	}
 
-	transaction.NextMsgCh <- md
+	if sendErr := transaction.SendMessage(md); sendErr != nil {
+		log.Error("db(%s#%d)[HandleUdpDataKeyWrappingOperations] transaction closed before forward: %v", dbId, transactionId, sendErr)
+		return sendErr
+	}
 
 	return err
 }

--- a/endpoints/server/msghandler.go
+++ b/endpoints/server/msghandler.go
@@ -287,7 +287,10 @@ func (s *UdpServer) HandleRegisterRequest(ppd *core.PacketParserData) (err error
 		return err
 	}
 
-	transaction.NextMsgCh <- rakMd
+	if sendErr := transaction.SendMessage(rakMd); sendErr != nil {
+		log.Error("server-agent(%s#%d@%s)[HandleRegisterRequest] transaction closed before forward: %v", regMsg.UserId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 
 	return err
 }
@@ -357,7 +360,10 @@ func (s *UdpServer) HandleListRequest(ppd *core.PacketParserData) (err error) {
 		return err
 	}
 
-	transaction.NextMsgCh <- ackMd
+	if sendErr := transaction.SendMessage(ackMd); sendErr != nil {
+		log.Error("server-agent(%s#%d@%s)[HandleListRequest] transaction closed before forward: %v", lstMsg.UserId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 
 	return err
 }
@@ -417,7 +423,10 @@ func (s *UdpServer) HandleACOnline(ppd *core.PacketParserData) (err error) {
 		return err
 	}
 
-	transaction.NextMsgCh <- aakMd
+	if sendErr := transaction.SendMessage(aakMd); sendErr != nil {
+		log.Error("server-ac(%s#%d@%s)[HandleACOnline] transaction closed before forward: %v", acId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 
 	return nil
 }
@@ -475,7 +484,10 @@ func (s *UdpServer) HandleDBOnline(ppd *core.PacketParserData) (err error) {
 		return err
 	}
 
-	transaction.NextMsgCh <- aakMd
+	if sendErr := transaction.SendMessage(aakMd); sendErr != nil {
+		log.Error("server-db(%s#%d@%s)[HandleDBOnline] transaction closed before forward: %v", dbId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 
 	return nil
 }
@@ -526,7 +538,10 @@ func (s *UdpServer) HandleDHPDARMessage(ppd *core.PacketParserData) (err error) 
 		return err
 	}
 
-	transaction.NextMsgCh <- aakMd
+	if sendErr := transaction.SendMessage(aakMd); sendErr != nil {
+		log.Error("server-agent(%s#%d@%s)[HandleDHPDARMessage] transaction closed before forward: %v", doId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 
 	return nil
 }
@@ -615,7 +630,10 @@ func (s *UdpServer) HandleDHPDAVMessage(ppd *core.PacketParserData) (err error) 
 		return err
 	}
 
-	transaction.NextMsgCh <- aakMd
+	if sendErr := transaction.SendMessage(aakMd); sendErr != nil {
+		log.Error("server-agent(%s#%d@%s)[HandleDHPDAVMessage] transaction closed before forward: %v", doId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 
 	return nil
 }
@@ -670,7 +688,10 @@ func (s *UdpServer) HandleDHPDRGMessage(ppd *core.PacketParserData) (err error) 
 		err = common.ErrTransactionIdNotFound
 		return err
 	}
-	transaction.NextMsgCh <- aakMd
+	if sendErr := transaction.SendMessage(aakMd); sendErr != nil {
+		log.Error("server-db(%s#%d@%s)[HandleDHPDRGMessage] transaction closed before forward: %v", doId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 	return nil
 }
 

--- a/endpoints/server/nhpauth.go
+++ b/endpoints/server/nhpauth.go
@@ -135,6 +135,9 @@ func (s *UdpServer) HandleKnockRequest(ppd *core.PacketParserData) (err error) {
 		return err
 	}
 
-	transaction.NextMsgCh <- ackMd
+	if sendErr := transaction.SendMessage(ackMd); sendErr != nil {
+		log.Error("server-agent(%s#%d@%s)[HandleKnockRequest] transaction closed before forward: %v", knkMsg.UserId, transactionId, addrStr, sendErr)
+		return sendErr
+	}
 	return nil
 }

--- a/endpoints/server/udpserver.go
+++ b/endpoints/server/udpserver.go
@@ -834,7 +834,10 @@ func (s *UdpServer) connectionRoutine(conn *UdpConn) {
 				transactionId := pkt.Counter()
 				transaction := s.device.FindLocalTransaction(transactionId)
 				if transaction != nil {
-					transaction.NextPacketCh <- pkt
+					if err := transaction.SendPacket(pkt); err != nil {
+						log.Warning("local transaction %d closed before packet forward: %v", transactionId, err)
+						s.device.ReleasePoolPacket(pkt)
+					}
 					continue
 				}
 			}
@@ -929,7 +932,9 @@ func (s *UdpServer) sendMessageRoutine() {
 				// forward to a specific transaction
 				transaction := md.ConnData.FindRemoteTransaction(md.PrevParserData.SenderTrxId)
 				if transaction != nil {
-					transaction.NextMsgCh <- md
+					if err := transaction.SendMessage(md); err != nil {
+						log.Warning("remote transaction %d closed before message forward: %v", md.PrevParserData.SenderTrxId, err)
+					}
 					continue
 				}
 			}

--- a/nhp/common/errors.go
+++ b/nhp/common/errors.go
@@ -86,6 +86,7 @@ var (
 	ErrPacketToMessageRoutineStopped       = newError("50007", "packet to message routine stopped", "消息处理线程已停止")
 	ErrInvalidIpAddress                    = newError("50008", "invalid ip address", "ip地址无效")
 	ErrPacketEncryptionFailed              = newError("50009", "packet encryption failed", "报文加密失败")
+	ErrTransactionClosed                   = newError("50010", "transaction is closed", "交互已关闭")
 
 	// agent
 	ErrKnockUserNotSpecified   = newError("51001", "knock user not specified", "没有指定敲门用户")

--- a/nhp/core/device.go
+++ b/nhp/core/device.go
@@ -301,13 +301,7 @@ func (d *Device) msgToPacketRoutine(id int) {
 				if d.IsTransactionRequest(mad.HeaderType) {
 					// save initiator transaction
 					mad.BasePacket.KeepAfterSend = true // packet is kept after sending and deleted at transaction level
-					t := &LocalTransaction{
-						transactionId: mad.header.Counter(),
-						connData:      mad.connData,
-						mad:           mad,
-						NextPacketCh:  make(chan *Packet),
-						timeout:       d.LocalTransactionTimeout(),
-					}
+					t := newLocalTransaction(mad.header.Counter(), mad.connData, mad, d.LocalTransactionTimeout())
 					d.AddLocalTransaction(t)
 					log.Debug("AddLocalTransaction:deviceType=%d,HeaderType=%d", d.deviceType, mad.HeaderType)
 				}
@@ -456,13 +450,7 @@ func (d *Device) packetToMsgRoutine(id int) {
 				log.Debug("packetToMsgRoutine: complete decrypting start IsTransactionRequest:deviceType:%d,headerType:%s", d.deviceType, HeaderTypeToString(ppd.HeaderType))
 				// start and save responder transaction
 				if d.IsTransactionRequest(ppd.HeaderType) {
-					t := &RemoteTransaction{
-						transactionId: ppd.SenderTrxId,
-						connData:      ppd.ConnData,
-						parserData:    ppd, // ppd is owned and to be destroyed by transaction
-						NextMsgCh:     make(chan *MsgData),
-						timeout:       d.RemoteTransactionTimeout(),
-					}
+					t := newRemoteTransaction(ppd.SenderTrxId, ppd.ConnData, ppd, d.RemoteTransactionTimeout())
 					ppd.ConnData.AddRemoteTransaction(t)
 					log.Debug("IsTransactionRequest:true")
 				}

--- a/nhp/core/transaction.go
+++ b/nhp/core/transaction.go
@@ -13,6 +13,7 @@ type LocalTransaction struct {
 	mad           *MsgAssemblerData
 	NextPacketCh  chan *Packet           // higher level entities should redirect packet to this channel
 	ExternalMsgCh chan *PacketParserData // a channel to receive an external msg to complete the transaction
+	done          chan struct{}          // closed by Run on exit; prevents sends to an exited transaction
 	timeout       int
 }
 
@@ -21,8 +22,71 @@ type RemoteTransaction struct {
 	connData      *ConnectionData
 	parserData    *PacketParserData
 	NextMsgCh     chan *MsgData // higher level entities should redirect message to this channel
+	done          chan struct{} // closed by Run on exit; prevents sends to an exited transaction
 	timeout       int
 }
+
+func newLocalTransaction(id uint64, connData *ConnectionData, mad *MsgAssemblerData, timeout int) *LocalTransaction {
+	return &LocalTransaction{
+		transactionId: id,
+		connData:      connData,
+		mad:           mad,
+		NextPacketCh:  make(chan *Packet),
+		ExternalMsgCh: make(chan *PacketParserData),
+		done:          make(chan struct{}),
+		timeout:       timeout,
+	}
+}
+
+func newRemoteTransaction(id uint64, connData *ConnectionData, parserData *PacketParserData, timeout int) *RemoteTransaction {
+	return &RemoteTransaction{
+		transactionId: id,
+		connData:      connData,
+		parserData:    parserData,
+		NextMsgCh:     make(chan *MsgData),
+		done:          make(chan struct{}),
+		timeout:       timeout,
+	}
+}
+
+// SendMessage forwards md to the transaction, or returns
+// common.ErrTransactionClosed if the transaction has already exited.
+func (t *RemoteTransaction) SendMessage(md *MsgData) error {
+	select {
+	case t.NextMsgCh <- md:
+		return nil
+	case <-t.done:
+		return common.ErrTransactionClosed
+	}
+}
+
+// Done is closed when the remote transaction exits.
+func (t *RemoteTransaction) Done() <-chan struct{} { return t.done }
+
+// SendPacket forwards pkt to the transaction, or returns
+// common.ErrTransactionClosed if the transaction has already exited.
+func (t *LocalTransaction) SendPacket(pkt *Packet) error {
+	select {
+	case t.NextPacketCh <- pkt:
+		return nil
+	case <-t.done:
+		return common.ErrTransactionClosed
+	}
+}
+
+// SendExternalMsg forwards ppd to the transaction, or returns
+// common.ErrTransactionClosed if the transaction has already exited.
+func (t *LocalTransaction) SendExternalMsg(ppd *PacketParserData) error {
+	select {
+	case t.ExternalMsgCh <- ppd:
+		return nil
+	case <-t.done:
+		return common.ErrTransactionClosed
+	}
+}
+
+// Done is closed when the local transaction exits.
+func (t *LocalTransaction) Done() <-chan struct{} { return t.done }
 
 func (d *Device) IsTransactionRequest(t int) bool {
 
@@ -142,16 +206,13 @@ func (t *LocalTransaction) Run() {
 	device := t.mad.device
 	var err error
 
-	t.ExternalMsgCh = make(chan *PacketParserData)
-
 	// clear up
 	defer func() {
 		t.mad.Destroy()
-		close(t.NextPacketCh)
-		close(t.ExternalMsgCh)
 
 		device.localTransactionMutex.Lock()
 		delete(device.localTransactionMap, t.transactionId)
+		close(t.done)
 		device.localTransactionMutex.Unlock()
 
 		// if local transaction is expecting a response, return an error
@@ -234,10 +295,10 @@ func (t *RemoteTransaction) Run() {
 
 	defer func() {
 		t.parserData.Destroy()
-		close(t.NextMsgCh)
 
 		conn.RemoteTransactionMutex.Lock()
 		delete(conn.RemoteTransactionMap, t.transactionId)
+		close(t.done)
 		conn.RemoteTransactionMutex.Unlock()
 
 		conn.Done()

--- a/nhp/core/transaction_test.go
+++ b/nhp/core/transaction_test.go
@@ -1,0 +1,211 @@
+package core
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	common "github.com/OpenNHP/opennhp/nhp/common"
+)
+
+func TestRemoteTransactionSendMessageAfterDone(t *testing.T) {
+	tx := &RemoteTransaction{
+		NextMsgCh: make(chan *MsgData),
+		done:      make(chan struct{}),
+	}
+	close(tx.done)
+
+	if err := tx.SendMessage(&MsgData{}); !errors.Is(err, common.ErrTransactionClosed) {
+		t.Fatalf("SendMessage after done = %v, want ErrTransactionClosed", err)
+	}
+}
+
+func TestRemoteTransactionSendRacesExit(t *testing.T) {
+	const (
+		iterations = 50
+		senders    = 64
+	)
+
+	for iteration := 0; iteration < iterations; iteration++ {
+		tx := &RemoteTransaction{
+			NextMsgCh: make(chan *MsgData),
+			done:      make(chan struct{}),
+		}
+
+		var delivered atomic.Int64
+		var closed atomic.Int64
+		var drainer sync.WaitGroup
+		drainer.Add(1)
+		go func() {
+			defer drainer.Done()
+			for {
+				select {
+				case <-tx.NextMsgCh:
+					delivered.Add(1)
+				case <-tx.done:
+					return
+				}
+			}
+		}()
+
+		panicCh := make(chan any, senders)
+		var entered atomic.Int64
+		var sendersWG sync.WaitGroup
+		for i := 0; i < senders; i++ {
+			sendersWG.Add(1)
+			go func() {
+				defer sendersWG.Done()
+				defer captureTransactionPanic(panicCh)
+				entered.Add(1)
+				if err := tx.SendMessage(&MsgData{}); errors.Is(err, common.ErrTransactionClosed) {
+					closed.Add(1)
+				} else if err != nil {
+					panicCh <- err
+				}
+			}()
+		}
+
+		for entered.Load() != senders {
+			runtime.Gosched()
+		}
+		close(tx.done)
+		sendersWG.Wait()
+		drainer.Wait()
+
+		select {
+		case recovered := <-panicCh:
+			t.Fatalf("iteration %d: send raced exit and panicked: %v", iteration, recovered)
+		default:
+		}
+		if got := delivered.Load() + closed.Load(); got != senders {
+			t.Fatalf("iteration %d: delivered + closed = %d, want %d", iteration, got, senders)
+		}
+	}
+}
+
+func TestRemoteTransactionSendRacesExitWithoutReceiver(t *testing.T) {
+	const senders = 64
+
+	tx := &RemoteTransaction{
+		NextMsgCh: make(chan *MsgData),
+		done:      make(chan struct{}),
+	}
+	var entered atomic.Int64
+	var sendersWG sync.WaitGroup
+	for i := 0; i < senders; i++ {
+		sendersWG.Add(1)
+		go func() {
+			defer sendersWG.Done()
+			entered.Add(1)
+			if err := tx.SendMessage(&MsgData{}); !errors.Is(err, common.ErrTransactionClosed) {
+				t.Errorf("SendMessage = %v, want ErrTransactionClosed", err)
+			}
+		}()
+	}
+
+	for entered.Load() != senders {
+		runtime.Gosched()
+	}
+	close(tx.done)
+
+	done := make(chan struct{})
+	go func() {
+		sendersWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("senders remained blocked after transaction exit")
+	}
+}
+
+func TestLocalTransactionSendsRaceExit(t *testing.T) {
+	const (
+		iterations = 30
+		senders    = 32
+	)
+
+	for iteration := 0; iteration < iterations; iteration++ {
+		tx := &LocalTransaction{
+			NextPacketCh:  make(chan *Packet),
+			ExternalMsgCh: make(chan *PacketParserData),
+			done:          make(chan struct{}),
+		}
+
+		var drainers sync.WaitGroup
+		drainers.Add(2)
+		go drainUntilTransactionDone(tx.NextPacketCh, tx.done, &drainers)
+		go drainUntilTransactionDone(tx.ExternalMsgCh, tx.done, &drainers)
+
+		panicCh := make(chan any, senders*2)
+		var sendersWG sync.WaitGroup
+		for i := 0; i < senders; i++ {
+			sendersWG.Add(2)
+			go func() {
+				defer sendersWG.Done()
+				defer captureTransactionPanic(panicCh)
+				_ = tx.SendPacket(&Packet{})
+			}()
+			go func() {
+				defer sendersWG.Done()
+				defer captureTransactionPanic(panicCh)
+				_ = tx.SendExternalMsg(&PacketParserData{})
+			}()
+		}
+
+		runtime.Gosched()
+		close(tx.done)
+		sendersWG.Wait()
+		drainers.Wait()
+
+		select {
+		case recovered := <-panicCh:
+			t.Fatalf("iteration %d: local send raced exit and panicked: %v", iteration, recovered)
+		default:
+		}
+	}
+}
+
+func TestRemoteTransactionCleanupOrdering(t *testing.T) {
+	conn := &ConnectionData{RemoteTransactionMap: make(map[uint64]*RemoteTransaction)}
+	tx := &RemoteTransaction{
+		transactionId: 42,
+		NextMsgCh:     make(chan *MsgData),
+		done:          make(chan struct{}),
+	}
+	conn.RemoteTransactionMap[tx.transactionId] = tx
+
+	captured := conn.FindRemoteTransaction(tx.transactionId)
+	conn.RemoteTransactionMutex.Lock()
+	delete(conn.RemoteTransactionMap, tx.transactionId)
+	close(tx.done)
+	conn.RemoteTransactionMutex.Unlock()
+
+	if got := conn.FindRemoteTransaction(tx.transactionId); got != nil {
+		t.Fatalf("FindRemoteTransaction after cleanup = %p, want nil", got)
+	}
+	if err := captured.SendMessage(&MsgData{}); !errors.Is(err, common.ErrTransactionClosed) {
+		t.Fatalf("stale transaction SendMessage = %v, want ErrTransactionClosed", err)
+	}
+}
+
+func captureTransactionPanic(ch chan<- any) {
+	if recovered := recover(); recovered != nil {
+		ch <- recovered
+	}
+}
+
+func drainUntilTransactionDone[T any](ch <-chan T, done <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ch:
+		case <-done:
+			return
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- Added lifecycle `done` signals and safe send helpers for local and remote transactions.
- Removed message-channel closes from transaction teardown; transactions are removed from their lookup map and marked done under the same mutex.
- Replaced every endpoint raw transaction-channel send with the safe helpers.
- Released late response packets when a local transaction exits between lookup and delivery.
- Added focused race-stress tests for remote messages, local packets, external messages, stale pointers, and blocked senders.

## Why

`FindLocalTransaction` and `FindRemoteTransaction` could return a transaction immediately before its `Run` cleanup closed the destination channel. The caller then sent through that stale pointer and panicked with `send on closed channel`, terminating the process. A plain pre-send closed check cannot make the lookup/send sequence atomic.

The new helpers select between delivery and an immutable lifecycle signal. The data channels are left for garbage collection, while map removal and lifecycle closure share the lookup mutex. A stale caller now receives `ErrTransactionClosed` instead of panicking or remaining blocked.

This improves server and endpoint availability during timeout, disconnect, and reconnect races. It ports the repository-agnostic core of [layervai/nhp#1096](https://github.com/layervai/nhp/pull/1096) to current OpenNHP.

## Validation

- `go test -race -run 'Test(Remote|Local)Transaction' -count=10 ./core` (`nhp` module)
- `go test -race -count=1 ./...` (`nhp` module)
- `go test -race -count=1 ./ac ./agent ./db` (`endpoints` module)
- `go test -race -c ./server` (`endpoints` module)
- `go vet ./...` in both modules

The full endpoint test sweep also reaches two unrelated current-main failures: relay expects a 301/400 redirect but receives 307, and server test initialization attempts to create `/opt/confidential-containers`. The changed endpoint packages pass and the server race build succeeds.
