### PR TITLE
fix(ci): allow fork contributors to trigger claude-pr-review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -89,6 +89,10 @@ jobs:
           # review branch protection. A later app-token step clears stale
           # older-commit bot requests only after Claude posts successfully.
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Allow fork contributors (read-only actors) to trigger this review.
+          # Safe here because tools are restricted to read-only gh pr subcommands
+          # and the checkout is pinned to the base commit (never the PR head).
+          allowed_non_write_users: '*'
           # Restrict tools to safe GitHub CLI operations for PR review
           claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr checks:*)"'
           prompt: |


### PR DESCRIPTION
Fork PRs fail the claude-pr-review check because the action's internal permission guard rejects actors with read-only access. Add allowed_non_write_users: '*' to bypass the check for this job.

This is safe because the job is already hardened:
- checkout is pinned to the base commit (PR head code never executes)
- tools are restricted to read-only gh pr subcommands
- GITHUB_TOKEN has minimal write scope (pull-requests, issues only)

## Summary

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD improvement

## Related Issues

Fixes #

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
