### PR TITLE
debug(ci): enable show_full_output to diagnose claude-pr-review failure

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -99,6 +99,8 @@ jobs:
           # Safe here because tools are restricted to read-only gh pr subcommands
           # and the checkout is pinned to the base commit (never the PR head).
           allowed_non_write_users: '*'
+          # Show full output to diagnose is_error:true failures; remove once stable.
+          show_full_output: 'true'
           # Restrict tools to safe GitHub CLI operations for PR review
           claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr checks:*)"'
           prompt: |


### PR DESCRIPTION
Claude SDK output is hidden by default; is_error:true with 0 cost and 1 turn makes the root cause opaque. Temporarily expose full output to identify what fails immediately after init.

## Summary

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD improvement

## Related Issues

Fixes #

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
