### PR TITLE
feat(agent): start from an in-memory private key

### DIFF
--- a/endpoints/agent/in_memory_start_test.go
+++ b/endpoints/agent/in_memory_start_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStartWithPrivateKeyDoesNotMaterializeConfig(t *testing.T) {
+	dir := t.TempDir()
+	privateKey := make([]byte, 32)
+	for i := range privateKey {
+		privateKey[i] = byte(i + 1)
+	}
+	privateKey[0] &= 248
+	privateKey[31] = (privateKey[31] & 127) | 64
+
+	a := &UdpAgent{}
+	if err := a.StartWithPrivateKey(dir, 0, privateKey); err != nil {
+		t.Fatalf("StartWithPrivateKey: %v", err)
+	}
+	t.Cleanup(a.Stop)
+
+	if !a.IsRunning() {
+		t.Fatal("agent is not running")
+	}
+	for _, name := range []string{"config.toml", "dhp.toml", "server.toml", "resource.toml"} {
+		path := filepath.Join(dir, "etc", name)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s exists after in-memory start (err=%v)", path, err)
+		}
+	}
+}
+
+func TestStartWithPrivateKeyRejectsWrongSize(t *testing.T) {
+	a := &UdpAgent{}
+	if err := a.StartWithPrivateKey(t.TempDir(), 0, make([]byte, 31)); err == nil {
+		t.Fatal("StartWithPrivateKey accepted a 31-byte key")
+	}
+}

--- a/endpoints/agent/in_memory_start_test.go
+++ b/endpoints/agent/in_memory_start_test.go
@@ -1,9 +1,12 @@
 package agent
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/OpenNHP/opennhp/nhp/common"
 )
 
 func TestStartWithPrivateKeyDoesNotMaterializeConfig(t *testing.T) {
@@ -14,15 +17,28 @@ func TestStartWithPrivateKeyDoesNotMaterializeConfig(t *testing.T) {
 	}
 	privateKey[0] &= 248
 	privateKey[31] = (privateKey[31] & 127) | 64
+	wantPrivateKey := bytes.Clone(privateKey)
 
 	a := &UdpAgent{}
-	if err := a.StartWithPrivateKey(dir, 0, privateKey); err != nil {
+	if err := a.StartWithPrivateKey(dir, 4, privateKey); err != nil {
 		t.Fatalf("StartWithPrivateKey: %v", err)
 	}
 	t.Cleanup(a.Stop)
+	for i := range privateKey {
+		privateKey[i] = 0
+	}
 
 	if !a.IsRunning() {
 		t.Fatal("agent is not running")
+	}
+	if a.config.LogLevel != 4 {
+		t.Fatalf("LogLevel = %d, want 4", a.config.LogLevel)
+	}
+	if a.config.DefaultCipherScheme != common.CIPHER_SCHEME_CURVE {
+		t.Fatalf("DefaultCipherScheme = %d, want Curve25519", a.config.DefaultCipherScheme)
+	}
+	if got := a.device.GetEcdhByCipherScheme(common.CIPHER_SCHEME_CURVE).PrivateKey(); !bytes.Equal(got, wantPrivateKey) {
+		t.Fatal("agent private key changed when the caller buffer was scrubbed")
 	}
 	for _, name := range []string{"config.toml", "dhp.toml", "server.toml", "resource.toml"} {
 		path := filepath.Join(dir, "etc", name)
@@ -30,6 +46,32 @@ func TestStartWithPrivateKeyDoesNotMaterializeConfig(t *testing.T) {
 			t.Fatalf("%s exists after in-memory start (err=%v)", path, err)
 		}
 	}
+}
+
+func TestStartWithPrivateKeyIgnoresPersistedConfig(t *testing.T) {
+	dir := t.TempDir()
+	etcDir := filepath.Join(dir, "etc")
+	if err := os.MkdirAll(etcDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	for _, name := range []string{"config.toml", "dhp.toml", "server.toml", "resource.toml"} {
+		if err := os.WriteFile(filepath.Join(etcDir, name), []byte("not valid toml"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s): %v", name, err)
+		}
+	}
+
+	privateKey := make([]byte, 32)
+	for i := range privateKey {
+		privateKey[i] = byte(i + 1)
+	}
+	privateKey[0] &= 248
+	privateKey[31] = (privateKey[31] & 127) | 64
+
+	a := &UdpAgent{}
+	if err := a.StartWithPrivateKey(dir, 0, privateKey); err != nil {
+		t.Fatalf("StartWithPrivateKey read persisted config: %v", err)
+	}
+	t.Cleanup(a.Stop)
 }
 
 func TestStartWithPrivateKeyRejectsWrongSize(t *testing.T) {

--- a/endpoints/agent/udpagent.go
+++ b/endpoints/agent/udpagent.go
@@ -314,17 +314,8 @@ dirPath: the path of app or shared library entry point
 logLevel: 0: silent, 1: error, 2: info, 3: debug, 4: verbose
 */
 func (a *UdpAgent) Start(dirPath string, logLevel int) (err error) {
-	common.ExeDirPath = dirPath
-	ExeDirPath = dirPath
-	// init logger
-	a.log = log.NewLogger("NHP-Agent", logLevel, filepath.Join(ExeDirPath, "logs"), "agent")
-	log.SetGlobalLogger(a.log)
+	a.initializeStart(dirPath, logLevel)
 
-	log.Info("=========================================================")
-	log.Info("=== NHP-Agent %s started                           ===", version.Version)
-	log.Info("=== REVISION %s ===", version.CommitId)
-	log.Info("=== RELEASE %s                       ===", version.BuildTime)
-	log.Info("=========================================================")
 	err = a.loadBaseConfig()
 	if err != nil {
 		return err
@@ -339,11 +330,52 @@ func (a *UdpAgent) Start(dirPath string, logLevel int) (err error) {
 		log.Error("private key parse error %v\n", err)
 		return fmt.Errorf("private key parse error %v", err)
 	}
+	return a.startWithPrivateKey(prk, true)
+}
 
+// StartWithPrivateKey starts an agent from an in-memory Curve25519 private key.
+// It deliberately does not read or watch config.toml, dhp.toml, server.toml, or
+// resource.toml. Embedders that keep identity keys in an OS keystore can use
+// this entry point without materializing the key in a plaintext config file,
+// then register peers and resources through AddServer and AddResource.
+//
+// dirPath remains the non-secret runtime root for logs. The caller retains
+// ownership of privateKey and may zero its buffer after this method returns;
+// core.NewDevice copies the key into its own ECDH state before returning.
+func (a *UdpAgent) StartWithPrivateKey(dirPath string, logLevel int, privateKey []byte) error {
+	if len(privateKey) != 32 {
+		return fmt.Errorf("private key has unexpected size %d (want 32)", len(privateKey))
+	}
+	a.initializeStart(dirPath, logLevel)
+	a.config = &Config{
+		LogLevel:            logLevel,
+		DefaultCipherScheme: common.CIPHER_SCHEME_CURVE,
+		DHPConfig:           &DHPConfig{},
+	}
+	a.knockUser = &KnockUser{}
+	a.knockTargetMap = make(map[string]*KnockTarget)
+	return a.startWithPrivateKey(privateKey, false)
+}
+
+func (a *UdpAgent) initializeStart(dirPath string, logLevel int) {
+	common.ExeDirPath = dirPath
+	ExeDirPath = dirPath
+	// init logger
+	a.log = log.NewLogger("NHP-Agent", logLevel, filepath.Join(ExeDirPath, "logs"), "agent")
+	log.SetGlobalLogger(a.log)
+
+	log.Info("=========================================================")
+	log.Info("=== NHP-Agent %s started                           ===", version.Version)
+	log.Info("=== REVISION %s ===", version.CommitId)
+	log.Info("=== RELEASE %s                       ===", version.BuildTime)
+	log.Info("=========================================================")
+}
+
+func (a *UdpAgent) startWithPrivateKey(prk []byte, loadConfigFiles bool) error {
 	a.device = core.NewDevice(core.NHP_AGENT, prk, nil)
 	if a.device == nil {
-		log.Critical("failed to create device %v\n", err)
-		return fmt.Errorf("failed to create device %v", err)
+		log.Critical("failed to create device")
+		return fmt.Errorf("failed to create device")
 	}
 
 	// start device routines
@@ -356,8 +388,10 @@ func (a *UdpAgent) Start(dirPath string, logLevel int) (err error) {
 	a.serverClusterMap = make(map[string]*ServerCluster)
 	a.serverClusterByName = make(map[string]*ServerCluster)
 
-	// load peers
-	_ = a.loadPeers()
+	if loadConfigFiles {
+		// load peers
+		_ = a.loadPeers()
+	}
 
 	a.remoteConnectionMap = make(map[string]*UdpConn)
 
@@ -375,8 +409,10 @@ func (a *UdpAgent) Start(dirPath string, logLevel int) (err error) {
 	a.knockTargetStopOnce = sync.Once{}
 	a.signals.knockTargetMapUpdated = make(chan struct{}, 1)
 
-	// load knock resources
-	_ = a.loadResources()
+	if loadConfigFiles {
+		// load knock resources
+		_ = a.loadResources()
+	}
 
 	a.recvMsgCh = a.device.DecryptedMsgQueue
 	a.sendMsgCh = make(chan *core.MsgData, core.SendQueueSize)


### PR DESCRIPTION
## Summary
- add an in-memory private-key startup path for embedded OpenNHP agents
- preserve the existing file-backed startup path
- validate exact X25519 key length and avoid config/server watchers for programmatic startup

This enables desktop orchestrators to unwrap device identity from an OS keystore without materializing `PrivateKeyBase64` in `config.toml`. The key is copied into the core ECDH device before the caller can scrub its buffer.

## Validation
- `cd endpoints && go test ./agent`
- `cd nhp && go test ./... && go vet ./...`

The full `endpoints` module has unrelated existing failures in relay redirect expectations and KBS `/opt/confidential-containers` initialization on an unprivileged macOS host.