### PR TITLE
feat(plugin): improve OTP verification email (code-in-subject, headers, injection-safe)

### DIFF
--- a/examples/server_plugin/basic/email_test.go
+++ b/examples/server_plugin/basic/email_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+// TestHasEnvPlaceholder pins the whole-string-only behavior so free-form
+// operator subjects containing a '$' are not mistaken for an un-expanded
+// envsubst variable (the false-positive class from the code review).
+func TestHasEnvPlaceholder(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// Genuine un-expanded placeholders → true.
+		{"${SMTP_SUBJECT}", true},
+		{"$SMTP_SUBJECT", true},
+		{"${SMTP_HOST}", true},
+		{"$SMTP2", true},
+		// Free-form text that merely contains '$' → false.
+		{"Code $5.00", false},
+		{"ACME $CORP verification", false},
+		{"Verify your $USD account", false},
+		{"OpenNHP ${SMTP_SUBJECT}", false}, // embedded, not whole-string
+		{"Your OpenNHP Verification Code", false},
+		{"", false},
+		{"$", false},
+		{"${}", false},
+		{"$lowercase", false}, // envsubst vars are upper/underscore/digit
+	}
+	for _, c := range cases {
+		if got := hasEnvPlaceholder(c.in); got != c.want {
+			t.Errorf("hasEnvPlaceholder(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/examples/server_plugin/basic/etc/config.toml
+++ b/examples/server_plugin/basic/etc/config.toml
@@ -9,12 +9,13 @@ smtp_port = "${SMTP_PORT}"
 smtp_username = "${SMTP_USERNAME}"
 smtp_password = "${SMTP_PASSWORD}"
 smtp_from = "${SMTP_FROM}"
-# The 6-digit OTP is appended to the subject line for inbox-preview
-# visibility. The subject is the least-protected part of a message (it is
-# reflected into bounce/auto-reply mail and often retained in gateway logs
-# where the body is not), so set a neutral subject here if you would rather
-# the code not appear there — it is always present in the body regardless.
 smtp_subject = "${SMTP_SUBJECT}"
+# By default the 6-digit OTP is appended to the subject line for inbox-
+# preview visibility. The subject is the least-protected part of a message
+# (reflected into bounce/auto-reply mail, retained in gateway logs, shown on
+# lock-screen previews where the body is not). Set false to keep the code
+# out of the Subject header — it is always present in the body regardless.
+# smtp_code_in_subject = true
 
 # Require the OTP recipient email to match the claimed userId.
 # When true, RequestOTP rejects requests where UserData["email"] != userId,

--- a/examples/server_plugin/basic/etc/config.toml
+++ b/examples/server_plugin/basic/etc/config.toml
@@ -9,6 +9,11 @@ smtp_port = "${SMTP_PORT}"
 smtp_username = "${SMTP_USERNAME}"
 smtp_password = "${SMTP_PASSWORD}"
 smtp_from = "${SMTP_FROM}"
+# The 6-digit OTP is appended to the subject line for inbox-preview
+# visibility. The subject is the least-protected part of a message (it is
+# reflected into bounce/auto-reply mail and often retained in gateway logs
+# where the body is not), so set a neutral subject here if you would rather
+# the code not appear there — it is always present in the body regardless.
 smtp_subject = "${SMTP_SUBJECT}"
 
 # Require the OTP recipient email to match the claimed userId.

--- a/examples/server_plugin/basic/main.go
+++ b/examples/server_plugin/basic/main.go
@@ -499,13 +499,18 @@ func sendOTPEmail(to, code string) error {
 	if subject == "" {
 		subject = "Your OpenNHP Verification Code"
 	}
+	// Include the code in the subject too, so it's visible from the inbox
+	// preview without opening the message.
+	subject = fmt.Sprintf("%s: %s", subject, code)
 
 	body := fmt.Sprintf("Subject: %s\r\n", subject)
 	body += "MIME-Version: 1.0\r\n"
 	body += "Content-Type: text/plain; charset=\"UTF-8\"\r\n"
 	body += "\r\n"
 	body += fmt.Sprintf("Your verification code is: %s\r\n", code)
-	body += fmt.Sprintf("This code will expire in 5 minutes.\r\n")
+	body += "This code will expire in 5 minutes.\r\n"
+	body += "\r\n"
+	body += "Learn more about OpenNHP at https://opennhp.org\r\n"
 
 	port, err := strconv.Atoi(baseConf.SMTPPort)
 	if err != nil || port <= 0 {

--- a/examples/server_plugin/basic/main.go
+++ b/examples/server_plugin/basic/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/OpenNHP/opennhp/nhp/common"
 	nhplog "github.com/OpenNHP/opennhp/nhp/log"
@@ -496,14 +497,38 @@ func sendOTPEmail(to, code string) error {
 	}
 
 	subject := baseConf.SMTPSubject
-	if subject == "" {
+	// Treat an unsubstituted envsubst placeholder (e.g. "${SMTP_SUBJECT}")
+	// as unset, mirroring the SMTPHost guard above.
+	if subject == "" || strings.HasPrefix(subject, "${") {
 		subject = "Your OpenNHP Verification Code"
 	}
 	// Include the code in the subject too, so it's visible from the inbox
 	// preview without opening the message.
 	subject = fmt.Sprintf("%s: %s", subject, code)
 
-	body := fmt.Sprintf("Subject: %s\r\n", subject)
+	from := baseConf.SMTPFrom
+	if from == "" || strings.HasPrefix(from, "${") {
+		from = "noreply@opennhp.org"
+	}
+
+	// Header fields are interpolated straight into the raw SMTP message;
+	// strip CR/LF from config/caller-sourced values so a stray newline
+	// cannot inject extra headers or body content.
+	headerSafe := strings.NewReplacer("\r", "", "\n", "").Replace
+	subject = headerSafe(subject)
+	from = headerSafe(from)
+	toHeader := headerSafe(to)
+
+	// A message with only Subject/MIME/Content-Type headers scores toward
+	// Junk on many receivers — which is exactly where the subject preview
+	// this change adds would not be seen. Include From/To/Date/Message-ID.
+	now := time.Now()
+	msgID := fmt.Sprintf("<%d.%d@opennhp.org>", now.UnixNano(), os.Getpid())
+	body := fmt.Sprintf("From: %s\r\n", from)
+	body += fmt.Sprintf("To: %s\r\n", toHeader)
+	body += fmt.Sprintf("Subject: %s\r\n", subject)
+	body += fmt.Sprintf("Date: %s\r\n", now.Format(time.RFC1123Z))
+	body += fmt.Sprintf("Message-ID: %s\r\n", msgID)
 	body += "MIME-Version: 1.0\r\n"
 	body += "Content-Type: text/plain; charset=\"UTF-8\"\r\n"
 	body += "\r\n"
@@ -521,11 +546,6 @@ func sendOTPEmail(to, code string) error {
 	var auth smtp.Auth
 	if baseConf.SMTPUsername != "" {
 		auth = smtp.PlainAuth("", baseConf.SMTPUsername, baseConf.SMTPPassword, baseConf.SMTPHost)
-	}
-
-	from := baseConf.SMTPFrom
-	if from == "" {
-		from = "noreply@opennhp.org"
 	}
 
 	return smtp.SendMail(addr, auth, from, []string{to}, []byte(body))

--- a/examples/server_plugin/basic/main.go
+++ b/examples/server_plugin/basic/main.go
@@ -34,6 +34,11 @@ type config struct {
 	SMTPPassword string `toml:"smtp_password"`
 	SMTPFrom     string `toml:"smtp_from"`
 	SMTPSubject  string `toml:"smtp_subject"`
+	// SMTPCodeInSubject, when true (the default when unset), appends the
+	// 6-digit OTP to the email subject for inbox-preview visibility. Set to
+	// false to keep the code out of the Subject header (it is always in the
+	// body); the subject is the least-protected part of a message.
+	SMTPCodeInSubject *bool `toml:"smtp_code_in_subject"`
 	// RequireEmailMatch, when true, enforces that the email address
 	// supplied in UserData matches the claimed userId. This is the
 	// minimum identity-binding check for a demo deployment.
@@ -513,8 +518,14 @@ func sendOTPEmail(to, code string) error {
 		subject = "Your OpenNHP Verification Code"
 	}
 	// Include the code in the subject too, so it's visible from the inbox
-	// preview without opening the message.
-	subject = fmt.Sprintf("%s: %s", subject, code)
+	// preview without opening the message. Opt out via smtp_code_in_subject
+	// = false (default true) to keep it out of the least-protected header.
+	codeInSubject := baseConf.SMTPCodeInSubject == nil || *baseConf.SMTPCodeInSubject
+	if codeInSubject {
+		// Trim a trailing ": " so an operator subject like "Your code:"
+		// doesn't render as "Your code:: 186617".
+		subject = fmt.Sprintf("%s: %s", strings.TrimRight(subject, ": "), code)
+	}
 
 	fromRaw := baseConf.SMTPFrom
 	if fromRaw == "" || hasEnvPlaceholder(fromRaw) {
@@ -542,10 +553,10 @@ func sendOTPEmail(to, code string) error {
 
 	// Header field bodies must be US-ASCII — net/smtp submits a plain DATA
 	// command and never negotiates SMTPUTF8/8BITMIME. RFC 2047-encode the
-	// free-form/caller values so a non-ASCII subject or address does not
-	// yield a non-conformant message. Address.String() also handles the
-	// CR/LF-injection concern (mail.ParseAddress rejects CR/LF); QEncoding
-	// is a no-op for pure-ASCII subjects.
+	// subject (QEncoding, a no-op for pure ASCII) so a non-ASCII subject is
+	// still conformant. Address.String() encodes the display name and
+	// handles CR/LF quoting (mail.ParseAddress already rejects CR/LF); note
+	// a non-ASCII addr-spec would still need SMTPUTF8, which is out of scope.
 	var b strings.Builder
 	fmt.Fprintf(&b, "From: %s\r\n", fromAddr.String())
 	fmt.Fprintf(&b, "To: %s\r\n", toAddr.String())
@@ -574,23 +585,29 @@ func sendOTPEmail(to, code string) error {
 	return smtp.SendMail(addr, auth, fromAddr.Address, []string{toAddr.Address}, []byte(b.String()))
 }
 
-// hasEnvPlaceholder reports whether s still contains an un-expanded
-// envsubst variable — "${VAR}", a bare "$VAR", or one embedded in a larger
-// string (e.g. "OpenNHP ${SMTP_SUBJECT}"). Used to treat a config that was
-// not run through envsubst as unset. A literal "$5.00" is not matched.
+// hasEnvPlaceholder reports whether s is *entirely* an un-expanded envsubst
+// variable — "${VAR}" or a bare "$VAR" — which is what envsubst leaves
+// behind when the config was not rendered. It deliberately matches the
+// whole string only, so free-form operator text that merely contains a '$'
+// ("Code $5.00", "ACME $CORP verification") is NOT treated as a placeholder.
 func hasEnvPlaceholder(s string) bool {
-	if strings.Contains(s, "${") {
-		return true
+	if !strings.HasPrefix(s, "$") {
+		return false
 	}
-	for i := 0; i+1 < len(s); i++ {
-		if s[i] == '$' {
-			c := s[i+1]
-			if c == '_' || (c >= 'A' && c <= 'Z') {
-				return true
-			}
+	name := s[1:]
+	if strings.HasPrefix(name, "{") && strings.HasSuffix(name, "}") {
+		name = name[1 : len(name)-1]
+	}
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c != '_' && !(c >= 'A' && c <= 'Z') && !(c >= '0' && c <= '9') {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func corsMiddleware(ctx *gin.Context) {

--- a/examples/server_plugin/basic/main.go
+++ b/examples/server_plugin/basic/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"net/mail"
 	"net/smtp"
 	"net/url"
 	"os"
@@ -488,7 +490,7 @@ func sendOTPEmail(to, code string) error {
 		smtpHost = baseConf.SMTPHost
 	}
 	// Treat unsubstituted envsubst placeholders as unconfigured.
-	if smtpHost == "" || strings.HasPrefix(smtpHost, "${") {
+	if smtpHost == "" || hasEnvPlaceholder(smtpHost) {
 		// SMTP not configured — succeed silently so local dev can complete
 		// registration without an email server. The OTP code is printed at
 		// Info level so it is visible in default log configurations.
@@ -496,46 +498,67 @@ func sendOTPEmail(to, code string) error {
 		return nil
 	}
 
+	// Validate the recipient up front: this keeps the To: header and the
+	// SMTP envelope recipient in lockstep, and turns a bad/injected address
+	// into a clear error instead of an opaque net/smtp failure deep in the
+	// stdlib. `to` is caller-controlled (UserData["email"] / UserId).
+	toAddr, err := mail.ParseAddress(to)
+	if err != nil {
+		return fmt.Errorf("invalid recipient address %q: %w", to, err)
+	}
+
 	subject := baseConf.SMTPSubject
-	// Treat an unsubstituted envsubst placeholder (e.g. "${SMTP_SUBJECT}")
-	// as unset, mirroring the SMTPHost guard above.
-	if subject == "" || strings.HasPrefix(subject, "${") {
+	// Treat an unsubstituted envsubst placeholder as unset.
+	if subject == "" || hasEnvPlaceholder(subject) {
 		subject = "Your OpenNHP Verification Code"
 	}
 	// Include the code in the subject too, so it's visible from the inbox
 	// preview without opening the message.
 	subject = fmt.Sprintf("%s: %s", subject, code)
 
-	from := baseConf.SMTPFrom
-	if from == "" || strings.HasPrefix(from, "${") {
-		from = "noreply@opennhp.org"
+	fromRaw := baseConf.SMTPFrom
+	if fromRaw == "" || hasEnvPlaceholder(fromRaw) {
+		fromRaw = "noreply@opennhp.org"
 	}
-
-	// Header fields are interpolated straight into the raw SMTP message;
-	// strip CR/LF from config/caller-sourced values so a stray newline
-	// cannot inject extra headers or body content.
-	headerSafe := strings.NewReplacer("\r", "", "\n", "").Replace
-	subject = headerSafe(subject)
-	from = headerSafe(from)
-	toHeader := headerSafe(to)
+	// Parse once: the header keeps the full form (display name allowed),
+	// while the envelope MAIL FROM uses the bare address — most servers
+	// reject the "Name <addr>" form as an envelope argument with a 501.
+	fromAddr, err := mail.ParseAddress(fromRaw)
+	if err != nil {
+		return fmt.Errorf("invalid smtp_from %q: %w", fromRaw, err)
+	}
 
 	// A message with only Subject/MIME/Content-Type headers scores toward
 	// Junk on many receivers — which is exactly where the subject preview
 	// this change adds would not be seen. Include From/To/Date/Message-ID.
+	// The Message-ID domain must match the From domain, or it trips a
+	// common spam heuristic and defeats the purpose of these headers.
+	domain := "opennhp.org"
+	if at := strings.LastIndex(fromAddr.Address, "@"); at >= 0 && at+1 < len(fromAddr.Address) {
+		domain = fromAddr.Address[at+1:]
+	}
 	now := time.Now()
-	msgID := fmt.Sprintf("<%d.%d@opennhp.org>", now.UnixNano(), os.Getpid())
-	body := fmt.Sprintf("From: %s\r\n", from)
-	body += fmt.Sprintf("To: %s\r\n", toHeader)
-	body += fmt.Sprintf("Subject: %s\r\n", subject)
-	body += fmt.Sprintf("Date: %s\r\n", now.Format(time.RFC1123Z))
-	body += fmt.Sprintf("Message-ID: %s\r\n", msgID)
-	body += "MIME-Version: 1.0\r\n"
-	body += "Content-Type: text/plain; charset=\"UTF-8\"\r\n"
-	body += "\r\n"
-	body += fmt.Sprintf("Your verification code is: %s\r\n", code)
-	body += "This code will expire in 5 minutes.\r\n"
-	body += "\r\n"
-	body += "Learn more about OpenNHP at https://opennhp.org\r\n"
+	msgID := fmt.Sprintf("<%d.%d@%s>", now.UnixNano(), os.Getpid(), domain)
+
+	// Header field bodies must be US-ASCII — net/smtp submits a plain DATA
+	// command and never negotiates SMTPUTF8/8BITMIME. RFC 2047-encode the
+	// free-form/caller values so a non-ASCII subject or address does not
+	// yield a non-conformant message. Address.String() also handles the
+	// CR/LF-injection concern (mail.ParseAddress rejects CR/LF); QEncoding
+	// is a no-op for pure-ASCII subjects.
+	var b strings.Builder
+	fmt.Fprintf(&b, "From: %s\r\n", fromAddr.String())
+	fmt.Fprintf(&b, "To: %s\r\n", toAddr.String())
+	fmt.Fprintf(&b, "Subject: %s\r\n", mime.QEncoding.Encode("UTF-8", subject))
+	fmt.Fprintf(&b, "Date: %s\r\n", now.Format(time.RFC1123Z))
+	fmt.Fprintf(&b, "Message-ID: %s\r\n", msgID)
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n")
+	b.WriteString("\r\n")
+	fmt.Fprintf(&b, "Your verification code is: %s\r\n", code)
+	b.WriteString("This code will expire in 5 minutes.\r\n")
+	b.WriteString("\r\n")
+	b.WriteString("Learn more about OpenNHP at https://opennhp.org\r\n")
 
 	port, err := strconv.Atoi(baseConf.SMTPPort)
 	if err != nil || port <= 0 {
@@ -548,7 +571,26 @@ func sendOTPEmail(to, code string) error {
 		auth = smtp.PlainAuth("", baseConf.SMTPUsername, baseConf.SMTPPassword, baseConf.SMTPHost)
 	}
 
-	return smtp.SendMail(addr, auth, from, []string{to}, []byte(body))
+	return smtp.SendMail(addr, auth, fromAddr.Address, []string{toAddr.Address}, []byte(b.String()))
+}
+
+// hasEnvPlaceholder reports whether s still contains an un-expanded
+// envsubst variable — "${VAR}", a bare "$VAR", or one embedded in a larger
+// string (e.g. "OpenNHP ${SMTP_SUBJECT}"). Used to treat a config that was
+// not run through envsubst as unset. A literal "$5.00" is not matched.
+func hasEnvPlaceholder(s string) bool {
+	if strings.Contains(s, "${") {
+		return true
+	}
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] == '$' {
+			c := s[i+1]
+			if c == '_' || (c >= 'A' && c <= 'Z') {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func corsMiddleware(ctx *gin.Context) {


### PR DESCRIPTION
## Summary
Improves the OTP verification email sent by the example ASP plugin. Split out from #1677 (the `server.toml` default swap stays there pending key verification).

- **Code in the subject** — e.g. `Your OpenNHP Verification Code: 186617`, visible from the inbox preview.
- **opennhp.org link** in the body.
- **Standard headers** — adds `From` / `To` / `Date` / `Message-ID` so the message isn't scored toward Junk (where the subject preview wouldn't be seen).
- **Placeholder guard** — an unsubstituted `${SMTP_SUBJECT}` is treated as unset (mirrors the existing `SMTPHost` guard), so a non-`envsubst`'d config doesn't send `Subject: ${SMTP_SUBJECT}: …`.
- **Header-injection safe** — CR/LF stripped from config/caller-sourced header values (subject, from, to).

### After
```
From: noreply@opennhp.org
To: alice@example.com
Subject: Your OpenNHP Verification Code: 186617
Date: Sat, 26 Jul 2026 12:00:00 +0000
Message-ID: <…@opennhp.org>
MIME-Version: 1.0
Content-Type: text/plain; charset="UTF-8"

Your verification code is: 186617
This code will expire in 5 minutes.

Learn more about OpenNHP at https://opennhp.org
```

A configured `smtp_subject` is still honored — the code is appended to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)