### PR TITLE
fix(ci): pin release-please-action to include GraphQL pagination fix

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,17 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - name: Release Please
-        uses: googleapis/release-please-action@v5
+        # Pin to the dist rebuild that bundles release-please v17.6.1+, which
+        # contains the dynamic batch size backoff fix for the GraphQL pagination
+        # bug seen in release-please v17.6.0 (Fetch merge commits failing with
+        # GitHub GraphQL trace 57C1:30C732:7F3477:9462FB:6AA167F8 on 2026-09-09).
+        # The floating @v5 tag still resolves to action v5.0.0, which ships
+        # the broken release-please v17.6.0, so we must pin a concrete ref
+        # instead. SHA 0b6b3fc is the "chore: build dist" commit on main
+        # (#1208) that re-bundles the dist after the v17.6.1 package.json bump
+        # (dependabot PR #1207). Revisit when upstream publishes a v5.x.x tag
+        # that includes this fix.
+        uses: googleapis/release-please-action@0b6b3fc0186a2f7118bfd88fab9ea481e1839504
         with:
           release-type: go
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Fixes the Release Please CI pipeline failure that occurred on 2026-09-09T14:06:49Z with GitHub GraphQL trace `57C1:30C732:7F3477:9462FB:6AA167F8`. The pipeline aborted at `Fetching merge commits on branch main with cursor: undefined` because the floating `googleapis/release-please-action@v5` tag still resolves to action `v5.0.0` (released 2026-04-22), which ships **release-please v17.6.0** — a version with a known GraphQL pagination bug.

### Root cause

- `release-please v17.6.0` issues oversized GraphQL batches when fetching merge commits, which GitHub occasionally rejects with `502 Bad Gateway` / `Something went wrong while executing your query`.
- The fix is `e5033c1` (`implement dynamic batch size backoff for GraphQL requests`, [googleapis/release-please#2783](https://github.com/googleapis/release-please/issues/2783)) released in `release-please v17.6.1` on 2026-05-26.
- The fix was mirrored into the action repo by dependabot PR [#1207](https://github.com/googleapis/release-please-action/pull/1207) (package.json bump to `^17.6.1`) followed by PR [#1208](https://github.com/googleapis/release-please-action/pull/1208) (`chore: build dist` to re-bundle `dist/index.js`).
- Upstream has **not yet tagged** a new release that contains the fix, so we pin to the specific commit SHA rather than a tag.

### Change

```diff
       - name: Release Please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@0b6b3fc0186a2f7118bfd88fab9ea481e1839504
         with:
           release-type: go
           token: ${{ steps.app-token.outputs.token }}
```

`0b6b3fc` is the dist-rebuild commit on `main` that ships `release-please v17.6.1+` inside the bundled `dist/index.js`. When upstream publishes a `v5.x.x` tag containing the fix, the SHA pin can be reverted to a floating `@v5` or replaced with that tag.

### Key files

- `.github/workflows/release-please.yml` — single line `uses:` change + explanatory comment.

### Untouched (intentionally)

- `.release-please-manifest.json` — already created on `main` by PR #1717, anchoring at `1.0.0`. Preserved so the next release continues from that version.
- No new `release-please-config.json`, no `CHANGELOG.md` edits, no other workflow changes.

### Verification

- YAML re-validated with `js-yaml`; structure and `uses:` fields parse correctly.
- Commit `d532202a` is signed with SSH (`Good "git" signature for claude-agent@opennhp.local with ED25519 key`), satisfying the project's GPG/SSH signing requirement.
- After merge, the next push to `main` will re-trigger the Release Please workflow; logs should show `Running release-please version: 17.6.1+` (no longer `17.6.0`) and the `Fetching merge commits on branch main` step should complete without the GraphQL trace error.

### References

- Upstream bug: [googleapis/release-please#2592](https://github.com/googleapis/release-please/issues/2592), [#2577](https://github.com/googleapis/release-please/issues/2577)
- Fix commit: [googleapis/release-please@e5033c1](https://github.com/googleapis/release-please/commit/e5033c13070a2f702fb06927f92ca198ac18a830)
- Mirror PRs: [release-please-action#1207](https://github.com/googleapis/release-please-action/pull/1207), [#1208](https://github.com/googleapis/release-please-action/pull/1208)
- Prior manifest fix: OpenNHP PR #1717 (commit `2f43208c`)