### PR TITLE
fix(agent): preserve extension response errors

### DIFF
--- a/endpoints/agent/knock.go
+++ b/endpoints/agent/knock.go
@@ -214,7 +214,7 @@ func (a *UdpAgent) knockRequest(res *KnockTarget, useCookie bool) (ackMsg *commo
 
 	if ackMsg.ErrCode != common.ErrSuccess.ErrorCode() {
 		log.Error("agent(%s#%d)[KnockRequest] response error: %s", knkMsg.UserId, knkMd.TransactionId, ackMsg.ErrMsg)
-		err = common.ErrorCodeToError(ackMsg.ErrCode)
+		err = common.ErrorFromResponse(ackMsg.ErrCode, ackMsg.ErrMsg)
 		return ackMsg, err
 	}
 
@@ -338,7 +338,7 @@ func (a *UdpAgent) ExitKnockRequest(res *KnockTarget) (ackMsg *common.ServerKnoc
 
 	if ackMsg.ErrCode != common.ErrSuccess.ErrorCode() {
 		log.Error("agent(%s#%d)[ExitKnockRequest] response error: %s", knkMsg.UserId, knkMd.TransactionId, ackMsg.ErrMsg)
-		err = common.ErrorCodeToError(ackMsg.ErrCode)
+		err = common.ErrorFromResponse(ackMsg.ErrCode, ackMsg.ErrMsg)
 		return ackMsg, err
 	}
 
@@ -579,7 +579,7 @@ func (a *UdpAgent) KnockDHP() (ackMsg *common.ServerDHPKnockAckMsg, err error) {
 
 	if ackMsg.ErrCode != common.ErrSuccess.ErrorCode() {
 		log.Error("agent(%s#%d)[KnockDHP] response error: %s", knkMsg.UserId, knkMd.TransactionId, ackMsg.ErrMsg)
-		err = common.ErrorCodeToError(ackMsg.ErrCode)
+		err = common.ErrorFromResponse(ackMsg.ErrCode, ackMsg.ErrMsg)
 		return ackMsg, err
 	}
 

--- a/endpoints/agent/request.go
+++ b/endpoints/agent/request.go
@@ -156,7 +156,7 @@ func (a *UdpAgent) RegisterPublicKey(otp string, target *KnockTarget) (rakMsg *c
 
 	if rakMsg.ErrCode != common.ErrSuccess.ErrorCode() {
 		log.Error("agent(%s#%d)[RegisterPublicKey] response error: %s", regMsg.UserId, regMd.TransactionId, rakMsg.ErrMsg)
-		err = common.ErrorCodeToError(rakMsg.ErrCode)
+		err = common.ErrorFromResponse(rakMsg.ErrCode, rakMsg.ErrMsg)
 		return rakMsg, err
 	}
 
@@ -243,7 +243,7 @@ func (a *UdpAgent) ListResource(target *KnockTarget) (lrtMsg *common.ServerListR
 
 	if lrtMsg.ErrCode != common.ErrSuccess.ErrorCode() {
 		log.Error("agent(%s#%d)[ListResource] list response error: %s", lstMsg.UserId, lstMd.TransactionId, lrtMsg.ErrMsg)
-		err = common.ErrorCodeToError(lrtMsg.ErrCode)
+		err = common.ErrorFromResponse(lrtMsg.ErrCode, lrtMsg.ErrMsg)
 		return lrtMsg, err
 	}
 

--- a/nhp/common/errors.go
+++ b/nhp/common/errors.go
@@ -72,6 +72,20 @@ func ErrorCodeToError(code string) *Error {
 	return nil // should not happen
 }
 
+// ErrorFromResponse maps a protocol response's code to a concrete error. Known
+// NHP codes retain their canonical, localized error. Extension codes emitted by
+// an auth service or AC retain the authenticated response message instead of
+// becoming a nil *Error inside a non-nil error interface.
+func ErrorFromResponse(code, message string) *Error {
+	if e := ErrorCodeToError(code); e != nil {
+		return e
+	}
+	if message == "" {
+		message = "unknown NHP error code " + code
+	}
+	return &Error{code: code, msgEN: message, msgCH: message}
+}
+
 // application errors
 var (
 	// generic

--- a/nhp/common/errors_test.go
+++ b/nhp/common/errors_test.go
@@ -1,0 +1,43 @@
+package common
+
+import "testing"
+
+func TestErrorFromResponseKnownCodeUsesCanonicalError(t *testing.T) {
+	got := ErrorFromResponse(ErrResourceNotFound.ErrorCode(), "untrusted wire text")
+	if got != ErrResourceNotFound {
+		t.Fatalf("ErrorFromResponse() = %p, want canonical error %p", got, ErrResourceNotFound)
+	}
+}
+
+func TestErrorFromResponseUnknownCodePreservesResponse(t *testing.T) {
+	const (
+		code    = "52142"
+		message = "registered agent owner is missing"
+	)
+
+	got := ErrorFromResponse(code, message)
+	if got == nil {
+		t.Fatal("ErrorFromResponse() returned nil")
+	}
+	if got.ErrorCode() != code {
+		t.Fatalf("ErrorCode() = %q, want %q", got.ErrorCode(), code)
+	}
+	if got.Error() != message {
+		t.Fatalf("Error() = %q, want %q", got.Error(), message)
+	}
+}
+
+func TestErrorFromResponseUnknownCodeWithoutMessageIsUseful(t *testing.T) {
+	const code = "59999"
+
+	got := ErrorFromResponse(code, "")
+	if got == nil {
+		t.Fatal("ErrorFromResponse() returned nil")
+	}
+	if got.ErrorCode() != code {
+		t.Fatalf("ErrorCode() = %q, want %q", got.ErrorCode(), code)
+	}
+	if got.Error() == "" {
+		t.Fatal("Error() is empty")
+	}
+}


### PR DESCRIPTION
## Summary

- add `common.ErrorFromResponse` for authenticated response code/message pairs
- retain canonical errors for built-in NHP codes
- preserve unknown auth-service and AC extension codes as concrete errors
- use the response-aware mapping for REG, LST, KNK, EXT, and DHP acknowledgements

## Why this matters

Auth services and ACs can legitimately return application-specific error codes outside OpenNHP's built-in error map. The current mapping returns a nil `*common.Error`; once stored in an `error` interface, callers see `err != nil` but panic when formatting it. Native UDP SDKs need a real error that preserves the authenticated code and message so they can fail closed and diagnose the rejection.

## Validation

- `cd nhp && go test ./common`
- `cd endpoints && go test ./agent`
- `cd nhp && golangci-lint run --new-from-rev=HEAD ./common`
- `cd endpoints && golangci-lint run --new-from-rev=HEAD ./agent`
- `git diff --check`
