### PR TITLE
feat(demoapp): restructure login layout, add footer + source link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ deploy/configs/
 *.log
 # demoapp runtime (local dev run from repo root)
 /data/
+# demoapp local dev: runtime DB / autogen secrets + Vite build output
+# (web/dist is embedded by the Docker/CI build, not committed)
+demoapp/data/
+demoapp/web/dist/

--- a/demoapp/routes.go
+++ b/demoapp/routes.go
@@ -92,6 +92,9 @@ func (a *App) Register(r *gin.Engine) error {
 	if origin := relayOrigin(a.Cfg.PublicRelayURL); origin != "" {
 		connectSrc += " " + origin
 	}
+	// The footer shows the visitor's public IP, fetched client-side from
+	// ipify (same pattern as the js-agent demo at agent.opennhp.org).
+	connectSrc += " https://api.ipify.org https://api6.ipify.org"
 	r.Use(func(c *gin.Context) {
 		c.Header("Content-Security-Policy",
 			fmt.Sprintf("default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src %s; object-src 'none'; frame-ancestors 'none'", connectSrc))

--- a/demoapp/web/index.html
+++ b/demoapp/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenNHP Demo App</title>
+    <title>OpenNHP Integration Demo App</title>
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
   <body>

--- a/demoapp/web/src/styles.css
+++ b/demoapp/web/src/styles.css
@@ -28,6 +28,64 @@ a:hover { text-decoration: underline; }
   margin-bottom: 16px;
 }
 
+/* Two-column auth layout: user credentials | OAuth/SAML. Collapses to a
+   single column on narrow viewports. */
+.auth-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: stretch;
+  margin-bottom: 16px;
+}
+.auth-grid .panel { margin-bottom: 0; }
+@media (max-width: 640px) {
+  .auth-grid { grid-template-columns: 1fr; }
+}
+.auth-section {
+  display: flex;
+  flex-direction: column;
+}
+/* Sign-in and create-account actions share one row. */
+.cred-actions {
+  display: flex;
+  gap: 8px;
+}
+.cred-actions .btn { margin-right: 0; }
+.auth-section .auth-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #c9d1d9;
+  margin: 0 0 4px;
+}
+/* Fill the OAuth panel's spare height (it has fewer controls than the
+   credentials panel) by vertically centering its button block. */
+.oauth-cta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+/* The OAuth panel carries a single action, so give its button more
+   presence — larger icon and padding — to balance the credentials panel. */
+.oauth-cta .btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 16px;
+  font-size: 16px;
+  margin-right: 0;
+}
+.oauth-cta .oauth-icon {
+  width: 22px;
+  height: 22px;
+  margin-right: 10px;
+}
+.auth-section .auth-hint {
+  color: #8b949e;
+  font-size: 12px;
+  margin: 0 0 16px;
+}
+
 .field { margin-bottom: 12px; }
 .field label {
   display: block;
@@ -78,6 +136,50 @@ a:hover { text-decoration: underline; }
 }
 .btn-danger { background: #da3633; color: #fff; }
 .btn-danger:hover { background: #f85149; }
+
+/* Source-code call-out section, sitting above the footer. */
+.source-section {
+  text-align: center;
+  margin-top: 16px;
+}
+.source-section a {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #c9d1d9;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+}
+.source-section a:hover {
+  background: #30363d;
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
+
+/* Page footer, mirrored from https://agent.opennhp.org/. */
+.footer {
+  margin-top: 32px;
+  padding: 20px 0;
+  border-top: 1px solid #30363d;
+  text-align: center;
+  color: #8b949e;
+  font-size: 12.5px;
+  line-height: 1.8;
+}
+.footer strong { color: #c9d1d9; font-weight: 600; }
+.footer a { color: #58a6ff; text-decoration: none; }
+.footer a:hover { text-decoration: underline; }
+.footer .ip-display {
+  color: #6e7681;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  font-size: 12px;
+  margin-bottom: 8px;
+  letter-spacing: 0.2px;
+}
 
 .alert {
   padding: 10px 14px;

--- a/demoapp/web/src/views/arch-diagram.ts
+++ b/demoapp/web/src/views/arch-diagram.ts
@@ -9,7 +9,7 @@
 export function renderArchDiagram(root: HTMLElement): void {
   root.innerHTML = `
     <details class="arch" open>
-      <summary>How the OpenNHP demo works</summary>
+      <summary>How the OpenNHP Integration Demo works</summary>
       <div class="arch-body">
         <img
           class="arch-diagram-image"

--- a/demoapp/web/src/views/footer.ts
+++ b/demoapp/web/src/views/footer.ts
@@ -1,0 +1,55 @@
+// Shared page footer, mirroring the one on https://agent.opennhp.org/:
+// a monospace public-IP line, an OpenNHP attribution, the sponsor credit,
+// and a link to this demo app's source. The IP is fetched client-side
+// from ipify (same pattern as the js-agent demo); the app's CSP
+// connect-src must allow api.ipify.org / api6.ipify.org for it to load.
+
+// Source-code call-out, rendered as its own section above the footer.
+export function renderSourceSection(root: HTMLElement): void {
+  const section = document.createElement('section');
+  section.className = 'panel source-section';
+  section.innerHTML = `
+    <a href="https://github.com/OpenNHP/opennhp/tree/main/demoapp" target="_blank" rel="noopener noreferrer">
+      <svg class="oauth-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.02.37-2.45-.49-2.6-.67-.09-.23-.48-.67-.82-.82-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+      </svg>
+      View this demo app's source on GitHub
+    </a>
+  `;
+  root.appendChild(section);
+}
+
+export function renderFooter(root: HTMLElement): void {
+  const footer = document.createElement('footer');
+  footer.className = 'footer';
+  footer.innerHTML = `
+    <div class="ip-display" id="ipDisplay">Detecting IP…</div>
+    <div>Powered by <a href="https://github.com/OpenNHP/opennhp" target="_blank" rel="noopener"><strong>OpenNHP</strong></a> &mdash; Network-infrastructure Hiding Protocol</div>
+    <div>Sponsored by: <a href="https://layerv.ai" target="_blank" rel="noopener">LayerV.ai</a></div>
+  `;
+  root.appendChild(footer);
+  void fetchIP();
+}
+
+// Detect the visitor's public IPv4/IPv6 and show it in the footer.
+async function fetchIP(): Promise<void> {
+  const el = document.getElementById('ipDisplay');
+  if (!el) return;
+  let ipv4: string | null = null;
+  let ipv6: string | null = null;
+  try {
+    const r = await fetch('https://api.ipify.org?format=json');
+    if (r.ok) ipv4 = (await r.json()).ip;
+  } catch (_) { /* ignore */ }
+  try {
+    const r = await fetch('https://api6.ipify.org?format=json');
+    if (r.ok) ipv6 = (await r.json()).ip;
+  } catch (_) { /* ignore */ }
+  if (ipv4 || ipv6) {
+    if (ipv4 && ipv6) el.textContent = `IPv4: ${ipv4}  |  IPv6: ${ipv6}`;
+    else if (ipv4) el.textContent = `IPv4: ${ipv4}`;
+    else el.textContent = `IPv6: ${ipv6}`;
+  } else {
+    el.textContent = 'IP detection unavailable';
+  }
+}

--- a/demoapp/web/src/views/login.ts
+++ b/demoapp/web/src/views/login.ts
@@ -4,6 +4,7 @@
 import { api, ApiError } from '../api.js';
 import { escapeHtml } from '../escape.js';
 import { renderArchDiagram } from './arch-diagram.js';
+import { renderSourceSection, renderFooter } from './footer.js';
 
 export interface LoginViewProps {
   onSignedIn: () => void;
@@ -13,32 +14,45 @@ export interface LoginViewProps {
 export function renderLogin(root: HTMLElement, props: LoginViewProps): void {
   root.innerHTML = `
     <div class="container">
-      <h1>OpenNHP Integration Demo</h1>
+      <h1>OpenNHP Integration Demo App</h1>
       <p class="subtitle">A working example of adding the OpenNHP to an existing web application</p>
 
       <div id="alert"></div>
 
-      <div class="panel">
-        <div class="field">
-          <label for="login-username">Username</label>
-          <input id="login-username" type="text" autocomplete="username" />
+      <div class="auth-grid">
+        <div class="panel auth-section">
+          <h2 class="auth-title">User credentials</h2>
+          <p class="auth-hint">Sign in with a username and password, or create a new account.</p>
+          <div class="field">
+            <label for="login-username">Username</label>
+            <input id="login-username" type="text" autocomplete="username" />
+          </div>
+          <div class="field">
+            <label for="login-password">Password</label>
+            <input id="login-password" type="password" autocomplete="current-password" />
+          </div>
+          <div class="cred-actions">
+            <button id="login-submit" class="btn btn-primary">Sign in</button>
+            <button id="login-switch-register" class="btn btn-secondary">New here? Create an account</button>
+          </div>
         </div>
-        <div class="field">
-          <label for="login-password">Password</label>
-          <input id="login-password" type="password" autocomplete="current-password" />
+
+        <div class="panel auth-section">
+          <h2 class="auth-title">OAuth / SAML</h2>
+          <p class="auth-hint">Sign in with a federated identity provider.</p>
+          <div class="oauth-cta">
+            <!-- OIDC RP not configured for this deployment; the handler returns
+                 503. Uncomment when an [[OIDC]] block is enabled in config.toml.
+            <a id="login-oidc" class="btn btn-secondary" href="/api/auth/oidc/login">Sign in with OIDC</a>
+            -->
+            <a id="login-github" class="btn btn-secondary" href="/api/auth/github/login">
+              <svg class="oauth-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.02.37-2.45-.49-2.6-.67-.09-.23-.48-.67-.82-.82-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+              </svg>
+              Sign in with GitHub
+            </a>
+          </div>
         </div>
-        <button id="login-submit" class="btn btn-primary">Sign in</button>
-        <!-- OIDC RP not configured for this deployment; the handler returns
-             503. Uncomment when an [[OIDC]] block is enabled in config.toml.
-        <a id="login-oidc" class="btn btn-secondary" href="/api/auth/oidc/login">Sign in with OIDC</a>
-        -->
-        <a id="login-github" class="btn btn-secondary" href="/api/auth/github/login">
-          <svg class="oauth-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.02.37-2.45-.49-2.6-.67-.09-.23-.48-.67-.82-.82-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
-          </svg>
-          Sign in with GitHub
-        </a>
-        <button id="login-switch-register" class="btn btn-secondary">New here? Create an account</button>
       </div>
 
       <div id="arch-diagram" class="arch-diagram"></div>
@@ -77,4 +91,8 @@ export function renderLogin(root: HTMLElement, props: LoginViewProps): void {
 
   const diagramRoot = root.querySelector<HTMLElement>('#arch-diagram')!;
   renderArchDiagram(diagramRoot);
+
+  const container = root.querySelector<HTMLElement>('.container')!;
+  renderSourceSection(container);
+  renderFooter(container);
 }

--- a/demoapp/web/src/views/register.ts
+++ b/demoapp/web/src/views/register.ts
@@ -5,6 +5,7 @@
 import { api, ApiError, type RegisterResponse, type ServerInfo } from '../api.js';
 import { escapeHtml } from '../escape.js';
 import { mountNhpRegPanel } from '../nhp-reg-panel.js';
+import { renderSourceSection, renderFooter } from './footer.js';
 
 export interface RegisterViewProps {
   onRegistered: () => void;
@@ -14,7 +15,7 @@ export interface RegisterViewProps {
 export function renderRegister(root: HTMLElement, props: RegisterViewProps): void {
   root.innerHTML = `
     <div class="container">
-      <h1>OpenNHP Integration Demo</h1>
+      <h1>OpenNHP Integration Demo App</h1>
       <p class="subtitle">A working example of adding the OpenNHP to an existing web application</p>
 
       <div id="alert"></div>
@@ -167,4 +168,8 @@ export function renderRegister(root: HTMLElement, props: RegisterViewProps): voi
     disposePanel?.();
     props.onSwitchToLogin();
   });
+
+  const container = root.querySelector<HTMLElement>('.container')!;
+  renderSourceSection(container);
+  renderFooter(container);
 }


### PR DESCRIPTION
## What

UI polish for the integrated demo app served at **demo.opennhp.org** ([`demoapp/`](../tree/main/demoapp)).

### Naming
- App renamed to **"OpenNHP Integration Demo App"** — HTML `<title>` plus the page `<h1>` on both the login and register views.
- Architecture diagram disclosure now reads **"How the OpenNHP Integration Demo works"**.

### Login layout
- Split the single login panel into **two equal-height sections**:
  - **User credentials** — username/password, with **Sign in** and **New here? Create an account** now on one row.
  - **OAuth / SAML** — GitHub sign-in, with a larger, vertically-centered button so the panel doesn't look empty.
- Two-column grid collapses to one column under 640px.

### Footer + source link
- Added a shared footer mirrored from **agent.opennhp.org**:
  - Public-IP line (IPv4/IPv6) fetched client-side from ipify.
  - *Powered by OpenNHP — Network-infrastructure Hiding Protocol*.
  - *Sponsored by: LayerV.ai*.
- Added a bordered **"View this demo app's source on GitHub"** call-out section (links to `demoapp/`) directly above the footer.

### Supporting changes
- **CSP:** widened `connect-src` in [`routes.go`](../blob/main/demoapp/routes.go) to allow `api.ipify.org` / `api6.ipify.org` for the footer's IP lookup — same pattern the js-agent demo already uses. This is the one security-relevant change here; it adds two outbound origins to a page that ships a per-session key to the browser.
- **.gitignore:** `demoapp/data/` (runtime SQLite DB + autogen secrets) and `demoapp/web/dist/` (Vite output, embedded by the Docker/CI build — not committed).

## Testing

Built and previewed locally end-to-end:
1. `cd endpoints/js-agent && npm ci && npm run build`
2. `cd demoapp/web && npm ci`, alias the SDK into `node_modules/@opennhp/agent`, `npm run build`
3. `cd demoapp && go run . -c etc/config.toml` → http://localhost:8081

Verified: both panels equal height, buttons on one row, footer renders with the resolved IP (`IPv4: … | IPv6: …`), and the source button sits above the footer. `gofmt` clean.

## Note

The demoapp SPA is only served when built with the `webdist` tag (or `web/dist` present on disk); NHP knock/registration actions still require a running `nhp-relay` + `nhp-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)