### PR TITLE
feat(demoapp): retitle, add Simplified Chinese (i18n) + language switcher

### DIFF
--- a/demoapp/web/index.html
+++ b/demoapp/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenNHP Integration Demo App</title>
+    <title>OpenNHP Login Integration Demo App</title>
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
   <body>

--- a/demoapp/web/src/i18n.ts
+++ b/demoapp/web/src/i18n.ts
@@ -1,0 +1,258 @@
+// Minimal i18n for the demo app: English + Simplified Chinese.
+//
+// Strings are looked up by key via t(key, vars?). Values may contain
+// {placeholder} tokens replaced from `vars`. A handful of footer strings
+// carry inline HTML (links) and are injected via innerHTML by the caller;
+// everything else is plain text. The active language is persisted in
+// localStorage and defaults to the browser's preferred language.
+
+export type Lang = 'en' | 'zh-cn';
+
+type Dict = Record<string, string>;
+
+const EN: Dict = {
+  // Shared
+  'common.signedInAs': 'Signed in as',
+  'common.signOut': 'Sign out',
+  'common.loading': 'Loading…',
+  'common.subtitle': 'A working example of adding the OpenNHP to an existing web application',
+
+  // Language switcher
+  'lang.label': 'Language',
+  'lang.en': 'English',
+  'lang.zh': '中文',
+
+  // Login
+  'login.title': 'OpenNHP Login Integration Demo App',
+  'login.credTitle': 'User credentials',
+  'login.credHint': 'Sign in with a username and password, or create a new account.',
+  'login.username': 'Username',
+  'login.password': 'Password',
+  'login.signIn': 'Sign in',
+  'login.createAccount': 'New here? Create an account',
+  'login.oauthTitle': 'OAuth / SAML',
+  'login.oauthHint': 'Sign in with a federated identity provider.',
+  'login.github': 'Sign in with GitHub',
+  'login.errRequired': 'Username and password are required.',
+  'login.signingIn': 'Signing in…',
+  'login.failed': 'Sign in failed: {msg}',
+
+  // Architecture diagram
+  'arch.summary': 'How the OpenNHP Integration Demo works',
+
+  // Footer
+  'footer.detectingIp': 'Detecting IP…',
+  'footer.ipUnavailable': 'IP detection unavailable',
+  'footer.poweredBy': 'Powered by <a href="https://github.com/OpenNHP/opennhp" target="_blank" rel="noopener"><strong>OpenNHP</strong></a> &mdash; Network-infrastructure Hiding Protocol',
+  'footer.sponsoredBy': 'Sponsored by: <a href="https://layerv.ai" target="_blank" rel="noopener">LayerV.ai</a>',
+  'footer.viewSource': "View this demo app's source on GitHub",
+
+  // Register
+  'reg.accountCreds': '1. Account credentials',
+  'reg.username': 'Username',
+  'reg.email': 'Email',
+  'reg.password': 'Password (min 8 chars)',
+  'reg.nhpServer': 'NHP server',
+  'reg.cipherScheme': 'Cipher scheme',
+  'reg.submit': 'Create account & request OTP',
+  'reg.switchLogin': 'Already have an account? Sign in',
+  'reg.noServers': 'No servers configured',
+  'reg.allRequired': 'All fields are required.',
+  'reg.selectServerScheme': 'Select an NHP server and cipher scheme.',
+  'reg.creating': 'Creating account and generating NHP key pair…',
+  'reg.failed': 'Registration failed: {msg}',
+  'reg.loadingScheme': 'Loading…',
+
+  // NHP registration panel
+  'nhp.title': 'NHP registration',
+  'nhp.back': 'Back',
+  'nhp.otpSentTo': 'An OTP has been sent to <strong>{email}</strong>. In docker environments, check the nhp-server logs for the OTP fallback.',
+  'nhp.otpLabel': 'OTP',
+  'nhp.registerBtn': 'Register public key with nhp-server',
+  'nhp.resend': 'Resend code',
+  'nhp.resendCooldown': 'Resend code ({n}s)',
+  'nhp.agentNotReady': 'Agent not ready. Go back and try again.',
+  'nhp.requestingNew': 'Requesting a new OTP…',
+  'nhp.newOtpSent': 'A new OTP has been sent to {email}.',
+  'nhp.otpReqFailed': 'NHP-OTP request failed{suffix}.',
+  'nhp.enterOtp': 'Enter the OTP from your email.',
+  'nhp.driving': 'Driving NHP-REG handshake…',
+  'nhp.regFailedCheck': 'NHP registration failed — check the OTP and try again.',
+  'nhp.complete': 'Registration complete.',
+  'nhp.handshakeFailed': 'NHP handshake failed: {msg}',
+  'nhp.creatingAgent': 'Creating NHP agent and requesting OTP…',
+
+  // Complete registration
+  'cr.title': 'Complete NHP Registration',
+  'cr.subtitle': 'Your account exists but the NHP key was never registered with nhp-server. Pick your cluster and cipher scheme, then complete the handshake to activate your account.',
+  'cr.binding': 'NHP binding',
+  'cr.cluster': 'NHP server cluster',
+  'cr.cipherScheme': 'Cipher scheme',
+  'cr.confirm': 'Confirm & request OTP',
+  'cr.noClusters': 'No nhp-server clusters are configured.',
+  'cr.selectClusterScheme': 'Select an NHP server cluster and cipher scheme.',
+  'cr.generating': 'Generating NHP key material under the selected binding…',
+  'cr.clickRetry': 'Click "Confirm & request OTP" to retry.',
+  'cr.bindingFailed': 'Binding failed: {msg}',
+  'cr.loadCatalogFailed': 'Failed to load server catalog: {msg}',
+
+  // Resources
+  'res.title': 'Protected Resources',
+  'res.subtitle': 'Click "Access" to knock nhp-server. The protected resource is hidden until the knock opens the door.',
+  'res.deleteAccount': 'Delete account',
+  'res.badgeAuth': 'Auth',
+  'res.badgeAlg': 'Alg',
+  'res.badgeServer': 'Server',
+  'res.access': 'Access',
+  'res.providerLocal': 'Local',
+  'res.deleteConfirm': 'Delete your account? This permanently removes your credentials and NHP key material from this demo. You can re-register afterward. This cannot be undone.',
+  'res.fetchingCreds': 'Fetching credentials from server…',
+  'res.loadFailed': 'Failed to load: {msg}',
+  'res.initAgent': 'Initializing NHP agent and listing services…',
+  'res.none': 'No accessible resources. Confirm registration completed and that the nhp-server basic plugin allows your user.',
+  'res.knocking': 'Knocking {id}…',
+  'res.knockSuccess': 'Knock successful — opening {host}',
+  'res.knockFailed': 'Knock failed: {err}',
+  'res.listFailed': 'listServices failed: {msg}',
+  'res.deleteFailed': 'Failed to delete account: {msg}',
+  'res.idPrefix': 'id',
+};
+
+const ZH: Dict = {
+  'common.signedInAs': '已登录：',
+  'common.signOut': '退出登录',
+  'common.loading': '加载中…',
+  'common.subtitle': '将 OpenNHP 集成到现有 Web 应用的可运行示例',
+
+  'lang.label': '语言',
+  'lang.en': 'English',
+  'lang.zh': '中文',
+
+  'login.title': 'OpenNHP 登录集成演示应用',
+  'login.credTitle': '用户凭据',
+  'login.credHint': '使用用户名和密码登录，或创建新账户。',
+  'login.username': '用户名',
+  'login.password': '密码',
+  'login.signIn': '登录',
+  'login.createAccount': '新用户？创建账户',
+  'login.oauthTitle': 'OAuth / SAML',
+  'login.oauthHint': '使用联合身份提供商登录。',
+  'login.github': '使用 GitHub 登录',
+  'login.errRequired': '用户名和密码为必填项。',
+  'login.signingIn': '正在登录…',
+  'login.failed': '登录失败：{msg}',
+
+  'arch.summary': 'OpenNHP 集成演示的工作原理',
+
+  'footer.detectingIp': '正在检测 IP…',
+  'footer.ipUnavailable': '无法检测 IP',
+  'footer.poweredBy': '驱动技术：<a href="https://github.com/OpenNHP/opennhp" target="_blank" rel="noopener"><strong>OpenNHP</strong></a> &mdash; 网络基础设施隐藏协议',
+  'footer.sponsoredBy': '赞助方：<a href="https://layerv.ai" target="_blank" rel="noopener">LayerV.ai</a>',
+  'footer.viewSource': '在 GitHub 上查看此演示应用的源代码',
+
+  'reg.accountCreds': '1. 账户凭据',
+  'reg.username': '用户名',
+  'reg.email': '电子邮箱',
+  'reg.password': '密码（至少 8 个字符）',
+  'reg.nhpServer': 'NHP 服务器',
+  'reg.cipherScheme': '加密方案',
+  'reg.submit': '创建账户并请求 OTP',
+  'reg.switchLogin': '已有账户？登录',
+  'reg.noServers': '未配置服务器',
+  'reg.allRequired': '所有字段均为必填项。',
+  'reg.selectServerScheme': '请选择 NHP 服务器和加密方案。',
+  'reg.creating': '正在创建账户并生成 NHP 密钥对…',
+  'reg.failed': '注册失败：{msg}',
+  'reg.loadingScheme': '加载中…',
+
+  'nhp.title': 'NHP 注册',
+  'nhp.back': '返回',
+  'nhp.otpSentTo': '一次性验证码（OTP）已发送至 <strong>{email}</strong>。在 docker 环境中，可在 nhp-server 日志中查看 OTP 回退值。',
+  'nhp.otpLabel': 'OTP',
+  'nhp.registerBtn': '向 nhp-server 注册公钥',
+  'nhp.resend': '重新发送验证码',
+  'nhp.resendCooldown': '重新发送验证码（{n}秒）',
+  'nhp.agentNotReady': '代理未就绪。请返回后重试。',
+  'nhp.requestingNew': '正在请求新的 OTP…',
+  'nhp.newOtpSent': '新的 OTP 已发送至 {email}。',
+  'nhp.otpReqFailed': 'NHP-OTP 请求失败{suffix}。',
+  'nhp.enterOtp': '请输入邮件中的 OTP。',
+  'nhp.driving': '正在执行 NHP-REG 握手…',
+  'nhp.regFailedCheck': 'NHP 注册失败 —— 请检查 OTP 后重试。',
+  'nhp.complete': '注册完成。',
+  'nhp.handshakeFailed': 'NHP 握手失败：{msg}',
+  'nhp.creatingAgent': '正在创建 NHP 代理并请求 OTP…',
+
+  'cr.title': '完成 NHP 注册',
+  'cr.subtitle': '您的账户已存在，但 NHP 密钥尚未向 nhp-server 注册。请选择集群和加密方案，然后完成握手以激活账户。',
+  'cr.binding': 'NHP 绑定',
+  'cr.cluster': 'NHP 服务器集群',
+  'cr.cipherScheme': '加密方案',
+  'cr.confirm': '确认并请求 OTP',
+  'cr.noClusters': '未配置 nhp-server 集群。',
+  'cr.selectClusterScheme': '请选择 NHP 服务器集群和加密方案。',
+  'cr.generating': '正在根据所选绑定生成 NHP 密钥材料…',
+  'cr.clickRetry': '点击“确认并请求 OTP”重试。',
+  'cr.bindingFailed': '绑定失败：{msg}',
+  'cr.loadCatalogFailed': '加载服务器目录失败：{msg}',
+
+  'res.title': '受保护的资源',
+  'res.subtitle': '点击“访问”以叩门 nhp-server。在叩门开门之前，受保护的资源处于隐藏状态。',
+  'res.deleteAccount': '删除账户',
+  'res.badgeAuth': '认证',
+  'res.badgeAlg': '算法',
+  'res.badgeServer': '服务器',
+  'res.access': '访问',
+  'res.providerLocal': '本地',
+  'res.deleteConfirm': '确定要删除您的账户吗？此操作将从本演示中永久移除您的凭据和 NHP 密钥材料。之后您可以重新注册。此操作无法撤销。',
+  'res.fetchingCreds': '正在从服务器获取凭据…',
+  'res.loadFailed': '加载失败：{msg}',
+  'res.initAgent': '正在初始化 NHP 代理并列出服务…',
+  'res.none': '没有可访问的资源。请确认注册已完成，且 nhp-server basic 插件已允许您的用户。',
+  'res.knocking': '正在叩门 {id}…',
+  'res.knockSuccess': '叩门成功 —— 正在打开 {host}',
+  'res.knockFailed': '叩门失败：{err}',
+  'res.listFailed': 'listServices 失败：{msg}',
+  'res.deleteFailed': '删除账户失败：{msg}',
+  'res.idPrefix': 'id',
+};
+
+const DICTS: Record<Lang, Dict> = { en: EN, 'zh-cn': ZH };
+
+const STORAGE_KEY = 'demoapp.lang';
+
+function detectLang(): Lang {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'en' || saved === 'zh-cn') return saved;
+  } catch { /* ignore */ }
+  const nav = (navigator.language || '').toLowerCase();
+  return nav.startsWith('zh') ? 'zh-cn' : 'en';
+}
+
+let current: Lang = detectLang();
+
+export function getLang(): Lang {
+  return current;
+}
+
+export function setLang(lang: Lang): void {
+  current = lang;
+  try {
+    localStorage.setItem(STORAGE_KEY, lang);
+  } catch { /* ignore */ }
+  try {
+    document.documentElement.lang = lang === 'zh-cn' ? 'zh-CN' : 'en';
+  } catch { /* ignore */ }
+}
+
+// Translate `key`, interpolating {name} tokens from `vars`. Falls back to
+// the English string, then to the raw key, so a missing translation is
+// visible but never blank.
+export function t(key: string, vars?: Record<string, string | number>): string {
+  const raw = DICTS[current][key] ?? EN[key] ?? key;
+  if (!vars) return raw;
+  return raw.replace(/\{(\w+)\}/g, (_, name) =>
+    name in vars ? String(vars[name]) : `{${name}}`,
+  );
+}

--- a/demoapp/web/src/i18n.ts
+++ b/demoapp/web/src/i18n.ts
@@ -256,3 +256,59 @@ export function t(key: string, vars?: Record<string, string | number>): string {
     name in vars ? String(vars[name]) : `{${name}}`,
   );
 }
+
+// Render the globe-icon language dropdown (EN ▾ / 中文 ▾) into `container`
+// (a view's .container). Mirrors the switcher on agent.opennhp.org.
+// Picking a language persists it and reloads so every view re-renders in
+// the chosen language.
+export function renderLangSwitcher(container: HTMLElement): void {
+  const langs: { code: Lang; short: string; name: string }[] = [
+    { code: 'en', short: 'EN', name: 'English' },
+    { code: 'zh-cn', short: '中文', name: '简体中文' },
+  ];
+  const cur = getLang();
+  const shortLabel = langs.find((l) => l.code === cur)?.short ?? 'EN';
+
+  const wrap = document.createElement('div');
+  wrap.className = 'lang-switcher';
+  wrap.innerHTML = `
+    <button id="langButton" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Language">
+      <svg class="lang-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M3 12h18"></path><path d="M12 3a14 14 0 0 1 0 18"></path><path d="M12 3a14 14 0 0 0 0 18"></path></svg>
+      <span id="langButtonLabel">${shortLabel}</span><span class="caret">▾</span>
+    </button>
+    <ul id="langMenu" class="lang-menu" role="menu" hidden>
+      ${langs.map((l) => `<li role="menuitem" data-lang="${l.code}" class="${l.code === cur ? 'active' : ''}">${l.name}</li>`).join('')}
+    </ul>
+  `;
+  // Prepend so it anchors to the container's top-right regardless of view.
+  container.insertBefore(wrap, container.firstChild);
+
+  const button = wrap.querySelector<HTMLButtonElement>('#langButton')!;
+  const menu = wrap.querySelector<HTMLUListElement>('#langMenu')!;
+
+  const closeMenu = (): void => {
+    menu.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+  };
+  button.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const open = menu.hidden;
+    menu.hidden = !open;
+    button.setAttribute('aria-expanded', String(open));
+  });
+  menu.addEventListener('click', (e) => {
+    const li = (e.target as HTMLElement).closest<HTMLLIElement>('li[data-lang]');
+    if (!li) return;
+    const lang = li.dataset.lang as Lang;
+    if (lang === getLang()) {
+      closeMenu();
+      return;
+    }
+    setLang(lang);
+    location.reload();
+  });
+  document.addEventListener('click', closeMenu);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeMenu();
+  });
+}

--- a/demoapp/web/src/main.ts
+++ b/demoapp/web/src/main.ts
@@ -3,7 +3,7 @@
 // complete-registration (resume) form accordingly.
 
 import { api, ApiError } from './api.js';
-import { getLang, setLang, t, type Lang } from './i18n.js';
+import { getLang, setLang, t } from './i18n.js';
 import { renderLogin } from './views/login.js';
 import { renderRegister } from './views/register.js';
 import { renderResources } from './views/resources.js';
@@ -13,64 +13,9 @@ type View = 'loading' | 'login' | 'register' | 'resources' | 'complete-registrat
 
 const root = document.querySelector<HTMLElement>('#app')!;
 
-// Fixed language switcher — a globe-icon dropdown (EN ▾) mirroring the one
-// on agent.opennhp.org. Picking a language persists the choice and reloads
-// so every view re-renders in the chosen language from scratch.
-function mountLangSwitcher(): void {
-  if (document.getElementById('lang-switcher')) return;
-  const langs: { code: Lang; short: string; name: string }[] = [
-    { code: 'en', short: 'EN', name: 'English' },
-    { code: 'zh-cn', short: '中文', name: '简体中文' },
-  ];
-  const cur = getLang();
-  const shortLabel = langs.find((l) => l.code === cur)?.short ?? 'EN';
-
-  const wrap = document.createElement('div');
-  wrap.id = 'lang-switcher';
-  wrap.className = 'lang-switcher';
-  wrap.innerHTML = `
-    <button id="langButton" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Language">
-      <svg class="lang-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M3 12h18"></path><path d="M12 3a14 14 0 0 1 0 18"></path><path d="M12 3a14 14 0 0 0 0 18"></path></svg>
-      <span id="langButtonLabel">${shortLabel}</span><span class="caret">▾</span>
-    </button>
-    <ul id="langMenu" class="lang-menu" role="menu" hidden>
-      ${langs.map((l) => `<li role="menuitem" data-lang="${l.code}" class="${l.code === cur ? 'active' : ''}">${l.name}</li>`).join('')}
-    </ul>
-  `;
-  document.body.appendChild(wrap);
-
-  const button = wrap.querySelector<HTMLButtonElement>('#langButton')!;
-  const menu = wrap.querySelector<HTMLUListElement>('#langMenu')!;
-
-  const closeMenu = (): void => {
-    menu.hidden = true;
-    button.setAttribute('aria-expanded', 'false');
-  };
-  button.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const open = menu.hidden;
-    menu.hidden = !open;
-    button.setAttribute('aria-expanded', String(open));
-  });
-  menu.addEventListener('click', (e) => {
-    const li = (e.target as HTMLElement).closest<HTMLLIElement>('li[data-lang]');
-    if (!li) return;
-    const lang = li.dataset.lang as Lang;
-    if (lang === getLang()) {
-      closeMenu();
-      return;
-    }
-    setLang(lang);
-    location.reload();
-  });
-  // Dismiss on outside click / Escape.
-  document.addEventListener('click', closeMenu);
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') closeMenu();
-  });
-}
-mountLangSwitcher();
-setLang(getLang()); // stamp <html lang> on first load
+// The language dropdown is rendered inside each view's .container (see
+// renderLangSwitcher). Here we just stamp <html lang> and the tab title.
+setLang(getLang());
 document.title = t('login.title');
 
 async function detectSession(): Promise<{ username: string; email: string; status: string; cipherScheme: string; serverName: string; authProvider: string } | null> {

--- a/demoapp/web/src/main.ts
+++ b/demoapp/web/src/main.ts
@@ -3,6 +3,7 @@
 // complete-registration (resume) form accordingly.
 
 import { api, ApiError } from './api.js';
+import { getLang, setLang, t, type Lang } from './i18n.js';
 import { renderLogin } from './views/login.js';
 import { renderRegister } from './views/register.js';
 import { renderResources } from './views/resources.js';
@@ -11,6 +12,31 @@ import { renderCompleteRegistration } from './views/complete-registration.js';
 type View = 'loading' | 'login' | 'register' | 'resources' | 'complete-registration';
 
 const root = document.querySelector<HTMLElement>('#app')!;
+
+// Fixed language switcher (EN | 中文). Switching persists the choice and
+// reloads so every view re-renders in the chosen language from scratch.
+function mountLangSwitcher(): void {
+  if (document.getElementById('lang-switcher')) return;
+  const bar = document.createElement('div');
+  bar.id = 'lang-switcher';
+  const langs: Lang[] = ['en', 'zh-cn'];
+  const labels: Record<Lang, string> = { en: 'English', 'zh-cn': '中文' };
+  bar.innerHTML = langs
+    .map((l) => `<button type="button" data-lang="${l}" class="${getLang() === l ? 'active' : ''}">${labels[l]}</button>`)
+    .join('');
+  bar.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('button[data-lang]');
+    if (!btn) return;
+    const lang = btn.dataset.lang as Lang;
+    if (lang === getLang()) return;
+    setLang(lang);
+    location.reload();
+  });
+  document.body.appendChild(bar);
+}
+mountLangSwitcher();
+setLang(getLang()); // stamp <html lang> on first load
+document.title = t('login.title');
 
 async function detectSession(): Promise<{ username: string; email: string; status: string; cipherScheme: string; serverName: string; authProvider: string } | null> {
   try {
@@ -88,7 +114,7 @@ function show(view: View): void {
       });
       return;
     case 'loading':
-      root.innerHTML = '<div class="container"><p class="note">Loading…</p></div>';
+      root.innerHTML = `<div class="container"><p class="note">${t('common.loading')}</p></div>`;
       return;
   }
 }

--- a/demoapp/web/src/main.ts
+++ b/demoapp/web/src/main.ts
@@ -13,26 +13,61 @@ type View = 'loading' | 'login' | 'register' | 'resources' | 'complete-registrat
 
 const root = document.querySelector<HTMLElement>('#app')!;
 
-// Fixed language switcher (EN | 中文). Switching persists the choice and
-// reloads so every view re-renders in the chosen language from scratch.
+// Fixed language switcher — a globe-icon dropdown (EN ▾) mirroring the one
+// on agent.opennhp.org. Picking a language persists the choice and reloads
+// so every view re-renders in the chosen language from scratch.
 function mountLangSwitcher(): void {
   if (document.getElementById('lang-switcher')) return;
-  const bar = document.createElement('div');
-  bar.id = 'lang-switcher';
-  const langs: Lang[] = ['en', 'zh-cn'];
-  const labels: Record<Lang, string> = { en: 'English', 'zh-cn': '中文' };
-  bar.innerHTML = langs
-    .map((l) => `<button type="button" data-lang="${l}" class="${getLang() === l ? 'active' : ''}">${labels[l]}</button>`)
-    .join('');
-  bar.addEventListener('click', (e) => {
-    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('button[data-lang]');
-    if (!btn) return;
-    const lang = btn.dataset.lang as Lang;
-    if (lang === getLang()) return;
+  const langs: { code: Lang; short: string; name: string }[] = [
+    { code: 'en', short: 'EN', name: 'English' },
+    { code: 'zh-cn', short: '中文', name: '简体中文' },
+  ];
+  const cur = getLang();
+  const shortLabel = langs.find((l) => l.code === cur)?.short ?? 'EN';
+
+  const wrap = document.createElement('div');
+  wrap.id = 'lang-switcher';
+  wrap.className = 'lang-switcher';
+  wrap.innerHTML = `
+    <button id="langButton" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Language">
+      <svg class="lang-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M3 12h18"></path><path d="M12 3a14 14 0 0 1 0 18"></path><path d="M12 3a14 14 0 0 0 0 18"></path></svg>
+      <span id="langButtonLabel">${shortLabel}</span><span class="caret">▾</span>
+    </button>
+    <ul id="langMenu" class="lang-menu" role="menu" hidden>
+      ${langs.map((l) => `<li role="menuitem" data-lang="${l.code}" class="${l.code === cur ? 'active' : ''}">${l.name}</li>`).join('')}
+    </ul>
+  `;
+  document.body.appendChild(wrap);
+
+  const button = wrap.querySelector<HTMLButtonElement>('#langButton')!;
+  const menu = wrap.querySelector<HTMLUListElement>('#langMenu')!;
+
+  const closeMenu = (): void => {
+    menu.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+  };
+  button.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const open = menu.hidden;
+    menu.hidden = !open;
+    button.setAttribute('aria-expanded', String(open));
+  });
+  menu.addEventListener('click', (e) => {
+    const li = (e.target as HTMLElement).closest<HTMLLIElement>('li[data-lang]');
+    if (!li) return;
+    const lang = li.dataset.lang as Lang;
+    if (lang === getLang()) {
+      closeMenu();
+      return;
+    }
     setLang(lang);
     location.reload();
   });
-  document.body.appendChild(bar);
+  // Dismiss on outside click / Escape.
+  document.addEventListener('click', closeMenu);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeMenu();
+  });
 }
 mountLangSwitcher();
 setLang(getLang()); // stamp <html lang> on first load

--- a/demoapp/web/src/nhp-reg-panel.ts
+++ b/demoapp/web/src/nhp-reg-panel.ts
@@ -10,6 +10,7 @@
 
 import { api, ApiError, type NhpEndpointConfig } from './api.js';
 import { escapeHtml } from './escape.js';
+import { t } from './i18n.js';
 import { createAgent, requestOtp, registerPublicKey, type AgentHandle } from './nhp.js';
 
 export interface NhpRegPanelOpts {
@@ -45,10 +46,10 @@ export function mountNhpRegPanel(container: HTMLElement, opts: NhpRegPanelOpts):
   function renderWaiting(message: string): void {
     container.innerHTML = `
       <div class="panel">
-        <h2>NHP registration</h2>
+        <h2>${t('nhp.title')}</h2>
         <div class="spinner"></div>
         <p class="note">${escapeHtml(message)}</p>
-        ${opts.onBack ? '<button class="btn btn-secondary" id="nhp-back">Back</button>' : ''}
+        ${opts.onBack ? `<button class="btn btn-secondary" id="nhp-back">${t('nhp.back')}</button>` : ''}
       </div>
     `;
     container.querySelector<HTMLButtonElement>('#nhp-back')?.addEventListener('click', () => opts.onBack?.());
@@ -57,18 +58,17 @@ export function mountNhpRegPanel(container: HTMLElement, opts: NhpRegPanelOpts):
   function renderOtpEntry(): void {
     container.innerHTML = `
       <div class="panel">
-        <h2>NHP registration</h2>
-        <p class="note">An OTP has been sent to <strong>${escapeHtml(opts.email)}</strong>.
-          In docker environments, check the nhp-server logs for the OTP fallback.</p>
+        <h2>${t('nhp.title')}</h2>
+        <p class="note">${t('nhp.otpSentTo', { email: escapeHtml(opts.email) })}</p>
         <div id="nhp-alert"></div>
         <div class="field">
-          <label for="nhp-otp">OTP</label>
+          <label for="nhp-otp">${t('nhp.otpLabel')}</label>
           <input id="nhp-otp" type="text" autocomplete="one-time-code" inputmode="numeric"
                  placeholder="000000" maxlength="6" />
         </div>
-        <button id="nhp-register" class="btn btn-primary">Register public key with nhp-server</button>
-        <button id="nhp-resend" class="btn btn-secondary">Resend code</button>
-        ${opts.onBack ? '<button class="btn btn-secondary" id="nhp-back">Back</button>' : ''}
+        <button id="nhp-register" class="btn btn-primary">${t('nhp.registerBtn')}</button>
+        <button id="nhp-resend" class="btn btn-secondary">${t('nhp.resend')}</button>
+        ${opts.onBack ? `<button class="btn btn-secondary" id="nhp-back">${t('nhp.back')}</button>` : ''}
       </div>
     `;
     const alert = container.querySelector<HTMLDivElement>('#nhp-alert')!;
@@ -99,37 +99,37 @@ export function mountNhpRegPanel(container: HTMLElement, opts: NhpRegPanelOpts):
       if (resendTimer) clearInterval(resendTimer);
       let remaining = RESEND_COOLDOWN_SECONDS;
       resendBtn.disabled = true;
-      resendBtn.textContent = `Resend code (${remaining}s)`;
+      resendBtn.textContent = t('nhp.resendCooldown', { n: remaining });
       resendTimer = setInterval(() => {
         remaining -= 1;
         if (remaining <= 0) {
           if (resendTimer) clearInterval(resendTimer);
           resendTimer = null;
           resendBtn.disabled = false;
-          resendBtn.textContent = 'Resend code';
+          resendBtn.textContent = t('nhp.resend');
         } else {
-          resendBtn.textContent = `Resend code (${remaining}s)`;
+          resendBtn.textContent = t('nhp.resendCooldown', { n: remaining });
         }
       }, 1000);
     };
     resendBtn.addEventListener('click', async () => {
       if (resendBtn.disabled) return;
       if (!handle) {
-        showAlert('error', 'Agent not ready. Go back and try again.');
+        showAlert('error', t('nhp.agentNotReady'));
         return;
       }
       resendBtn.disabled = true;
-      showAlert('info', 'Requesting a new OTP…');
+      showAlert('info', t('nhp.requestingNew'));
       try {
         const otp = await requestOtp(handle, opts.nhp, opts.email, debug);
         if (otp.success) {
-          showAlert('info', `A new OTP has been sent to ${opts.email}.`);
+          showAlert('info', t('nhp.newOtpSent', { email: opts.email }));
         } else {
-          showAlert('error', `NHP-OTP request failed${otp.error ? ': ' + otp.error : ''}.`);
+          showAlert('error', t('nhp.otpReqFailed', { suffix: otp.error ? ': ' + otp.error : '' }));
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        showAlert('error', `NHP-OTP request failed: ${msg}`);
+        showAlert('error', t('nhp.otpReqFailed', { suffix: ': ' + msg }));
       } finally {
         // Apply the cooldown whether the request succeeded or failed so
         // a caller cannot bypass the throttle by inducing errors.
@@ -140,27 +140,27 @@ export function mountNhpRegPanel(container: HTMLElement, opts: NhpRegPanelOpts):
     registerBtn.addEventListener('click', async () => {
       const otp = otpInput.value.trim();
       if (!otp) {
-        showAlert('error', 'Enter the OTP from your email.');
+        showAlert('error', t('nhp.enterOtp'));
         return;
       }
       if (!handle) {
-        showAlert('error', 'Agent not ready. Go back and try again.');
+        showAlert('error', t('nhp.agentNotReady'));
         return;
       }
       registerBtn.disabled = true;
-      showAlert('info', 'Driving NHP-REG handshake…');
+      showAlert('info', t('nhp.driving'));
       try {
         const result = await registerPublicKey(handle, opts.nhp, opts.email, otp, debug);
         if (!result.rakOk) {
-          showAlert('error', 'NHP registration failed — check the OTP and try again.');
+          showAlert('error', t('nhp.regFailedCheck'));
           return;
         }
         await api.registerConfirm(opts.regToken ?? '', opts.deviceId, result.expiresAt ?? 0, true);
-        showAlert('success', 'Registration complete.');
+        showAlert('success', t('nhp.complete'));
         opts.onComplete(true);
       } catch (err) {
         const msg = err instanceof ApiError || err instanceof Error ? err.message : String(err);
-        showAlert('error', `NHP handshake failed: ${msg}`);
+        showAlert('error', t('nhp.handshakeFailed', { msg }));
       } finally {
         registerBtn.disabled = false;
       }
@@ -170,9 +170,9 @@ export function mountNhpRegPanel(container: HTMLElement, opts: NhpRegPanelOpts):
   function renderError(message: string): void {
     container.innerHTML = `
       <div class="panel">
-        <h2>NHP registration</h2>
+        <h2>${t('nhp.title')}</h2>
         <div class="alert alert-error">${escapeHtml(message)}</div>
-        ${opts.onBack ? '<button class="btn btn-secondary" id="nhp-back">Back</button>' : ''}
+        ${opts.onBack ? `<button class="btn btn-secondary" id="nhp-back">${t('nhp.back')}</button>` : ''}
       </div>
     `;
     container.querySelector<HTMLButtonElement>('#nhp-back')?.addEventListener('click', () => opts.onBack?.());
@@ -180,20 +180,20 @@ export function mountNhpRegPanel(container: HTMLElement, opts: NhpRegPanelOpts):
 
   // Kick off requestOtp on mount.
   (async () => {
-    renderWaiting('Creating NHP agent and requesting OTP…');
+    renderWaiting(t('nhp.creatingAgent'));
     try {
       handle = await createAgent(opts.privateKey, opts.nhp, opts.deviceId, logLevel);
       const otp = await requestOtp(handle, opts.nhp, opts.email, debug);
       if (disposed) return;
       if (!otp.success) {
-        renderError(`NHP-OTP request failed${otp.error ? ': ' + otp.error : ''}.`);
+        renderError(t('nhp.otpReqFailed', { suffix: otp.error ? ': ' + otp.error : '' }));
         return;
       }
       renderOtpEntry();
     } catch (err) {
       if (disposed) return;
       const msg = err instanceof Error ? err.message : String(err);
-      renderError(`NHP-OTP request failed: ${msg}`);
+      renderError(t('nhp.otpReqFailed', { suffix: ': ' + msg }));
     }
   })();
 

--- a/demoapp/web/src/styles.css
+++ b/demoapp/web/src/styles.css
@@ -137,35 +137,52 @@ a:hover { text-decoration: underline; }
 .btn-danger { background: #da3633; color: #fff; }
 .btn-danger:hover { background: #f85149; }
 
-/* Fixed language switcher (top-right). */
-#lang-switcher {
+/* Language switcher — globe-icon dropdown, mirrored from
+   agent.opennhp.org and pinned to the top-right of the viewport. */
+.lang-switcher {
   position: fixed;
   top: 12px;
   right: 12px;
   z-index: 100;
+}
+.lang-switcher button {
+  background: #21262d;
+  color: #c9d1d9;
+  border: 1px solid #30363d;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
   display: inline-flex;
-  gap: 2px;
-  padding: 2px;
+  align-items: center;
+  gap: 4px;
+}
+.lang-switcher button:hover { background: #30363d; }
+.lang-switcher button .caret { font-size: 9px; color: #8b949e; }
+.lang-switcher button .lang-icon { width: 14px; height: 14px; flex-shrink: 0; color: #8b949e; }
+.lang-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
   background: #161b22;
   border: 1px solid #30363d;
-  border-radius: 6px;
-}
-#lang-switcher button {
-  padding: 4px 10px;
-  border: none;
   border-radius: 4px;
-  background: transparent;
-  color: #8b949e;
-  font-size: 12px;
-  font-weight: 600;
-  font-family: inherit;
+  list-style: none;
+  padding: 4px 0;
+  margin: 0;
+  min-width: 140px;
+  z-index: 10;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+}
+.lang-menu li {
+  padding: 6px 12px;
   cursor: pointer;
+  font-size: 13px;
+  color: #c9d1d9;
 }
-#lang-switcher button:hover { color: #c9d1d9; }
-#lang-switcher button.active {
-  background: #21262d;
-  color: #58a6ff;
-}
+.lang-menu li:hover { background: #21262d; }
+.lang-menu li.active { color: #58a6ff; font-weight: 600; }
 
 /* Source-code call-out section, sitting above the footer. */
 .source-section {

--- a/demoapp/web/src/styles.css
+++ b/demoapp/web/src/styles.css
@@ -10,7 +10,7 @@ body {
   min-height: 100vh;
 }
 
-.container { max-width: 960px; margin: 0 auto; }
+.container { max-width: 960px; margin: 0 auto; position: relative; }
 
 h1 { color: #58a6ff; font-size: 24px; margin-bottom: 8px; }
 h2 { color: #58a6ff; font-size: 16px; margin-bottom: 12px; }
@@ -138,11 +138,12 @@ a:hover { text-decoration: underline; }
 .btn-danger:hover { background: #f85149; }
 
 /* Language switcher — globe-icon dropdown, mirrored from
-   agent.opennhp.org and pinned to the top-right of the viewport. */
+   agent.opennhp.org and anchored to the top-right of the centered
+   container. */
 .lang-switcher {
-  position: fixed;
-  top: 12px;
-  right: 12px;
+  position: absolute;
+  top: 0;
+  right: 0;
   z-index: 100;
 }
 .lang-switcher button {

--- a/demoapp/web/src/styles.css
+++ b/demoapp/web/src/styles.css
@@ -137,6 +137,36 @@ a:hover { text-decoration: underline; }
 .btn-danger { background: #da3633; color: #fff; }
 .btn-danger:hover { background: #f85149; }
 
+/* Fixed language switcher (top-right). */
+#lang-switcher {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 100;
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+}
+#lang-switcher button {
+  padding: 4px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #8b949e;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+#lang-switcher button:hover { color: #c9d1d9; }
+#lang-switcher button.active {
+  background: #21262d;
+  color: #58a6ff;
+}
+
 /* Source-code call-out section, sitting above the footer. */
 .source-section {
   text-align: center;
@@ -146,18 +176,18 @@ a:hover { text-decoration: underline; }
   display: inline-flex;
   align-items: center;
   padding: 8px 16px;
-  background: #21262d;
-  border: 1px solid #30363d;
+  background: #238636;
+  border: 1px solid #2ea043;
   border-radius: 4px;
-  color: #c9d1d9;
+  color: #fff;
   text-decoration: none;
   font-size: 14px;
   font-weight: 600;
 }
 .source-section a:hover {
-  background: #30363d;
-  border-color: #58a6ff;
-  color: #58a6ff;
+  background: #2ea043;
+  border-color: #3fb950;
+  color: #fff;
 }
 
 /* Page footer, mirrored from https://agent.opennhp.org/. */

--- a/demoapp/web/src/views/arch-diagram.ts
+++ b/demoapp/web/src/views/arch-diagram.ts
@@ -6,10 +6,12 @@
 // `webdist` tag) include it via the same embed.FS that holds the rest of
 // the SPA — no extra fetch, no CSP hole for cross-origin assets.
 
+import { t } from '../i18n.js';
+
 export function renderArchDiagram(root: HTMLElement): void {
   root.innerHTML = `
     <details class="arch" open>
-      <summary>How the OpenNHP Integration Demo works</summary>
+      <summary>${t('arch.summary')}</summary>
       <div class="arch-body">
         <img
           class="arch-diagram-image"

--- a/demoapp/web/src/views/complete-registration.ts
+++ b/demoapp/web/src/views/complete-registration.ts
@@ -14,6 +14,7 @@
 
 import { api, ApiError, type ServerInfo } from '../api.js';
 import { escapeHtml } from '../escape.js';
+import { t } from '../i18n.js';
 import { mountNhpRegPanel } from '../nhp-reg-panel.js';
 
 export interface CompleteRegistrationViewProps {
@@ -27,15 +28,15 @@ export function renderCompleteRegistration(root: HTMLElement, props: CompleteReg
   root.innerHTML = `
     <div class="container">
       <div class="toolbar">
-        <div class="user">Signed in as <span>${escapeHtml(props.username)}</span></div>
-        <button id="signout-btn" class="btn btn-secondary">Sign out</button>
+        <div class="user">${t('common.signedInAs')} <span>${escapeHtml(props.username)}</span></div>
+        <button id="signout-btn" class="btn btn-secondary">${t('common.signOut')}</button>
       </div>
-      <h1>Complete NHP Registration</h1>
-      <p class="subtitle">Your account exists but the NHP key was never registered with nhp-server. Pick your cluster and cipher scheme, then complete the handshake to activate your account.</p>
+      <h1>${t('cr.title')}</h1>
+      <p class="subtitle">${t('cr.subtitle')}</p>
 
       <div id="alert"></div>
       <div id="bind-area">
-        <p class="note">Loading…</p>
+        <p class="note">${t('common.loading')}</p>
       </div>
       <div id="reg-area"></div>
     </div>
@@ -70,7 +71,7 @@ export function renderCompleteRegistration(root: HTMLElement, props: CompleteReg
       }
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : String(err);
-      showAlert('error', `Failed to load server catalog: ${msg}`);
+      showAlert('error', t('cr.loadCatalogFailed', { msg }));
       return;
     }
     renderChooser(servers, curServer, curScheme);
@@ -82,7 +83,7 @@ export function renderCompleteRegistration(root: HTMLElement, props: CompleteReg
     curScheme: string,
   ): void {
     if (servers.length === 0) {
-      bindArea.innerHTML = `<div class="alert alert-error">No nhp-server clusters are configured.</div>`;
+      bindArea.innerHTML = `<div class="alert alert-error">${t('cr.noClusters')}</div>`;
       return;
     }
     // Default the selection to the current binding, else the first server.
@@ -91,18 +92,18 @@ export function renderCompleteRegistration(root: HTMLElement, props: CompleteReg
 
     bindArea.innerHTML = `
       <div class="panel">
-        <h2>NHP binding</h2>
+        <h2>${t('cr.binding')}</h2>
         <div class="field">
-          <label for="cr-server">NHP server cluster</label>
+          <label for="cr-server">${t('cr.cluster')}</label>
           <select id="cr-server">
             ${servers.map((s) => `<option value="${escapeHtml(s.name)}" ${s.name === selName ? 'selected' : ''}>${escapeHtml(s.name)}</option>`).join('')}
           </select>
         </div>
         <div class="field">
-          <label for="cr-scheme">Cipher scheme</label>
+          <label for="cr-scheme">${t('cr.cipherScheme')}</label>
           <select id="cr-scheme"></select>
         </div>
-        <button id="cr-confirm" class="btn btn-primary">Confirm &amp; request OTP</button>
+        <button id="cr-confirm" class="btn btn-primary">${t('cr.confirm')}</button>
       </div>
     `;
 
@@ -129,11 +130,11 @@ export function renderCompleteRegistration(root: HTMLElement, props: CompleteReg
       const serverName = serverSelect.value;
       const cipherScheme = schemeSelect.value;
       if (!serverName || !cipherScheme) {
-        showAlert('error', 'Select an NHP server cluster and cipher scheme.');
+        showAlert('error', t('cr.selectClusterScheme'));
         return;
       }
       confirmBtn.disabled = true;
-      showAlert('info', 'Generating NHP key material under the selected binding…');
+      showAlert('info', t('cr.generating'));
       try {
         const reg = await api.registerBind(serverName, cipherScheme);
         // Hide the chooser once the panel is mounted.
@@ -153,12 +154,12 @@ export function renderCompleteRegistration(root: HTMLElement, props: CompleteReg
             disposePanel = undefined;
             regArea.innerHTML = '';
             renderChooser(servers, serverName, cipherScheme);
-            showAlert('info', 'Click "Confirm & request OTP" to retry.');
+            showAlert('info', t('cr.clickRetry'));
           },
         });
       } catch (err) {
         const msg = err instanceof ApiError ? err.message : String(err);
-        showAlert('error', `Binding failed: ${msg}`);
+        showAlert('error', t('cr.bindingFailed', { msg }));
       } finally {
         confirmBtn.disabled = false;
       }

--- a/demoapp/web/src/views/complete-registration.ts
+++ b/demoapp/web/src/views/complete-registration.ts
@@ -14,7 +14,7 @@
 
 import { api, ApiError, type ServerInfo } from '../api.js';
 import { escapeHtml } from '../escape.js';
-import { t } from '../i18n.js';
+import { t, renderLangSwitcher } from '../i18n.js';
 import { mountNhpRegPanel } from '../nhp-reg-panel.js';
 
 export interface CompleteRegistrationViewProps {
@@ -41,6 +41,8 @@ export function renderCompleteRegistration(root: HTMLElement, props: CompleteReg
       <div id="reg-area"></div>
     </div>
   `;
+
+  renderLangSwitcher(root.querySelector<HTMLElement>('.container')!);
 
   const alert = root.querySelector<HTMLDivElement>('#alert')!;
   const bindArea = root.querySelector<HTMLDivElement>('#bind-area')!;

--- a/demoapp/web/src/views/footer.ts
+++ b/demoapp/web/src/views/footer.ts
@@ -4,6 +4,8 @@
 // from ipify (same pattern as the js-agent demo); the app's CSP
 // connect-src must allow api.ipify.org / api6.ipify.org for it to load.
 
+import { t } from '../i18n.js';
+
 // Source-code call-out, rendered as its own section above the footer.
 export function renderSourceSection(root: HTMLElement): void {
   const section = document.createElement('section');
@@ -13,7 +15,7 @@ export function renderSourceSection(root: HTMLElement): void {
       <svg class="oauth-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
         <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.02.37-2.45-.49-2.6-.67-.09-.23-.48-.67-.82-.82-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
       </svg>
-      View this demo app's source on GitHub
+      ${t('footer.viewSource')}
     </a>
   `;
   root.appendChild(section);
@@ -23,9 +25,9 @@ export function renderFooter(root: HTMLElement): void {
   const footer = document.createElement('footer');
   footer.className = 'footer';
   footer.innerHTML = `
-    <div class="ip-display" id="ipDisplay">Detecting IP…</div>
-    <div>Powered by <a href="https://github.com/OpenNHP/opennhp" target="_blank" rel="noopener"><strong>OpenNHP</strong></a> &mdash; Network-infrastructure Hiding Protocol</div>
-    <div>Sponsored by: <a href="https://layerv.ai" target="_blank" rel="noopener">LayerV.ai</a></div>
+    <div class="ip-display" id="ipDisplay">${t('footer.detectingIp')}</div>
+    <div>${t('footer.poweredBy')}</div>
+    <div>${t('footer.sponsoredBy')}</div>
   `;
   root.appendChild(footer);
   void fetchIP();
@@ -50,6 +52,6 @@ async function fetchIP(): Promise<void> {
     else if (ipv4) el.textContent = `IPv4: ${ipv4}`;
     else el.textContent = `IPv6: ${ipv6}`;
   } else {
-    el.textContent = 'IP detection unavailable';
+    el.textContent = t('footer.ipUnavailable');
   }
 }

--- a/demoapp/web/src/views/login.ts
+++ b/demoapp/web/src/views/login.ts
@@ -3,7 +3,7 @@
 
 import { api, ApiError } from '../api.js';
 import { escapeHtml } from '../escape.js';
-import { t } from '../i18n.js';
+import { t, renderLangSwitcher } from '../i18n.js';
 import { renderArchDiagram } from './arch-diagram.js';
 import { renderSourceSection, renderFooter } from './footer.js';
 
@@ -94,6 +94,7 @@ export function renderLogin(root: HTMLElement, props: LoginViewProps): void {
   renderArchDiagram(diagramRoot);
 
   const container = root.querySelector<HTMLElement>('.container')!;
+  renderLangSwitcher(container);
   renderSourceSection(container);
   renderFooter(container);
 }

--- a/demoapp/web/src/views/login.ts
+++ b/demoapp/web/src/views/login.ts
@@ -14,7 +14,7 @@ export interface LoginViewProps {
 export function renderLogin(root: HTMLElement, props: LoginViewProps): void {
   root.innerHTML = `
     <div class="container">
-      <h1>OpenNHP Integration Demo App</h1>
+      <h1>OpenNHP Login Integration Demo App</h1>
       <p class="subtitle">A working example of adding the OpenNHP to an existing web application</p>
 
       <div id="alert"></div>

--- a/demoapp/web/src/views/login.ts
+++ b/demoapp/web/src/views/login.ts
@@ -3,6 +3,7 @@
 
 import { api, ApiError } from '../api.js';
 import { escapeHtml } from '../escape.js';
+import { t } from '../i18n.js';
 import { renderArchDiagram } from './arch-diagram.js';
 import { renderSourceSection, renderFooter } from './footer.js';
 
@@ -14,32 +15,32 @@ export interface LoginViewProps {
 export function renderLogin(root: HTMLElement, props: LoginViewProps): void {
   root.innerHTML = `
     <div class="container">
-      <h1>OpenNHP Login Integration Demo App</h1>
-      <p class="subtitle">A working example of adding the OpenNHP to an existing web application</p>
+      <h1>${t('login.title')}</h1>
+      <p class="subtitle">${t('common.subtitle')}</p>
 
       <div id="alert"></div>
 
       <div class="auth-grid">
         <div class="panel auth-section">
-          <h2 class="auth-title">User credentials</h2>
-          <p class="auth-hint">Sign in with a username and password, or create a new account.</p>
+          <h2 class="auth-title">${t('login.credTitle')}</h2>
+          <p class="auth-hint">${t('login.credHint')}</p>
           <div class="field">
-            <label for="login-username">Username</label>
+            <label for="login-username">${t('login.username')}</label>
             <input id="login-username" type="text" autocomplete="username" />
           </div>
           <div class="field">
-            <label for="login-password">Password</label>
+            <label for="login-password">${t('login.password')}</label>
             <input id="login-password" type="password" autocomplete="current-password" />
           </div>
           <div class="cred-actions">
-            <button id="login-submit" class="btn btn-primary">Sign in</button>
-            <button id="login-switch-register" class="btn btn-secondary">New here? Create an account</button>
+            <button id="login-submit" class="btn btn-primary">${t('login.signIn')}</button>
+            <button id="login-switch-register" class="btn btn-secondary">${t('login.createAccount')}</button>
           </div>
         </div>
 
         <div class="panel auth-section">
-          <h2 class="auth-title">OAuth / SAML</h2>
-          <p class="auth-hint">Sign in with a federated identity provider.</p>
+          <h2 class="auth-title">${t('login.oauthTitle')}</h2>
+          <p class="auth-hint">${t('login.oauthHint')}</p>
           <div class="oauth-cta">
             <!-- OIDC RP not configured for this deployment; the handler returns
                  503. Uncomment when an [[OIDC]] block is enabled in config.toml.
@@ -49,7 +50,7 @@ export function renderLogin(root: HTMLElement, props: LoginViewProps): void {
               <svg class="oauth-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.02.37-2.45-.49-2.6-.67-.09-.23-.48-.67-.82-.82-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
               </svg>
-              Sign in with GitHub
+              ${t('login.github')}
             </a>
           </div>
         </div>
@@ -71,17 +72,17 @@ export function renderLogin(root: HTMLElement, props: LoginViewProps): void {
     const username = (root.querySelector<HTMLInputElement>('#login-username')!).value.trim();
     const password = (root.querySelector<HTMLInputElement>('#login-password')!).value;
     if (!username || !password) {
-      showAlert('error', 'Username and password are required.');
+      showAlert('error', t('login.errRequired'));
       return;
     }
     submitBtn.disabled = true;
-    showAlert('info', 'Signing in…');
+    showAlert('info', t('login.signingIn'));
     try {
       await api.login(username, password);
       props.onSignedIn();
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : String(err);
-      showAlert('error', `Sign in failed: ${msg}`);
+      showAlert('error', t('login.failed', { msg }));
     } finally {
       submitBtn.disabled = false;
     }

--- a/demoapp/web/src/views/register.ts
+++ b/demoapp/web/src/views/register.ts
@@ -15,7 +15,7 @@ export interface RegisterViewProps {
 export function renderRegister(root: HTMLElement, props: RegisterViewProps): void {
   root.innerHTML = `
     <div class="container">
-      <h1>OpenNHP Integration Demo App</h1>
+      <h1>OpenNHP Login Integration Demo App</h1>
       <p class="subtitle">A working example of adding the OpenNHP to an existing web application</p>
 
       <div id="alert"></div>

--- a/demoapp/web/src/views/register.ts
+++ b/demoapp/web/src/views/register.ts
@@ -4,7 +4,7 @@
 
 import { api, ApiError, type RegisterResponse, type ServerInfo } from '../api.js';
 import { escapeHtml } from '../escape.js';
-import { t } from '../i18n.js';
+import { t, renderLangSwitcher } from '../i18n.js';
 import { mountNhpRegPanel } from '../nhp-reg-panel.js';
 import { renderSourceSection, renderFooter } from './footer.js';
 
@@ -171,6 +171,7 @@ export function renderRegister(root: HTMLElement, props: RegisterViewProps): voi
   });
 
   const container = root.querySelector<HTMLElement>('.container')!;
+  renderLangSwitcher(container);
   renderSourceSection(container);
   renderFooter(container);
 }

--- a/demoapp/web/src/views/register.ts
+++ b/demoapp/web/src/views/register.ts
@@ -4,6 +4,7 @@
 
 import { api, ApiError, type RegisterResponse, type ServerInfo } from '../api.js';
 import { escapeHtml } from '../escape.js';
+import { t } from '../i18n.js';
 import { mountNhpRegPanel } from '../nhp-reg-panel.js';
 import { renderSourceSection, renderFooter } from './footer.js';
 
@@ -15,37 +16,37 @@ export interface RegisterViewProps {
 export function renderRegister(root: HTMLElement, props: RegisterViewProps): void {
   root.innerHTML = `
     <div class="container">
-      <h1>OpenNHP Login Integration Demo App</h1>
-      <p class="subtitle">A working example of adding the OpenNHP to an existing web application</p>
+      <h1>${t('login.title')}</h1>
+      <p class="subtitle">${t('common.subtitle')}</p>
 
       <div id="alert"></div>
 
       <div class="panel">
-        <h2>1. Account credentials</h2>
+        <h2>${t('reg.accountCreds')}</h2>
         <div class="field">
-          <label for="reg-username">Username</label>
+          <label for="reg-username">${t('reg.username')}</label>
           <input id="reg-username" type="text" autocomplete="username" />
         </div>
         <div class="field">
-          <label for="reg-email">Email</label>
+          <label for="reg-email">${t('reg.email')}</label>
           <input id="reg-email" type="email" autocomplete="email" />
         </div>
         <div class="field">
-          <label for="reg-password">Password (min 8 chars)</label>
+          <label for="reg-password">${t('reg.password')}</label>
           <input id="reg-password" type="password" autocomplete="new-password" />
         </div>
         <div class="field">
-          <label for="reg-server">NHP server</label>
+          <label for="reg-server">${t('reg.nhpServer')}</label>
           <select id="reg-server" disabled></select>
         </div>
         <div class="field">
-          <label for="reg-scheme">Cipher scheme</label>
+          <label for="reg-scheme">${t('reg.cipherScheme')}</label>
           <select id="reg-scheme" disabled>
-            <option value="">Loading…</option>
+            <option value="">${t('reg.loadingScheme')}</option>
           </select>
         </div>
-        <button id="reg-submit" class="btn btn-primary">Create account &amp; request OTP</button>
-        <button id="reg-switch-login" class="btn btn-secondary">Already have an account? Sign in</button>
+        <button id="reg-submit" class="btn btn-primary">${t('reg.submit')}</button>
+        <button id="reg-switch-login" class="btn btn-secondary">${t('reg.switchLogin')}</button>
       </div>
 
       <div id="otp-panel"></div>
@@ -73,7 +74,7 @@ export function renderRegister(root: HTMLElement, props: RegisterViewProps): voi
       servers = [];
     }
     if (servers.length === 0) {
-      serverSelect.innerHTML = `<option value="">No servers configured</option>`;
+      serverSelect.innerHTML = `<option value="">${t('reg.noServers')}</option>`;
       return;
     }
     serverSelect.innerHTML = servers
@@ -108,21 +109,21 @@ export function renderRegister(root: HTMLElement, props: RegisterViewProps): voi
     const serverName = serverSelect.value;
     const cipherScheme = schemeSelect.value;
     if (!username || !email || !password) {
-      showAlert('error', 'All fields are required.');
+      showAlert('error', t('reg.allRequired'));
       return;
     }
     if (!serverName || !cipherScheme) {
-      showAlert('error', 'Select an NHP server and cipher scheme.');
+      showAlert('error', t('reg.selectServerScheme'));
       return;
     }
     submitBtn.disabled = true;
-    showAlert('info', 'Creating account and generating NHP key pair…');
+    showAlert('info', t('reg.creating'));
     let reg: RegisterResponse;
     try {
       reg = await api.register(username, password, email, serverName, cipherScheme);
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : String(err);
-      showAlert('error', `Registration failed: ${msg}`);
+      showAlert('error', t('reg.failed', { msg }));
       return;
     } finally {
       submitBtn.disabled = false;

--- a/demoapp/web/src/views/resources.ts
+++ b/demoapp/web/src/views/resources.ts
@@ -4,6 +4,7 @@
 
 import { api, ApiError, type ConfigResponse, type ResourceMeta } from '../api.js';
 import { escapeHtml } from '../escape.js';
+import { t } from '../i18n.js';
 import { createAgent, listResources, knockResource } from '../nhp.js';
 
 export interface ResourcesViewProps {
@@ -21,8 +22,8 @@ function authProviderLabel(p: string): string {
   switch (p) {
     case 'github': return 'GitHub';
     case 'oidc': return 'OIDC';
-    case 'password': return 'Local';
-    default: return 'Local';
+    case 'password': return t('res.providerLocal');
+    default: return t('res.providerLocal');
   }
 }
 
@@ -34,24 +35,24 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
     <div class="container">
       <div class="toolbar">
         <div class="toolbar-id">
-          <div class="user">Signed in as <span>${escapeHtml(props.username)}</span></div>
+          <div class="user">${t('common.signedInAs')} <span>${escapeHtml(props.username)}</span></div>
           <div class="badges">
-            <span class="badge"><span class="badge-k">Auth</span>${escapeHtml(provider)}</span>
-            <span class="badge badge-mono"><span class="badge-k">Alg</span>${escapeHtml(scheme)}</span>
-            <span class="badge"><span class="badge-k">Server</span>${escapeHtml(server)}</span>
+            <span class="badge"><span class="badge-k">${t('res.badgeAuth')}</span>${escapeHtml(provider)}</span>
+            <span class="badge badge-mono"><span class="badge-k">${t('res.badgeAlg')}</span>${escapeHtml(scheme)}</span>
+            <span class="badge"><span class="badge-k">${t('res.badgeServer')}</span>${escapeHtml(server)}</span>
           </div>
         </div>
         <div class="toolbar-actions">
-          <button id="signout-btn" class="btn btn-secondary">Sign out</button>
-          <button id="delete-account-btn" class="btn btn-danger">Delete account</button>
+          <button id="signout-btn" class="btn btn-secondary">${t('common.signOut')}</button>
+          <button id="delete-account-btn" class="btn btn-danger">${t('res.deleteAccount')}</button>
         </div>
       </div>
-      <h1>Protected Resources</h1>
-      <p class="subtitle">Click "Access" to knock nhp-server. The protected resource is hidden until the knock opens the door.</p>
+      <h1>${t('res.title')}</h1>
+      <p class="subtitle">${t('res.subtitle')}</p>
 
       <div id="alert"></div>
       <div id="resource-area">
-        <p class="note">Loading…</p>
+        <p class="note">${t('common.loading')}</p>
       </div>
     </div>
   `;
@@ -74,24 +75,21 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
     // Irreversible: the sealed NHP private key is deleted from the backend,
     // so the account (and its registered identity) cannot be recovered. The
     // nhp-server public key is left to expire via the server TTL.
-    const ok = window.confirm(
-      'Delete your account? This permanently removes your credentials and NHP ' +
-      'key material from this demo. You can re-register afterward. This cannot be undone.',
-    );
+    const ok = window.confirm(t('res.deleteConfirm'));
     if (!ok) return;
     try {
       await api.deleteAccount();
       props.onSignOut();
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : String(err);
-      showAlert('error', `Failed to delete account: ${msg}`);
+      showAlert('error', t('res.deleteFailed', { msg }));
     }
   });
 
   void bootstrap();
 
   async function bootstrap(): Promise<void> {
-    showAlert('info', 'Fetching credentials from server…');
+    showAlert('info', t('res.fetchingCreds'));
     let cfg: ConfigResponse;
     let creds;
     try {
@@ -100,11 +98,11 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
       creds = cr;
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : String(err);
-      showAlert('error', `Failed to load: ${msg}`);
+      showAlert('error', t('res.loadFailed', { msg }));
       return;
     }
 
-    showAlert('info', 'Initializing NHP agent and listing services…');
+    showAlert('info', t('res.initAgent'));
     const handle = await createAgent(creds.privateKey, creds.nhp, creds.deviceId, 'error');
     try {
       const ids = await listResources(handle, creds.nhp);
@@ -118,7 +116,7 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
         .filter((r): r is ResourceMeta => Boolean(r));
 
       if (visible.length === 0) {
-        area.innerHTML = `<p class="note">No accessible resources. Confirm registration completed and that the nhp-server basic plugin allows your user.</p>`;
+        area.innerHTML = `<p class="note">${t('res.none')}</p>`;
         return;
       }
 
@@ -129,9 +127,9 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
             <li class="resource-item" data-resid="${escapeHtml(r.id)}" data-url="${escapeHtml(r.url)}">
               <div>
                 <div class="resource-title">${escapeHtml(r.title)}</div>
-                <div class="resource-id">id: ${escapeHtml(r.id)} &middot; ${escapeHtml(r.url)}</div>
+                <div class="resource-id">${t('res.idPrefix')}: ${escapeHtml(r.id)} &middot; ${escapeHtml(r.url)}</div>
               </div>
-              <button class="btn btn-primary knock-btn" data-resid="${escapeHtml(r.id)}">Access</button>
+              <button class="btn btn-primary knock-btn" data-resid="${escapeHtml(r.id)}">${t('res.access')}</button>
             </li>
           `).join('')}
         </ul>
@@ -148,7 +146,7 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
     } catch (err) {
       handle.dispose();
       const msg = err instanceof Error ? err.message : String(err);
-      showAlert('error', `listServices failed: ${msg}`);
+      showAlert('error', t('res.listFailed', { msg }));
     }
   }
 
@@ -169,14 +167,14 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
     }
     const btn = item?.querySelector<HTMLButtonElement>('.knock-btn');
     if (btn) btn.disabled = true;
-    showAlert('info', `Knocking ${resourceId}…`);
+    showAlert('info', t('res.knocking', { id: resourceId }));
     try {
       const creds = await api.credentials();
       const handle = await createAgent(creds.privateKey, creds.nhp, creds.deviceId, 'error');
       const outcome = await knockResource(handle, creds.nhp, resourceId);
       handle.dispose();
       if (outcome.success && outcome.resourceHost) {
-        showAlert('success', `Knock successful — opening ${outcome.resourceHost}`);
+        showAlert('success', t('res.knockSuccess', { host: outcome.resourceHost }));
         const url = /^https?:\/\//.test(outcome.resourceHost)
           ? outcome.resourceHost
           : `https://${outcome.resourceHost}`;
@@ -195,12 +193,12 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
           window.location.href = url;
         }
       } else {
-        showAlert('error', `Knock failed: ${outcome.error ?? 'unknown'}`);
+        showAlert('error', t('res.knockFailed', { err: outcome.error ?? 'unknown' }));
         popup?.close();
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      showAlert('error', `Knock failed: ${msg}`);
+      showAlert('error', t('res.knockFailed', { err: msg }));
       popup?.close();
     } finally {
       if (btn) btn.disabled = false;

--- a/demoapp/web/src/views/resources.ts
+++ b/demoapp/web/src/views/resources.ts
@@ -4,7 +4,7 @@
 
 import { api, ApiError, type ConfigResponse, type ResourceMeta } from '../api.js';
 import { escapeHtml } from '../escape.js';
-import { t } from '../i18n.js';
+import { t, renderLangSwitcher } from '../i18n.js';
 import { createAgent, listResources, knockResource } from '../nhp.js';
 
 export interface ResourcesViewProps {
@@ -56,6 +56,8 @@ export function renderResources(root: HTMLElement, props: ResourcesViewProps): v
       </div>
     </div>
   `;
+
+  renderLangSwitcher(root.querySelector<HTMLElement>('.container')!);
 
   const alert = root.querySelector<HTMLDivElement>('#alert')!;
   const area = root.querySelector<HTMLDivElement>('#resource-area')!;


### PR DESCRIPTION
Follow-up UI work on the integrated demo app ([`demoapp/`](../tree/main/demoapp)), continuing from #1708 (already merged). These four commits were authored after that merge, so they land in a fresh PR.

## Changes

### Retitle
- App renamed to **"OpenNHP Login Integration Demo App"** — HTML `<title>` + page `<h1>` on both login and register.

### Simplified Chinese (i18n)
- New lightweight i18n layer ([`i18n.ts`](../blob/feat/demoapp-i18n-switcher/demoapp/web/src/i18n.ts)): EN + zh-CN dictionaries, `t(key, vars)` with `{placeholder}` interpolation, English fallback, `localStorage` persistence, browser-language default, `<html lang>` stamping.
- **Every** user-facing string routed through `t()`: login, register, complete-registration, resources, the shared NHP reg panel, the arch-diagram summary, and the footer — including dynamic strings (OTP flow, resend countdown, knock status).

### Language switcher
- A globe-icon dropdown (**EN ▾** → English / 简体中文) mirroring the switcher on **agent.opennhp.org** — same markup, icon, and styling; closes on outside-click / Escape.
- Rendered **inside the centered container** (absolute, top-right of the 960px content column) rather than pinned to the viewport edge.

### Source button
- The "View this demo app's source on GitHub" call-out button now has a filled green background so it clearly reads as a button.

## Testing

Built and previewed locally (`endpoints/js-agent` SDK build → `demoapp/web` build → `go run . -c etc/config.toml` → http://localhost:8081). Verified: English and 简体中文 both render across all views (including the OTP/registration flow and knock status), the switcher opens/persists/reloads correctly, and it sits at the container's top-right. `tsc --noEmit` and the Vite build pass.

## Note

zh-CN strings are translated for a demo; a native-speaker review pass before wider public use would be worthwhile. Translations live entirely in the SPA — independent of the `nhp-agentd` CLI and reg.opennhp.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)