### PR TITLE
docs(reg): number NHP-REG phase "Step 3 ·" in workflow diagram

### DIFF
--- a/endpoints/js-agent/examples/reg.html
+++ b/endpoints/js-agent/examples/reg.html
@@ -390,7 +390,7 @@
     <!-- Phase 3: NHP-REG -->
     <g class="seq-phase" id="seq-phase-reg">
       <rect class="seq-phase-box" x="8" y="230" width="384" height="128" rx="5"/>
-      <text class="seq-phase-label" x="16" y="244">NHP-REG  (prove &amp; register)</text>
+      <text class="seq-phase-label" x="16" y="244">Step 3 · NHP-REG  (prove &amp; register)</text>
 
       <line class="seq-msg" x1="55" y1="268" x2="200" y2="268"/>
       <polygon class="seq-arrowhead" points="200,268 194,265 194,271"/>

--- a/endpoints/js-agent/examples/reg.html
+++ b/endpoints/js-agent/examples/reg.html
@@ -37,9 +37,28 @@
     line-height: 1; cursor: pointer; opacity: 0.7; padding: 0;
   }
   #alert-container .alert-close:hover { opacity: 1; }
-  .page-header { text-align: left; max-width: 1200px; width: 100%; }
+  .page-header { text-align: left; max-width: 1200px; width: 100%;
+    display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
   .page-header h1 { color: #58a6ff; font-size: 26px; margin-bottom: 6px; }
   .page-header p { color: #8b949e; font-size: 14px; }
+  /* Language switcher */
+  .lang-switcher { position: relative; flex-shrink: 0; }
+  .lang-switcher button {
+    background: #21262d; color: #c9d1d9; border: 1px solid #30363d;
+    padding: 6px 12px; border-radius: 4px; font-size: 13px; cursor: pointer;
+    font-family: inherit; display: inline-flex; align-items: center; gap: 4px;
+  }
+  .lang-switcher button:hover { background: #30363d; }
+  .lang-switcher button .caret { font-size: 9px; color: #8b949e; }
+  .lang-switcher button .lang-icon { width: 14px; height: 14px; flex-shrink: 0; color: #8b949e; }
+  .lang-menu {
+    position: absolute; right: 0; top: calc(100% + 4px); background: #161b22;
+    border: 1px solid #30363d; border-radius: 4px; list-style: none; padding: 4px 0;
+    margin: 0; min-width: 140px; z-index: 10; box-shadow: 0 4px 14px rgba(0,0,0,0.4);
+  }
+  .lang-menu li { padding: 6px 12px; cursor: pointer; font-size: 13px; color: #c9d1d9; }
+  .lang-menu li:hover { background: #21262d; }
+  .lang-menu li.active { color: #58a6ff; font-weight: 600; }
   .layout {
     display: flex;
     gap: 24px;
@@ -236,36 +255,48 @@
 <div id="alert-container"></div>
 
 <header class="page-header">
-  <h1>NHP-Agent Key Registration Workflow Demo</h1>
-  <p>Register a new user/device key over the NHP-OTP / NHP-REG protocol</p>
+  <div>
+    <h1 data-i18n="page.heading">NHP-Agent Key Registration Workflow Demo</h1>
+    <p data-i18n="page.subtitle">Register a new user/device key over the NHP-OTP / NHP-REG protocol</p>
+  </div>
+  <div class="lang-switcher">
+    <button id="langButton" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Language">
+      <svg class="lang-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14 14 0 0 1 0 18"/><path d="M12 3a14 14 0 0 0 0 18"/></svg>
+      <span id="langButtonLabel">EN</span><span class="caret">&#9662;</span>
+    </button>
+    <ul id="langMenu" class="lang-menu" role="menu" hidden>
+      <li role="menuitem" data-lang="en">English</li>
+      <li role="menuitem" data-lang="zh-cn">&#31616;&#20307;&#20013;&#25991;</li>
+    </ul>
+  </div>
 </header>
 
 <div class="layout">
 <div class="card">
-  <h1>Registration Steps</h1>
+  <h1 data-i18n="card.heading">Registration Steps</h1>
 
   <!-- Steps 1 & 2 are shown together -->
   <div id="step-form" class="step active">
     <!-- Step 1: Generate a local key pair -->
-    <h3 class="step-title">Step 1: Generate key pair</h3>
-    <p class="step-desc">Create a device key pair locally in your browser. The private key never leaves your device.</p>
+    <h3 class="step-title" data-i18n="step1.title">Step 1: Generate key pair</h3>
+    <p class="step-desc" data-i18n="step1.desc">Create a device key pair locally in your browser. The private key never leaves your device.</p>
     <div class="field">
-      <label for="cipher-select">Cipher Scheme</label>
+      <label for="cipher-select" data-i18n="field.cipher">Cipher Scheme</label>
       <select id="cipher-select">
         <option value="curve25519">Curve25519 (X25519 + AES-256-GCM + BLAKE2s)</option>
         <option value="gmsm">GMSM / SM2 (SM2 + SM4-GCM + SM3)</option>
       </select>
-      <div class="hint">Must match the target server's scheme (Step 2).</div>
+      <div class="hint" data-i18n="field.cipher.hint">Must match the target server's scheme (Step 2).</div>
     </div>
-    <button class="btn btn-primary" id="btn-keygen" onclick="doGenerateKeyPair()">Generate Key Pair</button>
+    <button class="btn btn-primary" id="btn-keygen" onclick="doGenerateKeyPair()" data-i18n="btn.keygen">Generate Key Pair</button>
 
     <div id="keygen-result" style="display:none;margin-top:16px">
       <div class="field">
-        <label>Public Key <span class="hint">(registered with the server)</span></label>
+        <label data-i18n-html="field.pubkey">Public Key <span class="hint">(registered with the server)</span></label>
         <div class="key-display" id="keygen-pubkey"></div>
       </div>
       <div class="field">
-        <label>Private Key <span class="hint">(stays on this device — keep it safe)</span></label>
+        <label data-i18n-html="field.privkey">Private Key <span class="hint">(stays on this device — keep it safe)</span></label>
         <div class="key-display" id="keygen-privkey"></div>
       </div>
     </div>
@@ -275,62 +306,62 @@
     <hr>
 
     <!-- Step 2: Server + identity + send NHP-OTP -->
-    <h3 class="step-title">Step 2: Get verification code via NHP-OTP</h3>
-    <p class="step-desc">Choose the target server and identify yourself. The server binds your public key to this identity and emails a one-time code over the NHP-OTP message.</p>
+    <h3 class="step-title" data-i18n="step2.title">Step 2: Get verification code via NHP-OTP</h3>
+    <p class="step-desc" data-i18n="step2.desc">Choose the target server and identify yourself. The server binds your public key to this identity and emails a one-time code over the NHP-OTP message.</p>
     <div class="field">
-      <label for="relay-url">Relay URL</label>
+      <label for="relay-url" data-i18n="field.relay">Relay URL</label>
       <input type="text" id="relay-url" placeholder="https://relay.opennhp.org/relay" autocomplete="url">
-      <div class="hint">Auto-discovers available servers on change</div>
+      <div class="hint" data-i18n="field.relay.hint">Auto-discovers available servers on change</div>
     </div>
     <div class="field">
-      <label for="server-select">NHP-Server <span id="server-count"></span></label>
+      <label for="server-select"><span data-i18n="field.server">NHP-Server</span> <span id="server-count"></span></label>
       <select id="server-select" disabled>
-        <option value="">Enter relay URL first...</option>
+        <option value="" data-i18n="field.server.empty">Enter relay URL first...</option>
       </select>
       <div class="hint" id="server-detail"></div>
     </div>
     <div class="field">
-      <label for="asp-id">Auth Service Provider ID</label>
+      <label for="asp-id" data-i18n="field.asp">Auth Service Provider ID</label>
       <input type="text" id="asp-id" value="example" placeholder="example">
     </div>
     <div class="field">
-      <label for="email">Email <span style="font-weight:400;color:#8b949e">(used as User ID — the OTP code is sent here)</span></label>
+      <label for="email" data-i18n-html="field.email">Email <span style="font-weight:400;color:#8b949e">(used as User ID — the OTP code is sent here)</span></label>
       <input type="email" id="email" placeholder="alice@example.com" autocomplete="email" required>
-      <div class="hint">Used as both your user identity and OTP delivery address.</div>
+      <div class="hint" data-i18n="field.email.hint">Used as both your user identity and OTP delivery address.</div>
     </div>
     <div class="field">
-      <label for="device-id">Device ID</label>
+      <label for="device-id" data-i18n="field.device">Device ID</label>
       <input type="text" id="device-id" placeholder="auto-generated if empty">
-      <div class="hint">Leave blank to auto-generate</div>
+      <div class="hint" data-i18n="field.device.hint">Leave blank to auto-generate</div>
     </div>
     <div class="field">
-      <label for="org-id">Organization ID <span style="font-weight:400;color:#484f58">(optional)</span></label>
+      <label for="org-id" data-i18n-html="field.org">Organization ID <span style="font-weight:400;color:#484f58">(optional)</span></label>
       <input type="text" id="org-id" placeholder="opennhp.org">
     </div>
-    <button class="btn btn-primary" id="btn-next" onclick="goToOtpStep()">Get Verification Code (NHP-OTP)</button>
+    <button class="btn btn-primary" id="btn-next" onclick="goToOtpStep()" data-i18n="btn.getcode">Get Verification Code (NHP-OTP)</button>
     </div>
   </div>
 
   <!-- OTP entry -->
   <div id="step-otp" class="step">
-    <h3 class="step-title">Step 3: Register Agent Key via NHP-REG</h3>
+    <h3 class="step-title" data-i18n="step3.title">Step 3: Register Agent Key via NHP-REG</h3>
     <div class="status-row">
       <div class="spinner" id="spinner-otp"></div>
-      <span id="otp-status-text">Sending verification code...</span>
+      <span id="otp-status-text" data-i18n="status.sending">Sending verification code...</span>
     </div>
-    <p style="font-size:12px;color:#8b949e;margin-bottom:12px">
+    <p style="font-size:12px;color:#8b949e;margin-bottom:12px" data-i18n-html="otp.sentTo">
       A 6-digit code has been sent to <strong id="otp-email-display" style="color:#c9d1d9"></strong>.
       It expires in 5 minutes.
     </p>
     <div class="field">
-      <label for="otp-input">Verification Code</label>
+      <label for="otp-input" data-i18n="field.otp">Verification Code</label>
       <input type="text" id="otp-input" placeholder="000000" maxlength="6" inputmode="numeric" autocomplete="one-time-code">
     </div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="goToFormStep()">Back</button>
-      <button class="btn btn-primary" id="btn-register" onclick="doRegister()">Register</button>
+      <button class="btn btn-secondary" onclick="goToFormStep()" data-i18n="btn.back">Back</button>
+      <button class="btn btn-primary" id="btn-register" onclick="doRegister()" data-i18n="btn.register">Register</button>
     </div>
-    <p style="font-size:11px;color:#484f58;text-align:center;margin-top:8px">
+    <p style="font-size:11px;color:#484f58;text-align:center;margin-top:8px" data-i18n-html="otp.noCode">
       No code? <a href="#" onclick="goToFormStep();return false" class="back-link">Go back</a> and send a new one.
     </p>
   </div>
@@ -342,18 +373,18 @@
 </div>
 
 <aside class="protocol">
-  <h2>How registration works</h2>
+  <h2 data-i18n="diagram.heading">How registration works</h2>
   <svg viewBox="0 0 400 400" role="img" aria-labelledby="seq-title seq-desc">
     <title id="seq-title">Key generation, NHP-OTP and NHP-REG protocol workflow</title>
     <desc id="seq-desc">First your browser generates a key pair locally. Then it requests a one-time password over NHP-OTP and the server emails you the code. Finally your browser proves possession of its key over NHP-REG and the server acknowledges with NHP-RAK.</desc>
 
     <!-- Lane headers -->
     <rect class="seq-lane" x="10" y="4" width="90" height="26" rx="4"/>
-    <text class="seq-lane-label" x="55" y="21" text-anchor="middle">You</text>
+    <text class="seq-lane-label" x="55" y="21" text-anchor="middle" data-i18n="diagram.lane.you">You</text>
     <rect class="seq-lane" x="155" y="4" width="90" height="26" rx="4"/>
-    <text class="seq-lane-label" x="200" y="21" text-anchor="middle">Server</text>
+    <text class="seq-lane-label" x="200" y="21" text-anchor="middle" data-i18n="diagram.lane.server">Server</text>
     <rect class="seq-lane" x="300" y="4" width="90" height="26" rx="4"/>
-    <text class="seq-lane-label" x="345" y="21" text-anchor="middle">Email</text>
+    <text class="seq-lane-label" x="345" y="21" text-anchor="middle" data-i18n="diagram.lane.email">Email</text>
 
     <!-- Lifelines -->
     <line class="seq-life" x1="55" y1="30" x2="55" y2="392"/>
@@ -363,16 +394,16 @@
     <!-- Phase 1: Generate key pair (local, Step 1) -->
     <g class="seq-phase" id="seq-phase-keygen">
       <rect class="seq-phase-box" x="8" y="42" width="384" height="52" rx="5"/>
-      <text class="seq-phase-label" x="16" y="56">Step 1 · Generate key pair (local)</text>
+      <text class="seq-phase-label" x="16" y="56" data-i18n="diagram.phase1">Step 1 · Generate key pair (local)</text>
 
       <rect class="seq-node" x="18" y="62" width="130" height="24" rx="4"/>
-      <text class="seq-node-label" x="83" y="77" text-anchor="middle">key pair created</text>
+      <text class="seq-node-label" x="83" y="77" text-anchor="middle" data-i18n="diagram.keypairCreated">key pair created</text>
     </g>
 
     <!-- Phase 2: NHP-OTP (Step 2) -->
     <g class="seq-phase" id="seq-phase-otp">
       <rect class="seq-phase-box" x="8" y="106" width="384" height="112" rx="5"/>
-      <text class="seq-phase-label" x="16" y="120">Step 2 · NHP-OTP  (request code)</text>
+      <text class="seq-phase-label" x="16" y="120" data-i18n="diagram.phase2">Step 2 · NHP-OTP  (request code)</text>
 
       <line class="seq-msg" x1="55" y1="144" x2="200" y2="144"/>
       <polygon class="seq-arrowhead" points="200,144 194,141 194,147"/>
@@ -380,33 +411,33 @@
 
       <line class="seq-msg" x1="200" y1="174" x2="345" y2="174"/>
       <polygon class="seq-arrowhead" points="345,174 339,171 339,177"/>
-      <text class="seq-msg-label" x="272" y="170" text-anchor="middle">send OTP code</text>
+      <text class="seq-msg-label" x="272" y="170" text-anchor="middle" data-i18n="diagram.sendOtp">send OTP code</text>
 
       <line class="seq-msg" x1="345" y1="204" x2="55" y2="204" stroke-dasharray="4 3"/>
       <polygon class="seq-arrowhead" points="55,204 61,201 61,207"/>
-      <text class="seq-msg-label" x="200" y="200" text-anchor="middle">6-digit code (out-of-band)</text>
+      <text class="seq-msg-label" x="200" y="200" text-anchor="middle" data-i18n="diagram.code6">6-digit code (out-of-band)</text>
     </g>
 
     <!-- Phase 3: NHP-REG -->
     <g class="seq-phase" id="seq-phase-reg">
       <rect class="seq-phase-box" x="8" y="230" width="384" height="128" rx="5"/>
-      <text class="seq-phase-label" x="16" y="244">Step 3 · NHP-REG  (prove &amp; register)</text>
+      <text class="seq-phase-label" x="16" y="244" data-i18n="diagram.phase3">Step 3 · NHP-REG  (prove &amp; register)</text>
 
       <line class="seq-msg" x1="55" y1="268" x2="200" y2="268"/>
       <polygon class="seq-arrowhead" points="200,268 194,265 194,271"/>
       <text class="seq-msg-label" x="127" y="264" text-anchor="middle">NHP-REG: OTP + signature</text>
 
       <rect class="seq-node" x="168" y="284" width="64" height="30" rx="4"/>
-      <text class="seq-node-label" x="200" y="296" text-anchor="middle">verify OTP</text>
-      <text class="seq-node-label" x="200" y="308" text-anchor="middle">+ key</text>
+      <text class="seq-node-label" x="200" y="296" text-anchor="middle" data-i18n="diagram.verify1">verify OTP</text>
+      <text class="seq-node-label" x="200" y="308" text-anchor="middle" data-i18n="diagram.verify2">+ key</text>
 
       <line class="seq-msg" x1="200" y1="340" x2="55" y2="340"/>
       <polygon class="seq-arrowhead" points="55,340 61,337 61,343"/>
-      <text class="seq-msg-label" x="127" y="336" text-anchor="middle">NHP-RAK: success</text>
+      <text class="seq-msg-label" x="127" y="336" text-anchor="middle" data-i18n="diagram.rakSuccess">NHP-RAK: success</text>
     </g>
   </svg>
   <div class="api-examples">
-    <h3>API Usage Examples</h3>
+    <h3 data-i18n="api.heading">API Usage Examples</h3>
     <div class="tab-bar">
       <button class="tab-btn active" onclick="switchTab(event,'tab-js')">JavaScript SDK</button>
       <button class="tab-btn" onclick="switchTab(event,'tab-ts')">TypeScript</button>
@@ -452,7 +483,7 @@
 } <span class="c-kw">else</span> {
   <span class="c-id">console</span>.<span class="c-fn">error</span>(regResult.error, regResult.errorCode);
 }</pre>
-      <p class="api-note">The private key never leaves the device. <code>registerPublicKey()</code> sends the NHP-REG packet inside a Noise handshake that cryptographically proves key possession — no separate signature field needed.</p>
+      <p class="api-note" data-i18n-html="api.note.js">The private key never leaves the device. <code>registerPublicKey()</code> sends the NHP-REG packet inside a Noise handshake that cryptographically proves key possession — no separate signature field needed.</p>
     </div>
 
     <!-- TypeScript tab -->
@@ -481,12 +512,12 @@
   <span class="c-kw">const</span> pubKey: <span class="c-type">string</span> = <span class="c-id">agent</span>.<span class="c-fn">getPublicKey</span>();
   <span class="c-kw">const</span> expiresAt: <span class="c-type">number</span> | <span class="c-type">undefined</span> = reg.expiresAt;
 }</pre>
-      <p class="api-note">Full type definitions are shipped with the package. <code>OtpResult</code> and <code>RegisterResult</code> are both exported from <code>@opennhp/agent</code>.</p>
+      <p class="api-note" data-i18n-html="api.note.ts">Full type definitions are shipped with the package. <code>OtpResult</code> and <code>RegisterResult</code> are both exported from <code>@opennhp/agent</code>.</p>
     </div>
 
     <!-- curl / HTTP tab -->
     <div id="tab-curl" class="tab-panel">
-      <div class="step-divider">Step 2 — NHP-OTP (request code)</div>
+      <div class="step-divider" data-i18n="api.divider.otp">Step 2 — NHP-OTP (request code)</div>
       <pre class="code-block"><span class="c-comment"># The NHP-OTP packet is binary (Noise-encrypted UDP/relay).
 # Use the JS SDK above, or any language binding.
 # Example via the HTTP relay endpoint:</span>
@@ -503,7 +534,7 @@ nhp-agentd otp \
   --asp     example \
   --relay   https://relay.opennhp.org/relay</pre>
 
-      <div class="step-divider">Step 3 — NHP-REG (register key)</div>
+      <div class="step-divider" data-i18n="api.divider.reg">Step 3 — NHP-REG (register key)</div>
       <pre class="code-block"><span class="c-comment"># After receiving the 6-digit code by email:</span>
 nhp-agentd register \
   --server  <span class="c-str">&lt;server-public-key-base64&gt;</span> \
@@ -515,7 +546,7 @@ nhp-agentd register \
 
 <span class="c-comment"># On success the server responds with NHP-RAK:
 # { "errCode": "0", "aspId": "example", "expiresAt": 1234567890 }</span></pre>
-      <p class="api-note">The CLI tool ships with OpenNHP (<code>nhp-agentd</code>). For Go applications use the <code>endpoints/agent</code> package directly; for other languages implement the Noise handshake and wrap the JSON payload per the NHP-OTP / NHP-REG message spec.</p>
+      <p class="api-note" data-i18n-html="api.note.curl">The CLI tool ships with OpenNHP (<code>nhp-agentd</code>). For Go applications use the <code>endpoints/agent</code> package directly; for other languages implement the Noise handshake and wrap the JSON payload per the NHP-OTP / NHP-REG message spec.</p>
     </div>
   </div>
 </aside>
@@ -523,7 +554,7 @@ nhp-agentd register \
 
 <p class="footer page-footer">
   OpenNHP Agent SDK v<span id="sdk-version">—</span> &middot;
-  <a href="https://agent.opennhp.org/" target="_blank" rel="noopener">agent demo &rarr;</a> &middot;
+  <a href="https://agent.opennhp.org/" target="_blank" rel="noopener" data-i18n="footer.agentDemo">agent demo &rarr;</a> &middot;
   <a href="https://opennhp.org" target="_blank" rel="noopener">opennhp.org</a>
 </p>
 
@@ -560,6 +591,259 @@ let configClusters = [];   // clusters from config.json
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => document.querySelectorAll(sel);
+
+// ── i18n ──────────────────────────────────────────────────────────────────
+const I18N = {
+  en: {
+    'page.title': 'OpenNHP Agent Registration',
+    'page.heading': 'NHP-Agent Key Registration Workflow Demo',
+    'page.subtitle': 'Register a new user/device key over the NHP-OTP / NHP-REG protocol',
+    'card.heading': 'Registration Steps',
+    'step1.title': 'Step 1: Generate key pair',
+    'step1.desc': 'Create a device key pair locally in your browser. The private key never leaves your device.',
+    'field.cipher': 'Cipher Scheme',
+    'field.cipher.hint': "Must match the target server's scheme (Step 2).",
+    'btn.keygen': 'Generate Key Pair',
+    'btn.keygen.generating': 'Generating...',
+    'btn.keygen.regenerate': 'Regenerate Key Pair',
+    'field.pubkey': 'Public Key <span class="hint">(registered with the server)</span>',
+    'field.privkey': 'Private Key <span class="hint">(stays on this device — keep it safe)</span>',
+    'step2.title': 'Step 2: Get verification code via NHP-OTP',
+    'step2.desc': 'Choose the target server and identify yourself. The server binds your public key to this identity and emails a one-time code over the NHP-OTP message.',
+    'field.relay': 'Relay URL',
+    'field.relay.hint': 'Auto-discovers available servers on change',
+    'field.server': 'NHP-Server',
+    'field.server.empty': 'Enter relay URL first...',
+    'field.asp': 'Auth Service Provider ID',
+    'field.email': 'Email <span style="font-weight:400;color:#8b949e">(used as User ID — the OTP code is sent here)</span>',
+    'field.email.hint': 'Used as both your user identity and OTP delivery address.',
+    'field.device': 'Device ID',
+    'field.device.hint': 'Leave blank to auto-generate',
+    'field.org': 'Organization ID <span style="font-weight:400;color:#484f58">(optional)</span>',
+    'btn.getcode': 'Get Verification Code (NHP-OTP)',
+    'step3.title': 'Step 3: Register Agent Key via NHP-REG',
+    'status.sending': 'Sending verification code...',
+    'status.codeSent': 'Code sent! Check server logs (local dev) or email.',
+    'status.failed': 'Failed.',
+    'status.registering': 'Registering...',
+    'otp.sentTo': 'A 6-digit code has been sent to <strong id="otp-email-display" style="color:#c9d1d9"></strong>. It expires in 5 minutes.',
+    'field.otp': 'Verification Code',
+    'btn.back': 'Back',
+    'btn.register': 'Register',
+    'otp.noCode': 'No code? <a href="#" onclick="goToFormStep();return false" class="back-link">Go back</a> and send a new one.',
+    'diagram.heading': 'How registration works',
+    'diagram.lane.you': 'You',
+    'diagram.lane.server': 'Server',
+    'diagram.lane.email': 'Email',
+    'diagram.phase1': 'Step 1 · Generate key pair (local)',
+    'diagram.keypairCreated': 'key pair created',
+    'diagram.phase2': 'Step 2 · NHP-OTP  (request code)',
+    'diagram.sendOtp': 'send OTP code',
+    'diagram.code6': '6-digit code (out-of-band)',
+    'diagram.phase3': 'Step 3 · NHP-REG  (prove & register)',
+    'diagram.verify1': 'verify OTP',
+    'diagram.verify2': '+ key',
+    'diagram.rakSuccess': 'NHP-RAK: success',
+    'api.heading': 'API Usage Examples',
+    'api.note.js': 'The private key never leaves the device. <code>registerPublicKey()</code> sends the NHP-REG packet inside a Noise handshake that cryptographically proves key possession — no separate signature field needed.',
+    'api.note.ts': 'Full type definitions are shipped with the package. <code>OtpResult</code> and <code>RegisterResult</code> are both exported from <code>@opennhp/agent</code>.',
+    'api.divider.otp': 'Step 2 — NHP-OTP (request code)',
+    'api.divider.reg': 'Step 3 — NHP-REG (register key)',
+    'api.note.curl': 'The CLI tool ships with OpenNHP (<code>nhp-agentd</code>). For Go applications use the <code>endpoints/agent</code> package directly; for other languages implement the Noise handshake and wrap the JSON payload per the NHP-OTP / NHP-REG message spec.',
+    'footer.agentDemo': 'agent demo →',
+    // dynamic
+    'msg.enterEmail': 'Please enter your email (used as both user ID and OTP address)',
+    'msg.selectServer': 'Please select a target server',
+    'msg.genKeyFirst': 'Please generate a key pair first (Step 1)',
+    'msg.keygenFail': 'Key generation failed: {err}',
+    'msg.failed': 'Failed: {err}',
+    'msg.error': 'Error: {err}',
+    'msg.enter6': 'Enter a 6-digit code',
+    'msg.regFail': 'Registration failed: {err} (code: {code})',
+    'msg.cborCopied': 'CBOR token copied to clipboard.',
+    'msg.clipboardBlocked': 'Clipboard blocked — token shown in a textbox; press Cmd/Ctrl+C.',
+    'msg.schemeMismatch': 'Cipher scheme changed — please regenerate your key pair (Step 1).',
+    'server.count': '({n} available)',
+    'server.none': 'No servers in config.json',
+    'server.fingerprint': 'Fingerprint: {id} ',
+    'server.mismatchInline': ' — scheme mismatch, regenerate in Step 1',
+    'done.success': '✓ Registration Successful',
+    'done.server': 'Server: {name}',
+    'done.saved': 'Keys saved — keep your private key safe.',
+    'done.validUntil': 'Key valid until {date}. The nhp-server returned this absolute expiry (server-configured TTL).',
+    'done.validForever': 'Key valid indefinitely. The nhp-server is configured with no TTL on registered keys.',
+    'done.afterExpiry': 'After expiry you will need to re-register (re-run this page and enter a fresh OTP) to knock again.',
+    'done.privkeyLabel': 'Private Key <span class="hint">(saved to localStorage + download)</span>',
+    'done.downloadKey': 'Download Key File',
+    'done.copyToken': 'Copy CBOR Token',
+    'done.knock': 'Knock with this key →',
+    'done.knockHint': 'Click <strong>Knock with this key</strong> to open the <a href="https://agent.opennhp.org/" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none">agent demo (agent.opennhp.org)</a> with your registered key pre-filled and access the protected resource, or paste the <strong>CBOR Token</strong> into that page\'s "Load from Token" dialog (CBOR has the same fields as the JSON download, encoded compactly).',
+  },
+  'zh-cn': {
+    'page.title': 'OpenNHP 代理注册',
+    'page.heading': 'NHP 代理密钥注册流程演示',
+    'page.subtitle': '通过 NHP-OTP / NHP-REG 协议注册新的用户/设备密钥',
+    'card.heading': '注册步骤',
+    'step1.title': '步骤 1：生成密钥对',
+    'step1.desc': '在浏览器本地生成设备密钥对。私钥永远不会离开您的设备。',
+    'field.cipher': '加密方案',
+    'field.cipher.hint': '必须与目标服务器的方案一致（步骤 2）。',
+    'btn.keygen': '生成密钥对',
+    'btn.keygen.generating': '生成中…',
+    'btn.keygen.regenerate': '重新生成密钥对',
+    'field.pubkey': '公钥 <span class="hint">（注册到服务器）</span>',
+    'field.privkey': '私钥 <span class="hint">（保存在本设备 — 请妥善保管）</span>',
+    'step2.title': '步骤 2：通过 NHP-OTP 获取验证码',
+    'step2.desc': '选择目标服务器并标识您的身份。服务器会将您的公钥绑定到该身份，并通过 NHP-OTP 消息将一次性验证码发送到您的邮箱。',
+    'field.relay': '中继 URL',
+    'field.relay.hint': '更改时自动发现可用的服务器',
+    'field.server': 'NHP 服务器',
+    'field.server.empty': '请先输入中继 URL…',
+    'field.asp': '认证服务提供商 ID',
+    'field.email': '邮箱 <span style="font-weight:400;color:#8b949e">（用作用户 ID — 验证码发送到此邮箱）</span>',
+    'field.email.hint': '同时用作您的用户身份和验证码接收地址。',
+    'field.device': '设备 ID',
+    'field.device.hint': '留空则自动生成',
+    'field.org': '组织 ID <span style="font-weight:400;color:#484f58">（可选）</span>',
+    'btn.getcode': '获取验证码（NHP-OTP）',
+    'step3.title': '步骤 3：通过 NHP-REG 注册代理密钥',
+    'status.sending': '正在发送验证码…',
+    'status.codeSent': '验证码已发送！请查看服务器日志（本地开发）或邮箱。',
+    'status.failed': '失败。',
+    'status.registering': '注册中…',
+    'otp.sentTo': '6 位验证码已发送至 <strong id="otp-email-display" style="color:#c9d1d9"></strong>。5 分钟后过期。',
+    'field.otp': '验证码',
+    'btn.back': '返回',
+    'btn.register': '注册',
+    'otp.noCode': '没收到验证码？<a href="#" onclick="goToFormStep();return false" class="back-link">返回</a>并重新发送。',
+    'diagram.heading': '注册流程说明',
+    'diagram.lane.you': '您',
+    'diagram.lane.server': '服务器',
+    'diagram.lane.email': '邮箱',
+    'diagram.phase1': '步骤 1 · 本地生成密钥对',
+    'diagram.keypairCreated': '密钥对已生成',
+    'diagram.phase2': '步骤 2 · NHP-OTP（请求验证码）',
+    'diagram.sendOtp': '发送验证码',
+    'diagram.code6': '6 位验证码（带外）',
+    'diagram.phase3': '步骤 3 · NHP-REG（证明并注册）',
+    'diagram.verify1': '校验验证码',
+    'diagram.verify2': '+ 密钥',
+    'diagram.rakSuccess': 'NHP-RAK：成功',
+    'api.heading': 'API 使用示例',
+    'api.note.js': '私钥永远不会离开设备。<code>registerPublicKey()</code> 将 NHP-REG 报文放在 Noise 握手内发送，以密码学方式证明密钥持有 — 无需单独的签名字段。',
+    'api.note.ts': '完整类型定义随包一起提供。<code>OtpResult</code> 和 <code>RegisterResult</code> 均从 <code>@opennhp/agent</code> 导出。',
+    'api.divider.otp': '步骤 2 — NHP-OTP（请求验证码）',
+    'api.divider.reg': '步骤 3 — NHP-REG（注册密钥）',
+    'api.note.curl': 'CLI 工具随 OpenNHP 一起提供（<code>nhp-agentd</code>）。Go 应用可直接使用 <code>endpoints/agent</code> 包；其他语言请实现 Noise 握手并按 NHP-OTP / NHP-REG 消息规范封装 JSON 负载。',
+    'footer.agentDemo': '代理演示 →',
+    // dynamic
+    'msg.enterEmail': '请输入您的邮箱（同时用作用户 ID 和验证码地址）',
+    'msg.selectServer': '请选择目标服务器',
+    'msg.genKeyFirst': '请先生成密钥对（步骤 1）',
+    'msg.keygenFail': '生成密钥失败：{err}',
+    'msg.failed': '失败：{err}',
+    'msg.error': '错误：{err}',
+    'msg.enter6': '请输入 6 位验证码',
+    'msg.regFail': '注册失败：{err}（代码：{code}）',
+    'msg.cborCopied': 'CBOR 令牌已复制到剪贴板。',
+    'msg.clipboardBlocked': '剪贴板被阻止 — 令牌显示在文本框中，请按 Cmd/Ctrl+C。',
+    'msg.schemeMismatch': '加密方案已更改 — 请重新生成密钥对（步骤 1）。',
+    'server.count': '（共 {n} 个）',
+    'server.none': 'config.json 中没有服务器',
+    'server.fingerprint': '指纹：{id} ',
+    'server.mismatchInline': ' — 方案不匹配，请在步骤 1 重新生成',
+    'done.success': '✓ 注册成功',
+    'done.server': '服务器：{name}',
+    'done.saved': '密钥已保存 — 请妥善保管您的私钥。',
+    'done.validUntil': '密钥有效期至 {date}。nhp-server 返回了此绝对过期时间（服务器配置的 TTL）。',
+    'done.validForever': '密钥永久有效。nhp-server 配置为注册密钥无 TTL。',
+    'done.afterExpiry': '过期后，您需要重新注册（重新运行本页并输入新的验证码）才能再次敲门。',
+    'done.privkeyLabel': '私钥 <span class="hint">（已保存到 localStorage + 下载）</span>',
+    'done.downloadKey': '下载密钥文件',
+    'done.copyToken': '复制 CBOR 令牌',
+    'done.knock': '用此密钥敲门 →',
+    'done.knockHint': '点击 <strong>用此密钥敲门</strong> 打开 <a href="https://agent.opennhp.org/" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none">代理演示（agent.opennhp.org）</a>，其中会预填您注册的密钥并访问受保护资源；或将 <strong>CBOR 令牌</strong> 粘贴到该页面的“从令牌加载”对话框（CBOR 与 JSON 下载字段相同，编码更紧凑）。',
+  },
+};
+const LANG_LABELS = { en: 'EN', 'zh-cn': '中文' };
+let currentLang = detectLang();
+
+function detectLang() {
+  try {
+    const p = new URLSearchParams(window.location.search).get('lang');
+    if (p && I18N[p]) return p;
+  } catch (_) {}
+  try {
+    const s = localStorage.getItem('nhp-demo-lang');
+    if (s && I18N[s]) return s;
+  } catch (_) {}
+  const nav = (navigator.language || 'en').toLowerCase();
+  if (nav === 'zh-cn' || nav.startsWith('zh')) return 'zh-cn';
+  return 'en';
+}
+
+function t(key, vars) {
+  const dict = I18N[currentLang] || I18N.en;
+  let s = dict[key];
+  if (s == null) s = I18N.en[key];
+  if (s == null) return key;
+  if (vars) for (const k in vars) s = s.split('{' + k + '}').join(String(vars[k]));
+  return s;
+}
+
+function applyI18n() {
+  document.documentElement.lang = currentLang === 'zh-cn' ? 'zh-CN' : 'en';
+  document.title = t('page.title');
+  $$('[data-i18n]').forEach(el => { el.textContent = t(el.getAttribute('data-i18n')); });
+  $$('[data-i18n-html]').forEach(el => { el.innerHTML = t(el.getAttribute('data-i18n-html')); });
+  // Re-render dynamic areas that were built in the previous language.
+  if ($('#otp-email-display') && window.__otpEmail) $('#otp-email-display').textContent = window.__otpEmail;
+  if (window.__serverDetailRender) window.__serverDetailRender();
+  if (Array.isArray(servers) && servers.length > 0) {
+    $('#server-count').textContent = t('server.count', { n: servers.length });
+  }
+  const lbl = $('#langButtonLabel');
+  if (lbl) lbl.textContent = LANG_LABELS[currentLang] || currentLang.toUpperCase();
+  $$('#langMenu [data-lang]').forEach(li => li.classList.toggle('active', li.getAttribute('data-lang') === currentLang));
+}
+
+function setLanguage(lang) {
+  if (!I18N[lang] || lang === currentLang) return;
+  currentLang = lang;
+  try { localStorage.setItem('nhp-demo-lang', lang); } catch (_) {}
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', lang);
+    history.replaceState({}, '', url.toString());
+  } catch (_) {}
+  applyI18n();
+}
+
+function setupLangSwitcher() {
+  const button = $('#langButton'), menu = $('#langMenu');
+  if (!button || !menu) return;
+  button.addEventListener('click', e => {
+    e.stopPropagation();
+    const opening = menu.hidden;
+    menu.hidden = !opening;
+    button.setAttribute('aria-expanded', String(opening));
+  });
+  menu.addEventListener('click', e => {
+    const item = e.target.closest('[data-lang]');
+    if (!item) return;
+    setLanguage(item.getAttribute('data-lang'));
+    menu.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+  });
+  document.addEventListener('click', e => {
+    if (!menu.hidden && !menu.contains(e.target) && e.target !== button) {
+      menu.hidden = true; button.setAttribute('aria-expanded', 'false');
+    }
+  });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && !menu.hidden) { menu.hidden = true; button.setAttribute('aria-expanded', 'false'); button.focus(); }
+  });
+}
 
 function showStep(name) {
   $$('.step').forEach(el => el.classList.remove('active'));
@@ -603,7 +887,7 @@ $('#cipher-select').addEventListener('change', () => {
     keygenScheme = null;
     $('#keygen-result').style.display = 'none';
     $('#step2-block').style.display = 'none';
-    $('#btn-keygen').textContent = 'Generate Key Pair';
+    $('#btn-keygen').textContent = t('btn.keygen');
     highlightProtocolPhase('keygen');
   }
 });
@@ -624,16 +908,22 @@ $('#server-select').addEventListener('change', () => {
   const idx = parseInt($('#server-select').value);
   if (!isNaN(idx) && servers[idx]) {
     selectedServer = servers[idx];
-    const serverScheme = selectedServer.cipherScheme === 0 ? 'curve25519' : 'gmsm';
-    let detail = `Fingerprint: ${escapeHtml(selectedServer.id)} ${schemeBadge(serverScheme)}`;
-    // The cipher scheme is chosen by the user in Step 1. Warn if the picked
-    // server expects a different scheme than the generated key.
-    if (keygenScheme && keygenScheme !== serverScheme) {
-      detail += ' <span style="color:#f85149">— scheme mismatch, regenerate in Step 1</span>';
-    }
-    $('#server-detail').innerHTML = detail;
+    renderServerDetail();
   }
 });
+
+// Rebuilds the server-detail line; stored so applyI18n() can re-render it
+// after a language switch.
+function renderServerDetail() {
+  if (!selectedServer) return;
+  const serverScheme = selectedServer.cipherScheme === 0 ? 'curve25519' : 'gmsm';
+  let detail = t('server.fingerprint', { id: escapeHtml(selectedServer.id) }) + schemeBadge(serverScheme);
+  if (keygenScheme && keygenScheme !== serverScheme) {
+    detail += ` <span style="color:#f85149">${t('server.mismatchInline')}</span>`;
+  }
+  $('#server-detail').innerHTML = detail;
+}
+window.__serverDetailRender = renderServerDetail;
 
 function populateServers() {
   const sel = $('#server-select');
@@ -646,7 +936,7 @@ function populateServers() {
   }));
 
   if (servers.length === 0) {
-    sel.innerHTML = '<option value="">No servers in config.json</option>';
+    sel.innerHTML = `<option value="">${t('server.none')}</option>`;
     sel.disabled = true;
     return;
   }
@@ -657,7 +947,7 @@ function populateServers() {
     return `<option value="${i}">${escapeHtml(s.name)} (${cs})${host}</option>`;
   }).join('');
   sel.disabled = false;
-  $('#server-count').textContent = `(${servers.length} available)`;
+  $('#server-count').textContent = t('server.count', { n: servers.length });
   sel.value = '0';
   sel.dispatchEvent(new Event('change'));
 }
@@ -666,7 +956,7 @@ function populateServers() {
 window.doGenerateKeyPair = async () => {
   const btn = $('#btn-keygen');
   btn.disabled = true;
-  btn.textContent = 'Generating...';
+  btn.textContent = t('btn.keygen.generating');
   try {
     await initAgent();  // creates the agent and generates the key pair
     keygenScheme = cipherScheme;
@@ -674,11 +964,11 @@ window.doGenerateKeyPair = async () => {
     $('#keygen-privkey').textContent = agent.getPrivateKey();
     $('#keygen-result').style.display = 'block';
     $('#step2-block').style.display = 'block';  // reveal Step 2
-    btn.textContent = 'Regenerate Key Pair';
+    btn.textContent = t('btn.keygen.regenerate');
     highlightProtocolPhase('identity');  // key pair done → NHP-OTP is next
   } catch (err) {
-    showAlert('Key generation failed: ' + (err.message || 'Unknown'), 'error');
-    btn.textContent = 'Generate Key Pair';
+    showAlert(t('msg.keygenFail', { err: err.message || 'Unknown' }), 'error');
+    btn.textContent = t('btn.keygen');
   } finally {
     btn.disabled = false;
   }
@@ -687,9 +977,9 @@ window.doGenerateKeyPair = async () => {
 // ── Step 2: identify + send NHP-OTP ──
 window.goToOtpStep = async () => {
   const email = $('#email').value.trim();
-  if (!email) { showAlert('Please enter your email (used as both user ID and OTP address)', 'error'); return; }
-  if (!selectedServer) { showAlert('Please select a target server', 'error'); return; }
-  if (!agent || !agent.getPublicKey()) { showAlert('Please generate a key pair first (Step 1)', 'error'); return; }
+  if (!email) { showAlert(t('msg.enterEmail'), 'error'); return; }
+  if (!selectedServer) { showAlert(t('msg.selectServer'), 'error'); return; }
+  if (!agent || !agent.getPublicKey()) { showAlert(t('msg.genKeyFirst'), 'error'); return; }
 
   // Point the agent at the chosen server and bind the identity fields to
   // the already-generated key pair.
@@ -704,30 +994,31 @@ window.goToOtpStep = async () => {
 
   showStep('otp');
   highlightProtocolPhase('otp');  // OTP sent → NHP-REG is next
+  window.__otpEmail = email;
   $('#otp-email-display').textContent = email;
   $('#spinner-otp').classList.add('visible');
-  $('#otp-status-text').textContent = 'Sending verification code...';
+  $('#otp-status-text').textContent = t('status.sending');
 
   try {
     const result = await agent.requestOtp($('#asp-id').value.trim() || 'example', { email });
     $('#spinner-otp').classList.remove('visible');
     if (result.success) {
-      $('#otp-status-text').textContent = 'Code sent! Check server logs (local dev) or email.';
+      $('#otp-status-text').textContent = t('status.codeSent');
     } else {
-      showAlert(`Failed: ${result.error}`, 'error');
-      $('#otp-status-text').textContent = 'Failed.';
+      showAlert(t('msg.failed', { err: result.error }), 'error');
+      $('#otp-status-text').textContent = t('status.failed');
     }
   } catch (err) {
     $('#spinner-otp').classList.remove('visible');
-    showAlert('Error: ' + (err.message || 'Unknown'), 'error');
+    showAlert(t('msg.error', { err: err.message || 'Unknown' }), 'error');
   }
 };
 
 window.doRegister = async () => {
   const otp = $('#otp-input').value.trim();
-  if (!otp || otp.length !== 6) { showAlert('Enter a 6-digit code', 'error'); return; }
+  if (!otp || otp.length !== 6) { showAlert(t('msg.enter6'), 'error'); return; }
   $('#btn-register').disabled = true;
-  $('#btn-register').textContent = 'Registering...';
+  $('#btn-register').textContent = t('status.registering');
 
   try {
     const result = await agent.registerPublicKey(
@@ -749,45 +1040,37 @@ window.doRegister = async () => {
 
       showStep('done');
       highlightProtocolPhase('done');  // NHP-RAK received
+      const validity = result.expiresAt !== undefined
+        ? t('done.validUntil', { date: new Date(result.expiresAt).toUTCString() })
+        : t('done.validForever');
       $('#done-content').innerHTML = `
         <div class="alert alert-success">
-          <strong>&check; Registration Successful</strong><br>
-          Server: ${escapeHtml(selectedServer.name || selectedServer.id)}<br>
-          Keys saved — keep your private key safe.
+          <strong>${t('done.success')}</strong><br>
+          ${t('done.server', { name: escapeHtml(selectedServer.name || selectedServer.id) })}<br>
+          ${t('done.saved')}
         </div>
         <div class="alert alert-info" style="background:#0d2b1e;border-color:#238636;color:#7ee787">
-          ${result.expiresAt !== undefined
-            ? `<strong>Key valid until ${new Date(result.expiresAt).toUTCString()}.</strong>
-              The nhp-server returned this absolute expiry (server-configured TTL).`
-            : `<strong>Key valid indefinitely.</strong>
-              The nhp-server is configured with no TTL on registered keys.`}
-          After expiry you will need to re-register (re-run this page and enter a fresh OTP) to knock again.
+          ${validity}<br>${t('done.afterExpiry')}
         </div>
         <div class="field">
-          <label>Private Key <span class="hint">(saved to localStorage + download)</span></label>
+          <label>${t('done.privkeyLabel')}</label>
           <div class="key-display">${agent.getPrivateKey()}</div>
         </div>
         <div class="btn-row">
-          <button class="btn btn-secondary" onclick="downloadKey()">Download Key File</button>
-          <button class="btn btn-secondary" onclick="copyCborToken()">Copy CBOR Token</button>
-          <button class="btn btn-primary" onclick="goKnock()">Knock with this key &rarr;</button>
+          <button class="btn btn-secondary" onclick="downloadKey()">${t('done.downloadKey')}</button>
+          <button class="btn btn-secondary" onclick="copyCborToken()">${t('done.copyToken')}</button>
+          <button class="btn btn-primary" onclick="goKnock()">${t('done.knock')}</button>
         </div>
-        <p style="font-size:12px;color:#8b949e;margin-top:12px">
-          Click <strong>Knock with this key</strong> to open the
-          <a href="https://agent.opennhp.org/" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none">agent demo (agent.opennhp.org)</a>
-          with your registered key pre-filled and access the protected resource,
-          or paste the <strong>CBOR Token</strong> into that page's "Load from Token" dialog
-          (CBOR has the same fields as the JSON download, encoded compactly).
-        </p>
+        <p style="font-size:12px;color:#8b949e;margin-top:12px">${t('done.knockHint')}</p>
       `;
     } else {
-      showAlert(`Registration failed: ${result.error} (code: ${result.errorCode || '—'})`, 'error');
+      showAlert(t('msg.regFail', { err: result.error, code: result.errorCode || '—' }), 'error');
     }
   } catch (err) {
-    showAlert('Error: ' + (err.message || 'Unknown'), 'error');
+    showAlert(t('msg.error', { err: err.message || 'Unknown' }), 'error');
   } finally {
     $('#btn-register').disabled = false;
-    $('#btn-register').textContent = 'Register';
+    $('#btn-register').textContent = t('btn.register');
   }
 };
 
@@ -844,7 +1127,7 @@ window.copyCborToken = async () => {
   const token = buildCborToken();
   try {
     await navigator.clipboard.writeText(token);
-    showAlert('CBOR token copied to clipboard.', 'success');
+    showAlert(t('msg.cborCopied'), 'success');
   } catch {
     // Fallback: show in a textarea so the user can copy manually.
     const ta = document.createElement('textarea');
@@ -852,7 +1135,7 @@ window.copyCborToken = async () => {
     ta.style.cssText = 'position:fixed;top:0;left:0;width:90%;height:120px;z-index:9999';
     document.body.appendChild(ta);
     ta.select();
-    showAlert('Clipboard blocked — token shown in a textbox; press Cmd/Ctrl+C.', 'info');
+    showAlert(t('msg.clipboardBlocked'), 'info');
   }
 };
 
@@ -932,6 +1215,8 @@ function generateDeviceId() {
       }
     }
   } catch (_) {}
+  setupLangSwitcher();
+  applyI18n();
   populateServers();
   highlightProtocolPhase('keygen');
 })();

--- a/endpoints/js-agent/examples/reg.html
+++ b/endpoints/js-agent/examples/reg.html
@@ -523,6 +523,7 @@ nhp-agentd register \
 
 <p class="footer page-footer">
   OpenNHP Agent SDK v<span id="sdk-version">—</span> &middot;
+  <a href="https://agent.opennhp.org/" target="_blank" rel="noopener">agent demo &rarr;</a> &middot;
   <a href="https://opennhp.org" target="_blank" rel="noopener">opennhp.org</a>
 </p>
 
@@ -772,8 +773,10 @@ window.doRegister = async () => {
           <button class="btn btn-primary" onclick="goKnock()">Knock with this key &rarr;</button>
         </div>
         <p style="font-size:12px;color:#8b949e;margin-top:12px">
-          Click <strong>Knock</strong> to open the demo page with your registered key pre-filled,
-          or paste the <strong>CBOR Token</strong> into the demo page's "Load from Token" dialog
+          Click <strong>Knock with this key</strong> to open the
+          <a href="https://agent.opennhp.org/" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none">agent demo (agent.opennhp.org)</a>
+          with your registered key pre-filled and access the protected resource,
+          or paste the <strong>CBOR Token</strong> into that page's "Load from Token" dialog
           (CBOR has the same fields as the JSON download, encoded compactly).
         </p>
       `;

--- a/endpoints/js-agent/examples/relay-test.html
+++ b/endpoints/js-agent/examples/relay-test.html
@@ -304,6 +304,20 @@
       background: #2ea043;
       border-color: #2ea043;
     }
+    .details-panel > summary .reg-agent-btn {
+      margin-left: 12px;
+      padding: 4px 12px;
+      font-size: 12px;
+      font-weight: 500;
+      background: #1f6feb;
+      border: 1px solid #1f6feb;
+      color: #fff;
+      text-decoration: none;
+    }
+    .details-panel > summary .reg-agent-btn:hover {
+      background: #388bfd;
+      border-color: #388bfd;
+    }
     .details-panel > summary .summary-hint {
       margin-left: auto;
       font-weight: 400;
@@ -565,7 +579,6 @@
     </div>
   </div>
   <p class="subtitle" data-i18n-html="page.subtitle">The OpenNHP JavaScript SDK lets a browser app &ldquo;knock&rdquo; an nhp-server for zero-trust access before redirecting the user to a protected resource. Click <strong>Request Access</strong> button below to run the exact integration flow you'd add to your own web app &mdash; then peek at the right column for the equivalent code. SDK source on <a href="https://github.com/OpenNHP/opennhp/tree/main/endpoints/js-agent" target="_blank" rel="noopener">GitHub</a>.</p>
-  <p class="subtitle" id="reg-link" style="margin-top:-10px;margin-bottom:16px">&#128274; Need to register a new agent? <a href="reg.html" style="color:#58a6ff;font-weight:600">Open Registration Page</a> &mdash; keys are saved automatically and imported below.</p>
   <div class="panel" id="reg-banner" style="display:none;margin-bottom:16px;border-color:#238636">
     <div class="panel-title" style="color:#3fb950">&#x2705; Registered Agent Key Loaded</div>
     <div style="font-size:13px;line-height:1.6">
@@ -664,7 +677,7 @@
   <!-- NHP-Agent parameters (collapsed; opens automatically if keys are missing).
        These map 1:1 to the SDK calls: NHPAgent({...}) / setIdentity / addServer / knockResource. -->
   <details class="panel details-panel" id="keys-details">
-    <summary class="panel-title">&#9881; <span data-i18n="panel.parameters">NHP-Agent Parameters</span><button type="button" class="btn btn-secondary load-token-btn" id="loadFromTokenBtn" data-i18n="btn.loadFromToken">Load from Token</button><span class="summary-hint" data-i18n="summary.editHint">click to view / edit</span></summary>
+    <summary class="panel-title">&#9881; <span data-i18n="panel.parameters">NHP-Agent Parameters</span><a href="reg.html" class="btn btn-secondary reg-agent-btn" id="registerAgentBtn" onclick="event.stopPropagation()" data-i18n="btn.registerAgent">Register New Agent</a><button type="button" class="btn btn-secondary load-token-btn" id="loadFromTokenBtn" data-i18n="btn.loadFromToken">Load from Token</button><span class="summary-hint" data-i18n="summary.editHint">click to view / edit</span></summary>
     <div class="details-content">
       <!-- Server cluster picker. Populated from config.json "clusters"; hidden
            when only one cluster is configured. Selecting a cluster swaps the
@@ -903,6 +916,7 @@ if (result.success) {
       'btn.knock': 'Request Access',
       'btn.clear': 'Clear Log',
       'btn.loadFromToken': 'Load from Token',
+      'btn.registerAgent': 'Register New Agent',
 
       'panel.runtimeFlow': 'Runtime Flow',
       'panel.eventLog': 'SDK Event Log',
@@ -1014,6 +1028,7 @@ if (result.success) {
       'btn.knock': '请求访问',
       'btn.clear': '清空日志',
       'btn.loadFromToken': '从令牌加载',
+      'btn.registerAgent': '注册新代理',
 
       'panel.runtimeFlow': '运行时流程',
       'panel.eventLog': 'SDK 事件日志',
@@ -1326,7 +1341,6 @@ if (result.success) {
 
       // Show the registration banner.
       const banner = document.getElementById('reg-banner');
-      const link = document.getElementById('reg-link');
       if (banner) {
         const u = document.getElementById('reg-banner-user');
         const dev = document.getElementById('reg-banner-device');
@@ -1336,7 +1350,6 @@ if (result.success) {
         if (srv) srv.textContent = d.serverName || d.serverId || '—';
         banner.style.display = '';
       }
-      if (link) link.style.display = 'none';
 
       log('ok', `\u{1F510} Imported registered key for ${d.userId} (device ${d.deviceId}) from reg.html`);
     } catch (_) { /* ignore */ }
@@ -1346,7 +1359,6 @@ if (result.success) {
   window.clearRegData = () => {
     try { localStorage.removeItem('nhp-reg-data'); } catch (_) {}
     document.getElementById('reg-banner').style.display = 'none';
-    document.getElementById('reg-link').style.display = '';
     loadDefaultsFromConfig().then(() => {
       log('info', '\u{1F504} Reverted to demo keys from config.json');
     });


### PR DESCRIPTION
## Summary
- Adds a `Step 3 ·` prefix to the **NHP-REG (prove & register)** phase in the registration-page workflow diagram (`reg.opennhp.org`).
- The diagram already numbers **Step 1 · Generate key pair** and **Step 2 · NHP-OTP**; NHP-REG was unnumbered. This makes the numbering sequential and matches the form's own "Step 3: Register Agent Key via NHP-REG" title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)