### PR TITLE
修复 Release CICD 流水线 GraphQL 分页报错

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,17 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - name: Release Please
-        uses: googleapis/release-please-action@v5
+        # Pin to the dist rebuild that bundles release-please v17.6.1+, which
+        # contains the dynamic batch size backoff fix for the GraphQL pagination
+        # bug seen in release-please v17.6.0 (Fetch merge commits failing with
+        # GitHub GraphQL trace 57C1:30C732:7F3477:9462FB:6AA167F8 on 2026-09-09).
+        # The floating @v5 tag still resolves to action v5.0.0, which ships
+        # the broken release-please v17.6.0, so we must pin a concrete ref
+        # instead. SHA 0b6b3fc is the "chore: build dist" commit on main
+        # (#1208) that re-bundles the dist after the v17.6.1 package.json bump
+        # (dependabot PR #1207). Revisit when upstream publishes a v5.x.x tag
+        # that includes this fix.
+        uses: googleapis/release-please-action@0b6b3fc0186a2f7118bfd88fab9ea481e1839504
         with:
           release-type: go
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## 改动概述
Release CICD 流水线于 2026-09-09T14:06:49Z 调用 `googleapis/release-please-action@v5` 抓取 main 上的 merge commits 时失败，报错 trace `57C1:30C732:7F3477:9462FB:6AA167F8`。根因是 release-please v17.6.0 使用过大的 GraphQL batch 被 GitHub 拒绝（googleapis/release-please#2592、#2577）。本次修复把 action 固定到包含 GraphQL 动态回退 batch 修复（#2783 / e5033c1）的 commit，避免随机失败再次打断发布。

## 主要变更
- `.github/workflows/release-please.yml`：将 `googleapis/release-please-action@v5` 从浮动 tag 改为固定到 `googleapis/release-please-action@0b6b3fc`，该 commit 的 dist 已重新构建并携带 release-please v17.6.1+。
- 保留 `.release-please-manifest.json` 当前锚定的 `1.0.0`，下一次发布继续从该版本递增，不影响既有 release 节奏。

## 关键文件
- `.github/workflows/release-please.yml`

## 验证方式
- 本地确认工作树与 `origin/main` 在本次改动之前已对齐；`git merge origin/main` 结果为 `Already up to date.`，无需额外合并提交。
- 分支 `feat/req_8695bd4ea73dd4e5` 已成功推送到 origin：`https://github.com/OpenNHP/opennhp/tree/feat/req_8695bd4ea73dd4e5`。
- 待 merge 后，下一次 `release-please` workflow 运行将使用固定到 `0b6b3fc` 的 action，复用包含 GraphQL 修复的 release-please v17.6.1+，不再触发 trace `57C1:30C732:7F3477:9462FB:6AA167F8` 类型的报错。
